### PR TITLE
fix: add missing averaged_perceptron_tagger_eng NLTK package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger
+RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 ENV NLTK_DATA=/app/nltk_data
 
 # Disable Unstructured analytics

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -15,7 +15,7 @@ COPY requirements.lite.txt .
 RUN pip install --no-cache-dir -r requirements.lite.txt
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger
+RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 ENV NLTK_DATA=/app/nltk_data
 
 # Disable Unstructured analytics


### PR DESCRIPTION
## Summary

Adds `averaged_perceptron_tagger_eng` to the NLTK download step in `Dockerfile` and `Dockerfile.lite`.

The `unstructured` library calls `nltk.pos_tag()` when classifying short text fragments during markdown parsing (`text_type.py` → `contains_verb()` → `pos_tag()`). In NLTK 3.9+, `pos_tag()` requires `averaged_perceptron_tagger_eng`, not the old `averaged_perceptron_tagger`.

The package is missing from the Docker image. In environments with internet access the bug is masked because `unstructured`'s wrapper (`nlp/tokenize.py`) silently auto-downloads it at runtime — but this fails in containers without outbound internet or with read-only `/app/nltk_data` (permission denied → crash loop).

## How to reproduce

Create a simple markdown file:
```bash
echo '# Title

Short paragraph.

Another one.' > /tmp/test.md
```

**Works** (has internet — `unstructured` silently auto-downloads the missing package):
```bash
docker run --rm -v /tmp/test.md:/tmp/test.md \
  ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest python -c "
from langchain_community.document_loaders import UnstructuredMarkdownLoader
docs = UnstructuredMarkdownLoader('/tmp/test.md').load()
print('SUCCESS:', len(docs), 'documents')
"
# SUCCESS: 1 documents
```

**Fails** (no internet — exposes the missing package):
```bash
docker run --rm --network none -v /tmp/test.md:/tmp/test.md \
  ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest python -c "
from langchain_community.document_loaders import UnstructuredMarkdownLoader
docs = UnstructuredMarkdownLoader('/tmp/test.md').load()
print('SUCCESS:', len(docs), 'documents')
"
# LookupError: Resource averaged_perceptron_tagger_eng not found.
```

Fixes #141