### PR TITLE
Support generic PostgreSQL DB args to allow for ssl-mode settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -76,15 +76,13 @@ PDF_EXTRACT_IMAGES = True if env_value == "true" else False
 
 if POSTGRES_USE_UNIX_SOCKET:
     connection_suffix = f"{urllib.parse.quote_plus(POSTGRES_USER)}:{urllib.parse.quote_plus(POSTGRES_PASSWORD)}@/{urllib.parse.quote_plus(POSTGRES_DB)}?host={urllib.parse.quote_plus(DB_HOST)}"
-else:
-    connection_suffix = f"{urllib.parse.quote_plus(POSTGRES_USER)}:{urllib.parse.quote_plus(POSTGRES_PASSWORD)}@{DB_HOST}:{DB_PORT}/{urllib.parse.quote_plus(POSTGRES_DB)}"
-    if POSTGRES_DATABASE_ARGS:
     if POSTGRES_DATABASE_ARGS:
         connection_suffix = f"{connection_suffix}&{POSTGRES_DATABASE_ARGS}"
 else:
     connection_suffix = f"{urllib.parse.quote_plus(POSTGRES_USER)}:{urllib.parse.quote_plus(POSTGRES_PASSWORD)}@{DB_HOST}:{DB_PORT}/{urllib.parse.quote_plus(POSTGRES_DB)}"
     if POSTGRES_DATABASE_ARGS:
         connection_suffix = f"{connection_suffix}?{POSTGRES_DATABASE_ARGS}"
+
 CONNECTION_STRING = f"postgresql+psycopg2://{connection_suffix}"
 DSN = f"postgresql://{connection_suffix}"
 


### PR DESCRIPTION
Adds support for generic connection string arguments for PostgreSQL so that [SSL mode and TLS certificates](https://www.postgresql.org/docs/current/libpq-ssl.html) can be configured.

For example:

```bash
POSTGRES_DATABASE_ARGS="sslmode=verify-ca&sslrootcert=/app/certs/server-ca.pem&sslcert=/app/certs/client-cert.pem&sslkey=/app/certs/client-key.pem"
```
