### PR TITLE
♻️ feat: add PG_POOL_PRE_PING/PG_POOL_RECYCLE for dropped remote DB connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following environment variables are required to run the application:
 - `DB_HOST`: (Optional) The hostname or IP address of the PostgreSQL database server.
 - `DB_PORT`: (Optional) The port number of the PostgreSQL database server.
 - `PGVECTOR_CREATE_EXTENSION`: (Optional) Set to "False" to skip the `CREATE EXTENSION IF NOT EXISTS vector` call on startup. Default is "True". Use this when the `vector` extension is already installed on a managed Postgres (e.g. RDS, Azure Database for PostgreSQL) and the application user is not a superuser.
+- `PG_POOL_PRE_PING`: (Optional) Set to "False" to disable SQLAlchemy's pre-ping check. Default is "True". When enabled, the connection pool issues a lightweight `SELECT 1` before handing out a pooled connection, so stale connections dropped by a remote server or middlebox idle timeout are transparently replaced instead of surfacing as query errors. Recommended for any deployment that connects to a remote PostgreSQL instance (managed Postgres, connections that traverse a load balancer, etc.).
+- `PG_POOL_RECYCLE`: (Optional) Maximum age in seconds of a pooled connection before it is recycled. Default is "-1" (disabled). Set to a positive value when the server enforces a hard idle or max-lifetime limit (e.g. "1800" for a 30-minute cap).
 - `RAG_HOST`: (Optional) The hostname or IP address where the API server will run. Defaults to "0.0.0.0"
 - `RAG_PORT`: (Optional) The port number where the API server will run. Defaults to port 8000.
 - `JWT_SECRET`: (Optional) The secret key used for verifying JWT tokens for requests.

--- a/app/config.py
+++ b/app/config.py
@@ -62,6 +62,13 @@ DB_PORT = get_env_variable("DB_PORT", "5432")
 PGVECTOR_CREATE_EXTENSION = get_env_variable(
     "PGVECTOR_CREATE_EXTENSION", "True"
 ).lower() in ("true", "1", "yes", "on")
+PG_POOL_PRE_PING = get_env_variable("PG_POOL_PRE_PING", "True").lower() in (
+    "true",
+    "1",
+    "yes",
+    "on",
+)
+PG_POOL_RECYCLE = int(get_env_variable("PG_POOL_RECYCLE", "-1"))
 COLLECTION_NAME = get_env_variable("COLLECTION_NAME", "testcollection")
 ATLAS_MONGO_DB_URI = get_env_variable(
     "ATLAS_MONGO_DB_URI", "mongodb://127.0.0.1:27018/LibreChat"
@@ -340,6 +347,8 @@ if VECTOR_DB_TYPE == VectorDBType.PGVECTOR:
         collection_name=COLLECTION_NAME,
         mode="async",
         create_extension=PGVECTOR_CREATE_EXTENSION,
+        pool_pre_ping=PG_POOL_PRE_PING,
+        pool_recycle=PG_POOL_RECYCLE,
     )
 elif VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO:
     # Backward compatability check

--- a/app/services/vector_store/factory.py
+++ b/app/services/vector_store/factory.py
@@ -21,6 +21,8 @@ def get_vector_store(
     mode: str = "sync",
     search_index: Optional[str] = None,
     create_extension: bool = True,
+    pool_pre_ping: bool = True,
+    pool_recycle: int = -1,
 ):
     """Create a vector store instance for the given mode.
 
@@ -30,8 +32,19 @@ def get_vector_store(
     Set create_extension=False when the Postgres user lacks superuser
     privileges and the `vector` extension is already installed out-of-band
     (e.g. managed Postgres services like RDS, Azure Database for PostgreSQL).
+
+    pool_pre_ping issues a SELECT 1 before handing out a pooled connection,
+    so stale/dead connections (e.g. dropped by a remote server or middlebox
+    idle timeout) are detected and replaced instead of surfacing as a query
+    error. pool_recycle<=0 disables periodic recycling (SQLAlchemy default);
+    set a positive number of seconds when the server enforces an idle or
+    max-lifetime limit.
     """
     global _mongo_client
+
+    engine_args: dict = {"pool_pre_ping": pool_pre_ping}
+    if pool_recycle > 0:
+        engine_args["pool_recycle"] = pool_recycle
 
     if mode == "sync":
         return ExtendedPgVector(
@@ -40,6 +53,7 @@ def get_vector_store(
             collection_name=collection_name,
             use_jsonb=True,
             create_extension=create_extension,
+            engine_args=engine_args,
         )
     elif mode == "async":
         return AsyncPgVector(
@@ -48,6 +62,7 @@ def get_vector_store(
             collection_name=collection_name,
             use_jsonb=True,
             create_extension=create_extension,
+            engine_args=engine_args,
         )
     elif mode == "atlas-mongo":
         if _mongo_client is not None:

--- a/tests/services/test_vector_store_factory.py
+++ b/tests/services/test_vector_store_factory.py
@@ -142,6 +142,50 @@ def test_get_vector_store_propagates_create_extension_false():
         assert kwargs.get("create_extension") is False
 
 
+def test_get_vector_store_defaults_enable_pool_pre_ping():
+    """Default engine_args must enable pool_pre_ping — the back-compat-safe
+    default that prevents dead-connection errors on remote Postgres."""
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store("conn", mock_embeddings, "coll", mode="async")
+        _, kwargs = MockPG.call_args
+        engine_args = kwargs.get("engine_args")
+        assert engine_args == {"pool_pre_ping": True}
+
+
+def test_get_vector_store_can_disable_pool_pre_ping():
+    """pool_pre_ping=False must be propagated — the escape hatch for callers
+    that want to avoid the per-checkout SELECT 1 overhead."""
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store(
+            "conn", mock_embeddings, "coll", mode="async", pool_pre_ping=False
+        )
+        _, kwargs = MockPG.call_args
+        assert kwargs.get("engine_args") == {"pool_pre_ping": False}
+
+
+def test_get_vector_store_propagates_pool_recycle():
+    """pool_recycle>0 must appear in engine_args; pool_recycle<=0 must be
+    omitted so SQLAlchemy falls back to its own default (no recycling)."""
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store(
+            "conn", mock_embeddings, "coll", mode="async", pool_recycle=1800
+        )
+        _, kwargs = MockPG.call_args
+        engine_args = kwargs.get("engine_args")
+        assert engine_args == {"pool_pre_ping": True, "pool_recycle": 1800}
+
+    with patch("app.services.vector_store.factory.AsyncPgVector") as MockPG:
+        mock_embeddings = MagicMock()
+        factory.get_vector_store(
+            "conn", mock_embeddings, "coll", mode="async", pool_recycle=-1
+        )
+        _, kwargs = MockPG.call_args
+        assert "pool_recycle" not in kwargs.get("engine_args", {})
+
+
 def test_load_file_content_cleans_up_on_lazy_load_failure():
     """cleanup_temp_encoding_file is called even when lazy_load() raises."""
     from app.routes.document_routes import load_file_content


### PR DESCRIPTION
## Summary

Fixes persistent \"connection to external DB gets dropped\" issues on managed Postgres (Azure Container Apps, RDS behind an NLB, etc.) where the server — or a middlebox load balancer — silently closes idle connections and the next query fails because SQLAlchemy's pool hands out a dead connection.

- New `PG_POOL_PRE_PING` env var (default `True`). When enabled, the connection pool issues a lightweight `SELECT 1` before handing out a pooled connection, so stale connections are transparently replaced. The overhead is negligible and this is [SQLAlchemy's own recommended default](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic) for any deployment that isn't purely local.
- New `PG_POOL_RECYCLE` env var (default `-1`, disabled). Set to a positive number of seconds when the server enforces a hard idle/lifetime limit (e.g. `1800` for a 30-minute cap).
- Plumbs both settings through `get_vector_store` → `engine_args` on `ExtendedPgVector`/`AsyncPgVector`.

Closes #192, closes #125.

## Test plan

- [x] `tests/services/test_vector_store_factory.py` — three new tests for default-enabled pre-ping, explicit disable, and `pool_recycle` propagation.
- [ ] Manual: deploy against a Postgres reachable over a load balancer with an idle timeout, leave idle > timeout, then issue a query — should succeed instead of raising a dropped-connection error.

## Compatibility

Not a breaking change for local docker-compose setups (Postgres on the same host never idles out connections and a `SELECT 1` before each checkout is measured in microseconds). Users who for some reason want the old no-pre-ping behavior can set `PG_POOL_PRE_PING=False`.