### PR TITLE
fix: update LangChain packages for HuggingFace Hub 0.33.1+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-langchain==0.3.12
-langchain-community==0.3.12
+langchain==0.3.26
+langchain-community==0.3.26
 langchain-openai==0.2.11
-langchain-core==0.3.27
+langchain-core==0.3.66
 langchain-aws==0.2.1
 langchain-google-vertexai==2.0.0
-langchain_text_splitters==0.3.3
+langchain_text_splitters==0.3.8
 boto3==1.34.144
 sqlalchemy==2.0.28
 python-dotenv==1.0.1
@@ -30,7 +30,7 @@ opencv-python-headless==4.9.0.80
 pymongo==4.6.3
 langchain-mongodb==0.2.0
 langchain-ollama==0.2.0
-langchain-huggingface==0.1.0
+langchain-huggingface==0.3.0
 cryptography==44.0.1
 python-magic==0.4.27
 python-pptx==0.6.23


### PR DESCRIPTION
## Fix HuggingFace Hub Compatibility Issue

I run local embedding with Hugging Face TEI. I noticed that RAG API fails with `'InferenceClient' object has no attribute 'post'` error when using HuggingFace embeddings with HuggingFace Hub version 0.33.1 or later.

### Error Details
```
AttributeError: 'InferenceClient' object has no attribute 'post'
  File "/usr/local/lib/python3.10/site-packages/langchain_huggingface/embeddings/huggingface_endpoint.py", line 112, in embed_documents
    responses = self.client.post(
```

### Root Cause
- HuggingFace Hub 0.33.1+ removed the `post()` method from `InferenceClient`
- `langchain-huggingface==0.1.0` still used the deprecated `post()` method
- This created an incompatibility when the base image was updated with newer HuggingFace Hub versions

### Solution
Updated LangChain packages to versions compatible with HuggingFace Hub 0.33.1+:

langchain  0.3.12  -> 0.3.26 
langchain-community 0.3.12 -> 0.3.26
langchain-core 0.3.27 -> 0.3.66
langchain_text_splitters 0.3.3 -> 0.3.8
langchain-huggingface 0.1.0 -> 0.3.0

### Testing
- RAG API builds successfully
- HuggingFace embeddings work correctly  
- No breaking changes detected