### PR TITLE
🔒 chore: patch Dependabot security alerts in requirements files

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -1,7 +1,7 @@
 langchain==1.2.15
 langchain-community==0.4.1
-langchain-openai==1.1.13
-langchain-core==1.2.30
+langchain-openai==1.1.14
+langchain-core==1.2.31
 langchain-google-genai==4.2.2
 sqlalchemy==2.0.41
 python-dotenv==1.1.1
@@ -9,7 +9,7 @@ fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
-pypdf==6.9.1
+pypdf==6.10.2
 unstructured==0.18.32
 markdown==3.8.2
 networkx==3.2.1
@@ -19,13 +19,13 @@ docx2txt==0.9
 pypandoc==1.15
 PyJWT==2.12.1
 asyncpg==0.29.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 aiofiles==24.1.0
 rapidocr-onnxruntime==1.4.4
 opencv-python-headless==4.9.0.80
 pymongo>=4.12.0,<5
 langchain-mongodb==0.11.0
-cryptography==46.0.5
+cryptography==46.0.7
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 langchain==1.2.15
 langchain-community==0.4.1
-langchain-openai==1.1.13
-langchain-core==1.2.30
+langchain-openai==1.1.14
+langchain-core==1.2.31
 langchain-aws==1.4.3
-langchain-text-splitters==1.1.1
+langchain-text-splitters==1.1.2
 boto3>=1.42.42,<2
 sqlalchemy==2.0.41
 python-dotenv==1.1.1
@@ -11,7 +11,7 @@ fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
-pypdf==6.9.1
+pypdf==6.10.2
 unstructured==0.18.32
 markdown==3.8.2
 networkx==3.2.1
@@ -21,7 +21,7 @@ docx2txt==0.9
 pypandoc==1.15
 PyJWT==2.12.1
 asyncpg==0.29.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 sentence_transformers==3.1.1
 aiofiles==24.1.0
 rapidocr-onnxruntime==1.4.4
@@ -31,7 +31,7 @@ langchain-mongodb==0.11.0
 langchain-ollama==1.1.0
 langchain-huggingface==1.2.1
 langchain-google-genai==4.2.2
-cryptography==46.0.5
+cryptography==46.0.7
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2


### PR DESCRIPTION
## Summary

Bumps vulnerable packages pinned in `requirements.txt` and `requirements.lite.txt` to the first patched versions reported by [Dependabot](https://github.com/danny-avila/rag_api/security/dependabot).

| Package | From | To | Advisory |
|---|---|---|---|
| `langchain-openai` | 1.1.13 | 1.1.14 | [GHSA-r7w7-9xr2-qq2r](https://github.com/langchain-ai/langchain/security/advisories) — SSRF via DNS rebinding in image token counting |
| `langchain-core` | 1.2.30 | 1.2.31 | required by `langchain-openai` 1.1.14 |
| `langchain-text-splitters` | 1.1.1 | 1.1.2 | SSRF redirect bypass in `HTMLHeaderTextSplitter.split_text_from_url` (requirements.txt only) |
| `pypdf` | 6.9.1 | 6.10.2 | RAM exhaustion via FlateDecode image dimensions / predictor params, long runtimes for wrong size values, XMP entity expansion, infinite loop in `DictionaryObject.read_from_stream` |
| `python-multipart` | 0.0.22 | 0.0.26 | DoS via large multipart preamble/epilogue |
| `cryptography` | 46.0.5 | 46.0.7 | Buffer overflow on non-contiguous buffers + incomplete DNS name constraint enforcement |

Severities: 1 low, rest medium. No code changes required — all are patch/minor bumps within the pinned majors.

## Test plan
- [ ] `pip install -r requirements.txt` resolves cleanly
- [ ] `pip install -r requirements.lite.txt` resolves cleanly
- [ ] CI passes
- [ ] Dependabot alerts 76, 77, 80, 81, 82, 83, 86, 87, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101 auto-close after merge