### PR TITLE
fix: pdf images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /app
 
 # Install pandoc and netcat
 RUN apt-get update \
-    && apt-get install -y pandoc netcat-openbsd \
+    && apt-get install -y --no-install-recommends \
+    pandoc \
+    netcat-openbsd \
+    libgl1-mesa-glx \  
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -4,7 +4,11 @@ WORKDIR /app
 
 # Install pandoc and netcat
 RUN apt-get update \
-    && apt-get install -y pandoc netcat-openbsd \
+    && apt-get install -y --no-install-recommends \
+    pandoc \
+    netcat-openbsd \
+    libgl1-mesa-glx \  
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.lite.txt .


### PR DESCRIPTION
Fix for #88 `PDF_EXTRACT_IMAGES=True` failure to embed pdfs. Issue due to limitation of linux in previous image.

Added `libgl1-mesa-glx` and `libglib2.0-0` to install on building image in Dockerfile. 

Tested getting ids, embedding multiple file types, deleting and querying to ensure rag_api functional. 