### PR TITLE
📃 docs: add `EMBEDDINGS_CHUNK_SIZE` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following environment variables are required to run the application:
     - ollama: "nomic-embed-text"
     - bedrock: "amazon.titan-embed-text-v1"
     - google_genai: "gemini-embedding-001"
+- `EMBEDDINGS_CHUNK_SIZE`: (Optional) The chunk size used by the OpenAI and Azure embeddings clients to limit the number of inputs per request. Default value is `200`.
 - `RAG_AZURE_OPENAI_API_VERSION`: (Optional) Default is `2023-05-15`. The version of the Azure OpenAI API.
 - `RAG_AZURE_OPENAI_API_KEY`: (Optional) The API key for Azure OpenAI service.
     - Note: `AZURE_OPENAI_API_KEY` will work but `RAG_AZURE_OPENAI_API_KEY` will override it in order to not conflict with LibreChat setting.


### PR DESCRIPTION
## Summary

Documents the `EMBEDDINGS_CHUNK_SIZE` environment variable in `README.md`. This variable is read in `app/config.py` and passed to the OpenAI and Azure embeddings clients to cap the number of inputs per request, but it currently has no entry in the README.

## Test plan

Grep-verified that `EMBEDDINGS_CHUNK_SIZE` is referenced in `app/config.py` and had no entry in `README.md`.

## Issue number

N/A — discovered during codebase review.
