### PR TITLE
Support for the unstructured data like PPT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger
+RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng punkt
 ENV NLTK_DATA=/app/nltk_data
 
 # Disable Unstructured analytics


### PR DESCRIPTION
Issue:

Rag_api previously encountered an error when processing unstructured data, specifically attempting to download the averaged_perceptron_tagger_eng model at runtime. This led to failures when uploading PowerPoint (PPT) files to LibreChat, as the required package was not available in the container environment.

Solution:

To resolve this, I have added the necessary package directly to the Dockerfile. After this change, rag_api executes as expected, and Rag_api no longer reports missing dependencies or errors during PPT uploads.

`    if sentence_count(text, 3) > 1:
  File "/usr/local/lib/python3.10/site-packages/unstructured/partition/text_type.py", line 219, in sentence_count
    sentences = sent_tokenize(text)
  File "/usr/local/lib/python3.10/site-packages/unstructured/nlp/tokenize.py", line 56, in sent_tokenize
    _download_nltk_packages_if_not_present()
  File "/usr/local/lib/python3.10/site-packages/unstructured/nlp/tokenize.py", line 50, in _download_nltk_packages_if_not_present
    download_nltk_packages()
  File "/usr/local/lib/python3.10/site-packages/unstructured/nlp/tokenize.py", line 16, in download_nltk_packages
    nltk.download("averaged_perceptron_tagger_eng", quiet=True)
  File "/usr/local/lib/python3.10/site-packages/nltk/downloader.py", line 762, in download
    for msg in self.incr_download(info_or_id, download_dir, force):
  File "/usr/local/lib/python3.10/site-packages/nltk/downloader.py", line 630, in incr_download
    yield from self._download_package(info, download_dir, force)
  File "/usr/local/lib/python3.10/site-packages/nltk/downloader.py", line 686, in _download_package
    os.makedirs(download_dir, exist_ok=True)
  File "/usr/local/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/nltk_data'`