### PR TITLE
chore: updating lite requirements to include ollama and others

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -30,3 +30,6 @@ python-pptx==0.6.23
 xlrd==2.0.1
 langchain-aws==0.2.1
 boto3==1.34.144
+langchain-ollama==0.2.0
+langchain-openai==0.2.0
+langchain-huggingface==0.1.0


### PR DESCRIPTION
Updated lite requirements list to better reflect requirements list: 
langchain-ollama==0.2.0
langchain-openai==0.2.0
langchain-huggingface==0.1.0