### PR TITLE
feat: Qdrant Vector Database 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following environment variables are required to run the application:
 - `AWS_DEFAULT_REGION`: (Optional) defaults to `us-east-1`
 - `AWS_ACCESS_KEY_ID`: (Optional) needed for bedrock embeddings
 - `AWS_SECRET_ACCESS_KEY`: (Optional) needed for bedrock embeddings
+- `QDRANT_API_KEY`: (Optional) api key, not needed for docker container
 
 Make sure to set these environment variables before running the application. You can set them in a `.env` file or as system environment variables.
 
@@ -118,6 +119,19 @@ The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by Lib
 
 Follow one of the [four documented methods](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#procedure) to create the vector index.
 
+### Use Qdrant as Vector Database
+
+Additionally, we can use [Qdrant](https://qdrant.tech/documentation/) as the vector database. To do so, set the following environment variables
+
+```env
+VECTOR_DB_TYPE=qdrant
+DB_HOST=<host address>
+DB_PORT=<port number>
+COLLECTION_NAME=<vector collection>
+QDRANT_API_KEY=<api key>
+```
+
+To download qdrant docker image: `docker pull qdrant/qdrant` and start container on port 6333: `docker run -p 6333:6333 qdrant/qdrant`. Set `DB_HOST=localhost` and `DB_PORT=6333`. Will automatically create a collection of name `COLLECTION_NAME` if not already exists. `QDRANT_API_KEY` not neccesary to use. 
 
 ### Cloud Installation Settings:
 

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -30,3 +30,4 @@ python-pptx==0.6.23
 xlrd==2.0.1
 langchain-aws==0.2.1
 boto3==1.34.144
+qdrant-client==1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ cryptography==42.0.7
 python-magic==0.4.27
 python-pptx==0.6.23
 xlrd==2.0.1
+qdrant-client==1.11.2

--- a/store_factory.py
+++ b/store_factory.py
@@ -1,24 +1,30 @@
-from typing import Optional
+from typing import Optional, TypedDict
 from langchain_core.embeddings import Embeddings
 from store import AsyncPgVector, ExtendedPgVector
 from store import AtlasMongoVector
+from store import AsyncQdrant
+import qdrant_client
 from pymongo import MongoClient
+
+
+async_DB = (AsyncPgVector, AsyncQdrant) #Add if async database implementation 
 
 
 def get_vector_store(
     connection_string: str,
     embeddings: Embeddings,
     collection_name: str,
-    mode: str = "sync",
-    search_index: Optional[str] = None 
+    mode: str = "sync-PGVector",
+    search_index: Optional[str] = None,
+    api_key: Optional[str]  = None 
 ):
-    if mode == "sync":
+    if mode == "sync-PGVector":
         return ExtendedPgVector(
             connection_string=connection_string,
             embedding_function=embeddings,
             collection_name=collection_name,
         )
-    elif mode == "async":
+    elif mode == "async-PGVector":
         return AsyncPgVector(
             connection_string=connection_string,
             embedding_function=embeddings,
@@ -30,6 +36,30 @@ def get_vector_store(
         return AtlasMongoVector(
             collection=mong_collection, embedding=embeddings, index_name=search_index
         )
+    elif mode == "qdrant":
+        embeddings_dimension = len(embeddings.embed_query("Dimension"))
+        client = qdrant_client.QdrantClient(
+        url=connection_string,
+        api_key=api_key
+        )
+        collection_config = qdrant_client.http.models.VectorParams(
+            size=embeddings_dimension,
+            distance=qdrant_client.http.models.Distance.COSINE
+        )
+        if not client.collection_exists(collection_name):
+            collection_config = qdrant_client.http.models.VectorParams(
+                size=embeddings_dimension,
+                distance=qdrant_client.http.models.Distance.COSINE
+            )
+            client.create_collection(
+            collection_name=collection_name,
+            vectors_config=collection_config
+            )
+        return AsyncQdrant(
+            client=client,
+            collection_name=collection_name,
+            embedding=embeddings      
+            )
 
     else:
         raise ValueError("Invalid mode specified. Choose 'sync' or 'async'.")


### PR DESCRIPTION
Qdrant vector database supported. Added section in readme in setting up Qdrant environmental variables as well as specifically running docker image. Implemented Async methods for qdrant. 

Tested using bedrock with `amazon.titan-embed-text-v2:0` with all 3 supported currently vector databases (pgvector, qdrant, and atlas mongo) 

Tested `/ids`, `/documents` , `/delete` ,`/embed` , `/query` and `/query_multiple` endpoints successfully with qdrant, pgvector, and atlas mongo.