### PR TITLE
🔧 fix: missing xlrd requirement for .xls files

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -27,3 +27,4 @@ langchain-mongodb==0.1.3
 cryptography==42.0.7
 python-magic==0.4.27
 python-pptx==0.6.23
+xlrd==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ langchain-mongodb==0.1.3
 cryptography==42.0.7
 python-magic==0.4.27
 python-pptx==0.6.23
+xlrd==2.0.1


### PR DESCRIPTION
This PR adds [xlrd](https://pypi.org/project/xlrd/) to `requirements.txt` and `requirements.lite.txt`.  This fixes the following exception that is raised when an `.xls` file is submitted to the `/embed` endpoint:

> ImportError: Missing optional dependency 'xlrd'. Install xlrd >= 2.0.1 for xls Excel support Use pip or conda to install xlrd.

