### PR TITLE
[Enhancement] Add similarity threshold filter

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,6 +62,7 @@ MONGO_VECTOR_COLLECTION = get_env_variable(
 )  # Deprecated, backwards compatability
 CHUNK_SIZE = int(get_env_variable("CHUNK_SIZE", "1500"))
 CHUNK_OVERLAP = int(get_env_variable("CHUNK_OVERLAP", "100"))
+SIMILARITY_THRESHOLD = float(get_env_variable("SIMILARITY_THRESHOLD", "1"))
 
 env_value = get_env_variable("PDF_EXTRACT_IMAGES", "False").lower()
 PDF_EXTRACT_IMAGES = True if env_value == "true" else False

--- a/config.py
+++ b/config.py
@@ -177,6 +177,8 @@ OLLAMA_BASE_URL = get_env_variable("OLLAMA_BASE_URL", "http://ollama:11434")
 AWS_ACCESS_KEY_ID = get_env_variable("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = get_env_variable("AWS_SECRET_ACCESS_KEY", "")
 
+UNSTRUCTURED_API_KEY = get_env_variable("UNSTRUCTURED_API_KEY")
+
 ## Embeddings
 
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from langchain_community.document_loaders import (
     UnstructuredExcelLoader,
     UnstructuredPowerPointLoader,
 )
+from langchain_unstructured import UnstructuredLoader
 
 from models import (
     StoreDocument,
@@ -74,6 +75,7 @@ from config import (
     # RAG_EMBEDDING_MODEL_DEVICE_TYPE,
     # RAG_TEMPLATE,
     VECTOR_DB_TYPE,
+    UNSTRUCTURED_API_KEY
 )
 
 
@@ -351,7 +353,11 @@ def get_loader(filename: str, file_content_type: str, filepath: str):
     known_type = True
 
     if file_ext == "pdf":
-        loader = PyPDFLoader(filepath, extract_images=app.state.PDF_EXTRACT_IMAGES)
+        if UNSTRUCTURED_API_KEY:
+            loader = UnstructuredLoader(filepath, api_key=UNSTRUCTURED_API_KEY, strategy="auto", partition_via_api=True,
+                                        chunking_strategy="by_title", include_orig_elements=False, languages=["eng"])
+        else:
+            loader = PyPDFLoader(filepath, extract_images=app.state.PDF_EXTRACT_IMAGES)
     elif file_ext == "csv":
         loader = CSVLoader(filepath)
     elif file_ext == "rst":

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ from config import (
     LogMiddleware,
     RAG_HOST,
     RAG_PORT,
+    SIMILARITY_THRESHOLD,
     VectorDBType,
     # RAG_EMBEDDING_MODEL,
     # RAG_EMBEDDING_MODEL_DEVICE_TYPE,
@@ -243,6 +244,9 @@ async def query_embeddings_by_file_id(
             documents = vector_store.similarity_search_with_score_by_vector(
                 embedding, k=body.k, filter={"file_id": body.file_id}
             )
+
+        # Remove documents exceeding similarity threshold
+        documents[:] = [doc for doc in documents if doc[1] <= SIMILARITY_THRESHOLD]
 
         if not documents:
             return authorized_documents
@@ -636,6 +640,9 @@ async def query_embeddings_by_file_ids(body: QueryMultipleBody):
             documents = vector_store.similarity_search_with_score_by_vector(
                 embedding, k=body.k, filter={"file_id": {"$in": body.file_ids}}
             )
+
+        # Remove documents exceeding similarity threshold
+        documents[:] = [doc for doc in documents if doc[1] <= SIMILARITY_THRESHOLD]
 
         # Ensure documents list is not empty
         if not documents:

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -1,7 +1,8 @@
 langchain==0.3.12
 langchain-community==0.3.12
 langchain-openai==0.2.11 
-langchain-core==0.3.25 
+langchain-core==0.3.25
+langchain_unstructured==0.1.6
 sqlalchemy==2.0.28
 python-dotenv==1.0.1
 fastapi==0.110.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ langchain-community==0.3.12
 langchain-openai==0.2.11 
 langchain-core==0.3.25 
 langchain-aws==0.2.1
+langchain_unstructured==0.1.6
 boto3==1.34.144
 sqlalchemy==2.0.28
 python-dotenv==1.0.1


### PR DESCRIPTION
As LibreChat performs file search by looping over all documents available to the respective endpoint, in case of many documents (e.g. larger agent knowledge base) it returns large results even if most of it is not at all relevant. This causes a lot of input tokens for LLM and high API usage price in case of using more advanced models.

This PR introduces an option to set similarity threshold. All results over the similarity threshold will be filtered and not provided back to LibreChat.

If the similarity threshold is not set, a default value of 1 will be used which means nothing will be filtered out. Therefore, there is no breaking change to existing deployments.