### PR TITLE
🛠️ fix: Enhance Error Logging, Update Dependencies, and Optimize NLTK Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Download standard NLTK data, to prevent unstructured from downloading packages at runtime
+RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger
+ENV NLTK_DATA=/app/nltk_data
+
+# Disable Unstructured analytics
+ENV SCARF_NO_ANALYTICS=true
+
 COPY . .
 
 CMD ["python", "main.py"]

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -14,6 +14,13 @@ RUN apt-get update \
 COPY requirements.lite.txt .
 RUN pip install --no-cache-dir -r requirements.lite.txt
 
+# Download standard NLTK data, to prevent unstructured from downloading packages at runtime
+RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger
+ENV NLTK_DATA=/app/nltk_data
+
+# Disable Unstructured analytics
+ENV SCARF_NO_ANALYTICS=true
+
 COPY . .
 
 CMD ["python", "main.py"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: ankane/pgvector:latest

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -1,7 +1,7 @@
-langchain==0.3.9 
-langchain-community==0.3.9
+langchain==0.3.12
+langchain-community==0.3.12
 langchain-openai==0.2.11 
-langchain-core==0.3.21 
+langchain-core==0.3.25 
 sqlalchemy==2.0.28
 python-dotenv==1.0.1
 fastapi==0.110.0
@@ -9,7 +9,7 @@ psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
 pypdf==4.1.0
-unstructured==0.15.13
+unstructured==0.16.11
 markdown==3.6
 networkx==3.2.1
 pandas==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-langchain==0.3.9 
-langchain-community==0.3.9
+langchain==0.3.12
+langchain-community==0.3.12
 langchain-openai==0.2.11 
-langchain-core==0.3.21 
+langchain-core==0.3.25 
 langchain-aws==0.2.1
 boto3==1.34.144
 sqlalchemy==2.0.28
@@ -11,7 +11,7 @@ psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
 pypdf==4.1.0
-unstructured==0.15.13
+unstructured==0.16.11
 markdown==3.6
 networkx==3.2.1
 pandas==2.2.1


### PR DESCRIPTION
## Summary

I enhanced error logging with traceback throughout the application, updated dependencies for `unstructured` and `langchain` core packages, adjusted Dockerfiles to pre-download NLTK data and disable Unstructured analytics, and removed the version specification from `docker-compose.yaml`.

- Added detailed error logging with traceback in `main.py` to aid in debugging and error tracking.
- Updated `unstructured` and `langchain` core packages to the latest versions in `requirements.txt` and `requirements.lite.txt`.
- Modified `Dockerfile` and `Dockerfile.lite` to download NLTK data during build time, preventing `unstructured` from downloading packages at runtime.
- Set the `NLTK_DATA` environment variable to `/app/nltk_data` in Dockerfiles for consistent NLTK data path.
- Disabled Unstructured analytics by setting `SCARF_NO_ANALYTICS=true` in Dockerfiles.
- Removed the version specification from `docker-compose.yaml` to utilize the default version.

Relevant GitHub references:
- https://github.com/Unstructured-IO/unstructured/pull/3796
- https://github.com/nltk/nltk/issues/3293

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes by:

- Running the application to ensure it operates correctly with the updated dependencies.
- Triggering exceptions to confirm that error logging with traceback works as expected.
- Building Docker images using the updated Dockerfiles and verifying that NLTK data is downloaded during the build process.
- Running the application using the updated `docker-compose.yaml` to ensure there are no Docker-related issues.
- Checking the application logs to confirm that Unstructured analytics is disabled.

### **Test Configuration**:

- Operating System: Ubuntu 22.04 LTS
- Docker version: 23.0.6
- Docker Compose version: 2.17.3
- Python version: 3.11

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
