### PR TITLE
✨ feat: add PGVECTOR_CREATE_EXTENSION env to support managed Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following environment variables are required to run the application:
 - `POSTGRES_PASSWORD`: (Optional) The password for connecting to the PostgreSQL database.
 - `DB_HOST`: (Optional) The hostname or IP address of the PostgreSQL database server.
 - `DB_PORT`: (Optional) The port number of the PostgreSQL database server.
+- `PGVECTOR_CREATE_EXTENSION`: (Optional) Set to "False" to skip the `CREATE EXTENSION IF NOT EXISTS vector` call on startup. Default is "True". Use this when the `vector` extension is already installed on a managed Postgres (e.g. RDS, Azure Database for PostgreSQL) and the application user is not a superuser.
 - `RAG_HOST`: (Optional) The hostname or IP address where the API server will run. Defaults to "0.0.0.0"
 - `RAG_PORT`: (Optional) The port number where the API server will run. Defaults to port 8000.
 - `JWT_SECRET`: (Optional) The secret key used for verifying JWT tokens for requests.

--- a/app/config.py
+++ b/app/config.py
@@ -59,6 +59,9 @@ POSTGRES_USER = get_env_variable("POSTGRES_USER", "myuser")
 POSTGRES_PASSWORD = get_env_variable("POSTGRES_PASSWORD", "mypassword")
 DB_HOST = get_env_variable("DB_HOST", "db")
 DB_PORT = get_env_variable("DB_PORT", "5432")
+PGVECTOR_CREATE_EXTENSION = get_env_variable(
+    "PGVECTOR_CREATE_EXTENSION", "True"
+).lower() in ("true", "1", "yes", "on")
 COLLECTION_NAME = get_env_variable("COLLECTION_NAME", "testcollection")
 ATLAS_MONGO_DB_URI = get_env_variable(
     "ATLAS_MONGO_DB_URI", "mongodb://127.0.0.1:27018/LibreChat"
@@ -336,6 +339,7 @@ if VECTOR_DB_TYPE == VectorDBType.PGVECTOR:
         embeddings=embeddings,
         collection_name=COLLECTION_NAME,
         mode="async",
+        create_extension=PGVECTOR_CREATE_EXTENSION,
     )
 elif VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO:
     # Backward compatability check

--- a/app/services/vector_store/factory.py
+++ b/app/services/vector_store/factory.py
@@ -20,11 +20,16 @@ def get_vector_store(
     collection_name: str,
     mode: str = "sync",
     search_index: Optional[str] = None,
+    create_extension: bool = True,
 ):
     """Create a vector store instance for the given mode.
 
     Note: For 'atlas-mongo' mode, the MongoClient is stored at module level
     so it can be closed on shutdown via close_vector_store_connections().
+
+    Set create_extension=False when the Postgres user lacks superuser
+    privileges and the `vector` extension is already installed out-of-band
+    (e.g. managed Postgres services like RDS, Azure Database for PostgreSQL).
     """
     global _mongo_client
 
@@ -34,6 +39,7 @@ def get_vector_store(
             embedding_function=embeddings,
             collection_name=collection_name,
             use_jsonb=True,
+            create_extension=create_extension,
         )
     elif mode == "async":
         return AsyncPgVector(
@@ -41,6 +47,7 @@ def get_vector_store(
             embedding_function=embeddings,
             collection_name=collection_name,
             use_jsonb=True,
+            create_extension=create_extension,
         )
     elif mode == "atlas-mongo":
         if _mongo_client is not None:

--- a/tests/services/test_vector_store_factory.py
+++ b/tests/services/test_vector_store_factory.py
@@ -113,6 +113,35 @@ def test_get_vector_store_async_passes_use_jsonb():
         assert kwargs.get("use_jsonb") is True
 
 
+def test_get_vector_store_defaults_create_extension_true():
+    """PgVector must default to create_extension=True for back-compat."""
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store("conn", mock_embeddings, "coll", mode="async")
+        _, kwargs = MockPG.call_args
+        assert kwargs.get("create_extension") is True
+
+
+def test_get_vector_store_propagates_create_extension_false():
+    """create_extension=False must reach the underlying PGVector — the escape
+    hatch for managed Postgres where the app user can't CREATE EXTENSION."""
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store(
+            "conn", mock_embeddings, "coll", mode="async", create_extension=False
+        )
+        _, kwargs = MockPG.call_args
+        assert kwargs.get("create_extension") is False
+
+    with patch("app.services.vector_store.factory.ExtendedPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store(
+            "conn", mock_embeddings, "coll", mode="sync", create_extension=False
+        )
+        _, kwargs = MockPG.call_args
+        assert kwargs.get("create_extension") is False
+
+
 def test_load_file_content_cleans_up_on_lazy_load_failure():
     """cleanup_temp_encoding_file is called even when lazy_load() raises."""
     from app.routes.document_routes import load_file_content


### PR DESCRIPTION
## Summary

- Adds a new `PGVECTOR_CREATE_EXTENSION` env var (default `True` — back-compatible) that, when set to `False`, skips the `CREATE EXTENSION IF NOT EXISTS vector` call langchain's `PGVector` runs on startup.
- Plumbs a `create_extension` argument through `get_vector_store` into `ExtendedPgVector`/`AsyncPgVector`.
- Documents the new env var in the README.

Fixes a startup crash on managed Postgres (RDS, Azure Database for PostgreSQL, Cloud SQL, etc.) where the application user is not a superuser but the `vector` extension has already been pre-installed out-of-band. Without this flag, the container loops on `psycopg2.errors.InsufficientPrivilege: permission denied to create extension "vector"`.

Closes #275, closes #99.

## Test plan

- [x] `tests/services/test_vector_store_factory.py` — added `test_get_vector_store_defaults_create_extension_true` and `test_get_vector_store_propagates_create_extension_false` covering both sync and async modes.
- [ ] Manual: deploy with `PGVECTOR_CREATE_EXTENSION=False` against a Postgres instance where the app user is not a superuser and `vector` is pre-installed — container should start cleanly.
- [ ] Manual: deploy without the env var set — behavior should be unchanged (extension creation attempted as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)