### PR TITLE
✨ feat: Add 'entity_id' Parameter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
               "8000",
               "--reload"
           ],
-          "jinja": true
+          "jinja": true,
+          "envFile": "${workspaceFolder}/.env"
       }
   ]
 }

--- a/config.py
+++ b/config.py
@@ -76,7 +76,13 @@ HTTP_REQ = "http_req"
 
 logger = logging.getLogger()
 
-debug_mode = get_env_variable("DEBUG_RAG_API", "False").lower() == "true"
+debug_mode = os.getenv("DEBUG_RAG_API", "False").lower() in (
+    "true",
+    "1",
+    "yes",
+    "y",
+    "t",
+)
 console_json = get_env_variable("CONSOLE_JSON", "False").lower() == "true"
 
 if debug_mode:

--- a/models.py
+++ b/models.py
@@ -26,9 +26,10 @@ class StoreDocument(BaseModel):
 
 
 class QueryRequestBody(BaseModel):
-    file_id: str
     query: str
+    file_id: str
     k: int = 4
+    entity_id: Optional[str] = None
 
 
 class CleanupMethod(str, Enum):


### PR DESCRIPTION
## Summary

I added support for 'entity_id' as an alternative to 'user_id' in various endpoints, improved the handling of the 'DEBUG_RAG_API' environment variable, and updated the VSCode launch settings to include an 'envFile' configuration.

- Added `entity_id` as an alternative parameter in the `/query`, `/embed`, `/embed-upload`, and `/local/embed` endpoints to allow authorization using `entity_id` for shared resources.
- Improved `debug_mode` environment variable handling by ensuring consistent parsing of boolean values, supporting multiple truthy values like `'true'`, `'1'`, `'yes'`, etc.
- Updated exception handling to provide more detailed error responses when request validation fails.
- Updated VSCode `launch.json` to include `envFile` configuration, allowing environment variables to be loaded during debugging sessions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the changes by running the API locally and invoking the updated endpoints with and without `entity_id` and `user_id` to verify that authorization works correctly. I tested different `DEBUG_RAG_API` values to ensure the debug mode setting is properly handled. I also ran the application in VSCode to confirm that the `envFile` configuration loads environment variables as expected.

### **Test Configuration**:

- **OS**: Ubuntu 20.04
- **Python Version**: 3.9
- **Environment**: Variables set in `.env` file during testing

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.