### PR TITLE
🔒 chore: bump python-dotenv to 1.2.2 to patch Dependabot alert

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -4,7 +4,7 @@ langchain-openai==1.1.14
 langchain-core==1.2.31
 langchain-google-genai==4.2.2
 sqlalchemy==2.0.41
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ langchain-aws==1.4.3
 langchain-text-splitters==1.1.2
 boto3>=1.42.42,<2
 sqlalchemy==2.0.41
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5


### PR DESCRIPTION
## Summary

Patches Dependabot alert #103: *python-dotenv: Symlink following in set_key allows arbitrary file overwrite via cross-device rename fallback*. Affects versions `<1.2.2`; fixed in `1.2.2`.

Bumps `python-dotenv` from `1.1.1` to `1.2.2` in both `requirements.txt` and `requirements.lite.txt` (alert was filed against the lite file, but the main file has the same pin).

## Exposure note

`python-dotenv.set_key()` is not used by this project at runtime — we only call `load_dotenv()` / `find_dotenv()`, which are read-only. The vulnerable code path is only reachable if a consumer calls `set_key` against a user-controlled path. Bumping anyway to keep the supply chain clean and close the alert.

## Test plan

- [ ] CI (`build-and-test`) should pass.