### PR TITLE
🔧 fix: missing python-magic and python-pptx in requirements.lite.txt

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -25,3 +25,5 @@ opencv-python-headless==4.9.0.80
 pymongo==4.6.3
 langchain-mongodb==0.1.3
 cryptography==42.0.7
+python-magic==0.4.27
+python-pptx==0.6.23


### PR DESCRIPTION
This PR fixes `requirements.lite.txt` which is missing two requirements that were added in #51. Without these requirements, the "lite" version will fail when powerpoint files are submitted for processing.

**Changes**:
- Added [python-magic](https://pypi.org/project/python-magic/) and [python-pptx](https://pypi.org/project/python-pptx/) to `requirements.lite.txt`, matching the versions in `requirements.txt`.
