### PR TITLE
refactor: Async batch processing, limits, and configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The following environment variables are required to run the application:
 - `COLLECTION_NAME`: (Optional) The name of the collection in the vector store. Default value is "testcollection".
 - `CHUNK_SIZE`: (Optional) The size of the chunks for text processing. Default value is "1500".
 - `CHUNK_OVERLAP`: (Optional) The overlap between chunks during text processing. Default value is "100".
+- `MAX_CHUNKS`: (Optional) The max number of chunks to process in one file. Default is unlimited.
+- `EMBEDDING_TIMEOUT`: (Optional) The time limit for processsing (embedding) chunks. Default value is "100000" (100s)
+- `BATCH_SIZE`: (Optional) The number of chunks to embed and add to vector storage in each api call. Default value is "75"
+  - Note: Ideal (fastest total embedding time) `BATCH_SIZE` will depend on embeddings provider, model, and file size
+- `CONCURRENT_LIMIT`: The max number of async embedding api calls allowed concurrently. Default value is 20
 - `RAG_UPLOAD_DIR`: (Optional) The directory where uploaded files are stored. Default value is "./uploads/".
 - `PDF_EXTRACT_IMAGES`: (Optional) A boolean value indicating whether to extract images from PDF files. Default value is "False".
 - `DEBUG_RAG_API`: (Optional) Set to "True" to show more verbose logging output in the server console, and to enable postgresql database routes

--- a/config.py
+++ b/config.py
@@ -62,6 +62,12 @@ MONGO_VECTOR_COLLECTION = get_env_variable(
 )  # Deprecated, backwards compatability
 CHUNK_SIZE = int(get_env_variable("CHUNK_SIZE", "1500"))
 CHUNK_OVERLAP = int(get_env_variable("CHUNK_OVERLAP", "100"))
+maxChunks = get_env_variable("MAX_CHUNKS")
+MAX_CHUNKS = int(maxChunks) if maxChunks else None 
+EMBEDDING_TIMEOUT = int(get_env_variable("EMBEDDING_TIMEOUT",100000))#default 100 second timeout
+
+BATCH_SIZE = int(get_env_variable("BATCH_SIZE","75"))
+CONCURRENT_LIMIT = int(get_env_variable("CONCURRENT_LIMIT","20"))
 
 env_value = get_env_variable("PDF_EXTRACT_IMAGES", "False").lower()
 PDF_EXTRACT_IMAGES = True if env_value == "true" else False

--- a/process_docs.py
+++ b/process_docs.py
@@ -1,0 +1,38 @@
+from langchain.schema import Document
+import time
+import asyncio
+from config import  (
+    CONCURRENT_LIMIT,
+    BATCH_SIZE,
+    EMBEDDING_TIMEOUT,
+    vector_store,
+    logger
+)
+
+
+#Prepare documents to be async added to vectorstore async in batches
+async def store_documents(
+    docs: list[Document], ids:list[str]
+):
+    semaphore = asyncio.Semaphore(CONCURRENT_LIMIT)
+    tasks = []
+    logger.info(f"Processing list of documents of length: {len(docs)}")
+    start_time = time.perf_counter()
+    for i in range(0, len(docs), BATCH_SIZE):
+        batch = docs[i : min(i + BATCH_SIZE, len(docs))]
+        #logger.info(f"Sending batch {i} to {i+len(batch)} / {len(docs)}")
+        task = asyncio.create_task(process_batch(batch, ids, semaphore))
+        tasks.append(task)
+    try:
+        idList = await asyncio.wait_for(asyncio.gather(*tasks), timeout=(EMBEDDING_TIMEOUT/1000)) 
+        end_time = time.perf_counter()
+        elapsed = end_time - start_time
+        logger.info(f"SUCCESS: processed {len(docs)} documents in time: {elapsed}")
+    except asyncio.TimeoutError:
+        raise Exception(f"TIMEOUT: embedding process took over the time limit of {EMBEDDING_TIMEOUT}ms. Partially added to database")
+    return [id for sublist in idList for id in sublist]
+
+#Helper for process_documents
+async def process_batch(batch: list[Document], ids: list[str], semaphore):
+    async with semaphore:
+        return await vector_store.aadd_documents(batch,ids=ids)


### PR DESCRIPTION
Added async api calls to embed (process) and add chunks (documents) to vector storage. 

Added env variables: `MAX_CHUNKS`, `EMBEDDING_TIMEOUT`, `BATCH_SIZE`, and `CONCURRENT_LIMIT` to configure/limit batching api class. Description in Readme. 

Tested with PGVector with bedrock and `amazon.titan-embed-text-v2:0`. Also rebuilt in docker successfully.
1) Verified `BATCH_SIZE` and `CONCURRENT_LIMIT` affecting process calls to embed correctly
2) Verified `MAX_CHUNKS` works as limit and throws exception if over. Correct default behavior of ignoring
3) Verified `EMBEDDING_TIMEOUT` works within limit and throws exception if over 