### PR TITLE
fix: Github Workflows. Remove debug code from common docker workflow

### DIFF
--- a/.github/workflows/docker-build-workflow.yaml
+++ b/.github/workflows/docker-build-workflow.yaml
@@ -1,0 +1,59 @@
+name: Docker Dev Images Build
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag for the Docker images'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - target: main
+            file: Dockerfile
+            image_name: librechat-rag-api-dev
+          - target: lite
+            file: Dockerfile.lite
+            image_name: librechat-rag-api-dev-lite
+
+    steps:
+      # Check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Set up QEMU
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Log in to GitHub Container Registry
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build and push Docker images for each target
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target }}

--- a/.github/workflows/docker-build-workflow.yaml
+++ b/.github/workflows/docker-build-workflow.yaml
@@ -54,6 +54,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}          
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}
           platforms: linux/amd64,linux/arm64
           target: ${{ matrix.target }}

--- a/.github/workflows/docker-build-workflow.yaml
+++ b/.github/workflows/docker-build-workflow.yaml
@@ -52,11 +52,8 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: true
-          # tags: |
-          #   ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
-          #   ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}
           tags: |
-            ghcr.io/denispalnitsky/${{ matrix.image_name }}:${{ github.sha }}
-            ghcr.io/denispalnitsky/${{ matrix.image_name }}:${{ inputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}          
           platforms: linux/amd64,linux/arm64
           target: ${{ matrix.target }}

--- a/.github/workflows/docker-build-workflow.yaml
+++ b/.github/workflows/docker-build-workflow.yaml
@@ -52,8 +52,11 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: true
+          # tags: |
+          #   ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
+          #   ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ inputs.tag }}
+            ghcr.io/denispalnitsky/${{ matrix.image_name }}:${{ github.sha }}
+            ghcr.io/denispalnitsky/${{ matrix.image_name }}:${{ inputs.tag }}
           platforms: linux/amd64,linux/arm64
           target: ${{ matrix.target }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -3,10 +3,11 @@ name: Docker Dev Images Build
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - main
+    # paths-ignore:
+    #   - 'README.md'
+    # branches:
+    #   - main
+    
 
 jobs:
   call-docker-build:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -3,10 +3,10 @@ name: Docker Dev Images Build
 on:
   workflow_dispatch:
   push:
-    # paths-ignore:
-    #   - 'README.md'
-    # branches:
-    #   - main
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - main
     
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Docker Dev Images Release
 on:
   workflow_dispatch:
   push:
-    # tags:
-    #   - '*'
+    tags:
+      - '*'
 
 jobs:
   call-docker-build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Docker Dev Images Release
 on:
   workflow_dispatch:
   push:
-    tags:
-      - '*'
+    # tags:
+    #   - '*'
 
 jobs:
   call-docker-build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,13 @@
-name: Docker Dev Images Build
+name: Docker Dev Images Release
 
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - main
+    tags:
+      - '*'
 
 jobs:
   call-docker-build:
     uses: ./.github/workflows/docker-build-workflow.yaml
     with:
-      tag: latest
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
Removes debug code accidentally pushed to `main` and switch `images.yaml` workflow to use common `docker-build` workflow.

Fixes #40 