### PR TITLE
chore: make "lite" docker image lighter

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,4 +1,4 @@
-FROM python:3.10 AS lite
+FROM python:3.10-slim AS lite
 
 WORKDIR /app
 


### PR DESCRIPTION
This reduces the "lite" docker image size by over 1GB:
```
❯ docker images | grep python-with
python-with-slim                      1                  8e2af154aac9   42 seconds ago   1.81GB
python-without-slim                   1                  f94cf64c4591   2 minutes ago    2.97GB
```
and removes about 100 vulnerabilities (See):
https://hub.docker.com/_/python/tags?name=3.10.16-slim-bookworm
https://hub.docker.com/_/python/tags?name=3.10.16-bookworm

slim is still based around glibc, so C bindings should still work