### PR TITLE
🔒 chore: bump pytest to 9.0.3 to patch Dependabot alert #88

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
-pytest==8.3.4
-pytest-asyncio==0.26.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 testcontainers[postgres]>=4.14.0
 mongomock==4.3.0
 httpx==0.27.0


### PR DESCRIPTION
## Summary

Patches [Dependabot alert #88](https://github.com/danny-avila/rag_api/security/dependabot/88) — `pytest` < 9.0.3 has vulnerable `tmpdir` handling.

| Package | From | To | Reason |
|---|---|---|---|
| `pytest` | 8.3.4 | 9.0.3 | Fixes the advisory |
| `pytest-asyncio` | 0.26.0 | 1.3.0 | Required — 0.26.0 pins `pytest<9`; 1.3.0 is the first release that supports pytest 9 |

`pytest.ini` already declares `asyncio_mode = auto`, which is what pytest-asyncio 1.x requires, so no config changes are needed.

## Test plan
- [ ] `pip install -r test_requirements.txt` resolves cleanly
- [ ] `pytest` runs against the existing suite without collection errors
- [ ] CI passes on this branch
- [ ] Dependabot alert #88 auto-closes after merge