### PR TITLE
📜 chore: Known Extensions for erlang, elixir, haskell and jsx/tsx

### DIFF
--- a/config.py
+++ b/config.py
@@ -291,4 +291,11 @@ known_source_ext = [
     "swift",
     "vue",
     "svelte",
+    "ex",
+    "exs",
+    "erl",
+    "tsx",
+    "jsx",
+    "hs",
+    "lhs",
 ]


### PR DESCRIPTION
Just a simple addition to support more extensions related to programming languages when parsing files.