### PR TITLE
fix: Upload signed PDFs

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -24,3 +24,4 @@ rapidocr-onnxruntime==1.3.17
 opencv-python-headless==4.9.0.80
 pymongo==4.6.3
 langchain-mongodb==0.1.3
+cryptography==42.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ rapidocr-onnxruntime==1.3.17
 opencv-python-headless==4.9.0.80
 pymongo==4.6.3
 langchain-mongodb==0.1.3
+cryptography==42.0.7


### PR DESCRIPTION
The cryptography library is required by pypdf to process signed PDFs. (Also see #35)

Fixes #35
