### PR TITLE
Update config.py

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -190,6 +190,7 @@ def init_embeddings(provider, model):
             api_key=RAG_OPENAI_API_KEY,
             openai_api_base=RAG_OPENAI_BASEURL,
             openai_proxy=RAG_OPENAI_PROXY,
+            chunk_size=200
         )
     elif provider == EmbeddingsProvider.AZURE:
         from langchain_openai import AzureOpenAIEmbeddings


### PR DESCRIPTION
fix(embeddings): increase chunk_size for OpenAIEmbeddings to avoid API limits

Adjusted the `chunk_size` parameter in the `OpenAIEmbeddings` class to 200, based on the calculation:
- Maximum payload size: 300 000 tokens  
- Upper‐bound chunk size: 1 500 tokens  
- ⇒ 300 000 / 1 500 = 200  

This ensures embedding requests stay within OpenAI’s maximum input size and prevents failures due to oversized requests.