### PR TITLE
Updated documentation to highlight existence of RAG_USE_FULL_CONTEXT variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following environment variables are required to run the application:
 - `COLLECTION_NAME`: (Optional) The name of the collection in the vector store. Default value is "testcollection".
 - `CHUNK_SIZE`: (Optional) The size of the chunks for text processing. Default value is "1500".
 - `CHUNK_OVERLAP`: (Optional) The overlap between chunks during text processing. Default value is "100".
+- `RAG_USE_FULL_CONTEXT`: (Optional) Set to "True" to fetch entire context of the file(s) uploaded/referenced into the conversation. Default value is "false" which means it fetches only the top 4 results (top_k=4) of the file based on the user's message.
 - `RAG_UPLOAD_DIR`: (Optional) The directory where uploaded files are stored. Default value is "./uploads/".
 - `PDF_EXTRACT_IMAGES`: (Optional) A boolean value indicating whether to extract images from PDF files. Default value is "False".
 - `DEBUG_RAG_API`: (Optional) Set to "True" to show more verbose logging output in the server console, and to enable postgresql database routes


### PR DESCRIPTION
Currently, there isn't documentation that highlights the ability to use full context of the documents uploaded for RAG. This causes new users like myself to run into subpar RAG results in certain scenarios. Adding documentation for the RAG_USE_FULL_CONTEXT parameter/variable to raise awareness of this feature.

Related discussion: https://github.com/danny-avila/LibreChat/discussions/4066