### PR TITLE
Add environment variable for disabling 'check_embedding_ctx_length'.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -179,6 +179,8 @@ OLLAMA_BASE_URL = get_env_variable("OLLAMA_BASE_URL", "http://ollama:11434")
 AWS_ACCESS_KEY_ID = get_env_variable("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = get_env_variable("AWS_SECRET_ACCESS_KEY", "")
 GOOGLE_APPLICATION_CREDENTIALS = get_env_variable("GOOGLE_APPLICATION_CREDENTIALS", "")
+env_value = get_env_variable("RAG_CHECK_EMBEDDING_CTX_LENGTH", "True").lower()
+RAG_CHECK_EMBEDDING_CTX_LENGTH = True if env_value == "true" else False
 
 ## Embeddings
 
@@ -193,6 +195,7 @@ def init_embeddings(provider, model):
             openai_api_base=RAG_OPENAI_BASEURL,
             openai_proxy=RAG_OPENAI_PROXY,
             chunk_size=EMBEDDINGS_CHUNK_SIZE,
+            check_embedding_ctx_length=RAG_CHECK_EMBEDDING_CTX_LENGTH,
         )
     elif provider == EmbeddingsProvider.AZURE:
         from langchain_openai import AzureOpenAIEmbeddings
@@ -203,6 +206,7 @@ def init_embeddings(provider, model):
             azure_endpoint=RAG_AZURE_OPENAI_ENDPOINT,
             api_version=RAG_AZURE_OPENAI_API_VERSION,
             chunk_size=EMBEDDINGS_CHUNK_SIZE,
+            check_embedding_ctx_length=RAG_CHECK_EMBEDDING_CTX_LENGTH,
         )
     elif provider == EmbeddingsProvider.HUGGINGFACE:
         from langchain_huggingface import HuggingFaceEmbeddings


### PR DESCRIPTION
When using an OpenAI compatible endpoint with e.g., vLLM, the referenced models may not be one of the default openai models. The langchain OpenAIEmbeddings will then pre-tokenize the input using a local tiktoken tokenizer, before sending this to the endpoint as tokenized input.
This of course will not work if the tokenizer of the vLLM model is different from the openai tokenizer.

Disabling this check will directly send input to the given endpoint without checking the tokenized input first. 
For vLLM I have checked, and giving input larger than the context length will not cause any errors, but it will simply be truncated and will return an embedding as expected.

