### PR TITLE
Add Deployment as configuration for azure openai

### DIFF
--- a/config.py
+++ b/config.py
@@ -137,6 +137,7 @@ AZURE_OPENAI_API_KEY = get_env_variable("AZURE_OPENAI_API_KEY", "")
 RAG_AZURE_OPENAI_API_KEY = get_env_variable("RAG_AZURE_OPENAI_API_KEY", AZURE_OPENAI_API_KEY)
 AZURE_OPENAI_ENDPOINT = get_env_variable("AZURE_OPENAI_ENDPOINT", "")
 RAG_AZURE_OPENAI_ENDPOINT = get_env_variable("RAG_AZURE_OPENAI_ENDPOINT", AZURE_OPENAI_ENDPOINT).rstrip("/")
+RAG_AZURE_OPENAI_DEPLOYMENT = get_env_variable("RAG_AZURE_OPENAI_ENDPOINT", "").rstrip("/")
 HF_TOKEN = get_env_variable("HF_TOKEN", "")
 OLLAMA_BASE_URL = get_env_variable("OLLAMA_BASE_URL", "http://ollama:11434")
 
@@ -155,7 +156,8 @@ def init_embeddings(provider, model):
         return AzureOpenAIEmbeddings(
             model=model,
             api_key=RAG_AZURE_OPENAI_API_KEY,
-            azure_endpoint=RAG_AZURE_OPENAI_ENDPOINT
+            azure_endpoint=RAG_AZURE_OPENAI_ENDPOINT,
+            deployment=RAG_AZURE_OPENAI_DEPLOYMENT
         )
     elif provider == "huggingface":
         return HuggingFaceEmbeddings(model_name=model, encode_kwargs={


### PR DESCRIPTION
Added deployment name to be passed from an environment variable which inturn is passed into AzureOpenAIEmbeddings langchain object without which passing the deployment model is seeming impossible.