### PR TITLE
chore(deps): update Python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS main
+FROM python:3.12 AS main
 
 WORKDIR /app
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS lite
+FROM python:3.12-slim AS lite
 
 WORKDIR /app
 


### PR DESCRIPTION
Python 3.12 is the maximum version supported by rapidocr-onnxruntime and unstructured. Python 3.13+ is not yet supported by these packages.