### PR TITLE
feat: Pinecone Vector Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following environment variables are required to run the application:
 - `AWS_DEFAULT_REGION`: (Optional) defaults to `us-east-1`
 - `AWS_ACCESS_KEY_ID`: (Optional) needed for bedrock embeddings
 - `AWS_SECRET_ACCESS_KEY`: (Optional) needed for bedrock embeddings
+- `PINECONE_API_KEY`: (Optional) needed for pinecone vector database
 
 Make sure to set these environment variables before running the application. You can set them in a `.env` file or as system environment variables.
 
@@ -97,7 +98,7 @@ COLLECTION_NAME=<vector collection>
 ATLAS_SEARCH_INDEX=<vector search index>
 ```
 
-The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by LibreChat. Even if it is the same, the `$COLLECTION_NAME` collection needs to be a completely new one, separate from all collections used by LibreChat. In addition,  create a vector search index for collection above (remember to assign `$ATLAS_SEARCH_INDEX`) with the following json:
+The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by LibreChat. Even if it is the same, the `$COLLECTION_NAME` collection needs to be a completely new one, separate from all collections used by LibreChat. In addition, create a vector search index for collection above (remember to assign `$ATLAS_SEARCH_INDEX`) with the following json:
 
 ```json
 {
@@ -118,6 +119,18 @@ The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by Lib
 
 Follow one of the [four documented methods](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#procedure) to create the vector index.
 
+### Use Pinecone as Vector Database
+
+Another option for a vector database, we could use [Pinecone](https://www.pinecone.io/). To do so, set the following environment variables along with creating a pinecone account to get api key.
+
+```env
+VECTOR_DB_TYPE=pinecone
+COLLECTION_NAME=<index name>
+PINECOIN_API_KEY=<api key>
+AWS_DEFAULT_REGION=<defaults 'us-east-1'>
+```
+
+A new index with name `COLLECTION_NAME` will be created automatically if one does not already exist in your Pinecone vector database.
 
 ### Cloud Installation Settings:
 

--- a/config.py
+++ b/config.py
@@ -6,6 +6,8 @@ import logging
 from enum import Enum
 from datetime import datetime
 from dotenv import find_dotenv, load_dotenv
+from langchain_pinecone import Pinecone
+from openai import api_key
 from starlette.middleware.base import BaseHTTPMiddleware
 from store_factory import get_vector_store
 
@@ -15,6 +17,7 @@ load_dotenv(find_dotenv())
 class VectorDBType(Enum):
     PGVECTOR = "pgvector"
     ATLAS_MONGO = "atlas-mongo"
+    PINECONE = "pinecone"
 
 
 class EmbeddingsProvider(Enum):
@@ -169,6 +172,7 @@ HF_TOKEN = get_env_variable("HF_TOKEN", "")
 OLLAMA_BASE_URL = get_env_variable("OLLAMA_BASE_URL", "http://ollama:11434")
 AWS_ACCESS_KEY_ID = get_env_variable("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = get_env_variable("AWS_SECRET_ACCESS_KEY", "")
+PINECONE_API_KEY = get_env_variable("PINECONE_API_KEY", "")
 
 ## Embeddings
 
@@ -275,6 +279,15 @@ elif VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO:
         collection_name=COLLECTION_NAME,
         mode="atlas-mongo",
         search_index=ATLAS_SEARCH_INDEX,
+    )
+elif VECTOR_DB_TYPE == VectorDBType.PINECONE:
+    AWS_DEFAULT_REGION = get_env_variable("AWS_DEFAULT_REGION", "us-east-1")
+    vector_store = get_vector_store(
+        connection_string=AWS_DEFAULT_REGION,
+        embeddings=embeddings,
+        collection_name=COLLECTION_NAME,
+        mode="pinecone",
+        api_key=PINECONE_API_KEY,
     )
 else:
     raise ValueError(f"Unsupported vector store type: {VECTOR_DB_TYPE}")

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -24,6 +24,7 @@ rapidocr-onnxruntime==1.3.24
 opencv-python-headless==4.9.0.80
 pymongo==4.6.3
 langchain-mongodb==0.2.0
+langchain-pinecone==0.2.0
 cryptography==42.0.7
 python-magic==0.4.27
 python-pptx==0.6.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ langchain-mongodb==0.2.0
 langchain-ollama==0.2.0
 langchain-openai==0.2.0
 langchain-huggingface==0.1.0
+langchain-pinecone==0.2.0
 cryptography==42.0.7
 python-magic==0.4.27
 python-pptx==0.6.23

--- a/store.py
+++ b/store.py
@@ -4,7 +4,7 @@ from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.documents import Document
 from langchain_core.runnables.config import run_in_executor
 from sqlalchemy.orm import Session
-
+from langchain_pinecone import PineconeVectorStore
 from langchain_mongodb import MongoDBAtlasVectorSearch
 from langchain_core.embeddings import Embeddings
 from typing import (
@@ -150,3 +150,85 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
         # implement the deletion of documents by file_id in self._collection
         if ids is not None:
             self._collection.delete_many({"file_id": {"$in": ids}})
+
+
+class ExtendedPCVector(PineconeVectorStore):
+    @property
+    def embedding_function(self) -> Embeddings:
+        return self.embeddings
+
+    def add_documents(self, docs: list[Document], ids: list[str]):
+        # {file_id}_{idx}
+        new_ids = [id for id in range(len(ids))]
+        file_id = docs[0].metadata["file_id"]
+        f_ids = [f"{file_id}_{id}" for id in new_ids]
+        return super().add_documents(docs, ids=f_ids)
+
+    def get_ids_prefix(self, file_id: str) -> list[str]:
+        prefix = file_id + "_"
+        ids = []
+        for results in self._index.list(prefix=prefix, namespace=self._namespace):
+            ids.extend(results)
+        return ids
+
+    def get_all_ids(self) -> List[str]:
+        baseIDs = set()
+        for ids in self._index.list(namespace=self._namespace):
+            for id in ids:
+                base = id.split('_')[0]
+                baseIDs.add(base)
+        return list(baseIDs)
+
+    def get_documents_by_ids(self, ids: List[str]) -> List[Document]:
+        idList = []
+        for id in ids:
+            result = self.get_ids_prefix(id)
+            idList.extend(result)
+        results = self._index.fetch(idList)
+        documents = []
+        for vector in results["vectors"]:
+            metadata = results["vectors"][vector]["metadata"]
+            metadataF = {
+                "file_id": metadata["file_id"],
+                "digest": metadata["digest"],
+                "source": metadata["source"],
+                "user_id": metadata["user_id"],
+            }
+            doc = Document(page_content=metadata["text"], metadata=metadataF)
+            documents.append(doc)
+        return documents
+
+    def delete(self, ids: Optional[List[str]] = None) -> None:
+        for id in ids:
+            idList = self.get_ids_prefix(id)
+            self._index.delete(ids=idList, namespace=self._namespace)
+            # Deletes based on prefix, more efficient but delete more if names overlap, implement for all?
+
+    def similarity_search_with_score_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 4,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Perform a similarity search with scores using an embedding vector.
+        """
+        query_results = self._index.query(
+            vector=embedding,
+            top_k=k,
+            include_metadata=True,
+            namespace=self._namespace,
+            **kwargs,
+        )
+        docs = query_results["matches"]
+        processed_documents = []
+        for match in docs:
+            metadata = match["metadata"]
+            if "metadata" in metadata and "_id" in metadata["metadata"]:
+                del metadata["metadata"]["_id"]
+            text = metadata["text"]
+            del metadata["text"]
+            doc = Document(page_content=text, metadata=metadata)
+            processed_documents.append((doc, match["score"]))
+        return processed_documents


### PR DESCRIPTION
Added Pinecone vector database support. To setup (also in readme) set `VECTOR_DB_TYPE=pinecone` and `PINECONE_API_KEY=<api key>` 

Tested with Pinecone, openai `text-embedding-3-small`
1) Embedding multiple text files
2) Getting all ids for multiple files 
3) Deleting documents, ensuring not in database
4) Querying one file, ensuring relevant results to query 
5) Getting documents according to id
6) Querying multiple documents, ensuring all documents are queried 
7) Change back to Pgvector , to ensure still working