### PR TITLE
📐 feat: add EMBEDDINGS_DIMENSIONS env for text-embedding-3 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The following environment variables are required to run the application:
     - bedrock: "amazon.titan-embed-text-v1"
     - google_genai: "gemini-embedding-001"
 - `EMBEDDINGS_CHUNK_SIZE`: (Optional) The chunk size used by the OpenAI and Azure embeddings clients to limit the number of inputs per request. Default value is `200`.
+- `EMBEDDINGS_DIMENSIONS`: (Optional) Output vector size to request from the embedding model. Only honored by the `openai` and `azure` providers, and only supported by `text-embedding-3-*` models. Leave unset to use the model's native dimensionality (1536 for `text-embedding-3-small`, 3072 for `text-embedding-3-large`). Setting a smaller value (e.g. `512`, `1024`) trades some retrieval quality for lower storage cost and faster similarity search. Note: do not change this on an existing collection — all vectors in a `pgvector` column must share the same dimensionality.
 - `RAG_AZURE_OPENAI_API_VERSION`: (Optional) Default is `2023-05-15`. The version of the Azure OpenAI API.
 - `RAG_AZURE_OPENAI_API_KEY`: (Optional) The API key for Azure OpenAI service.
     - Note: `AZURE_OPENAI_API_KEY` will work but `RAG_AZURE_OPENAI_API_KEY` will override it in order to not conflict with LibreChat setting.

--- a/app/config.py
+++ b/app/config.py
@@ -304,12 +304,17 @@ EMBEDDINGS_PROVIDER = EmbeddingsProvider(
     get_env_variable("EMBEDDINGS_PROVIDER", EmbeddingsProvider.OPENAI.value).lower()
 )
 
-_embeddings_dimensions_raw = get_env_variable("EMBEDDINGS_DIMENSIONS", None)
-EMBEDDINGS_DIMENSIONS = (
-    int(_embeddings_dimensions_raw)
-    if _embeddings_dimensions_raw not in (None, "")
-    else None
-)
+# Only parse EMBEDDINGS_DIMENSIONS for providers that honor it (OpenAI / Azure).
+# Parsing unconditionally at import would turn an unrelated stale env var
+# (e.g. EMBEDDINGS_DIMENSIONS=foo left over from an OpenAI deployment) into a
+# hard boot failure under bedrock / hf / ollama / etc., even though those
+# providers silently ignore the value.
+EMBEDDINGS_DIMENSIONS = None
+
+if EMBEDDINGS_PROVIDER in (EmbeddingsProvider.OPENAI, EmbeddingsProvider.AZURE):
+    _embeddings_dimensions_raw = get_env_variable("EMBEDDINGS_DIMENSIONS", None)
+    if _embeddings_dimensions_raw not in (None, ""):
+        EMBEDDINGS_DIMENSIONS = int(_embeddings_dimensions_raw)
 
 if EMBEDDINGS_PROVIDER == EmbeddingsProvider.OPENAI:
     EMBEDDINGS_MODEL = get_env_variable("EMBEDDINGS_MODEL", "text-embedding-3-small")

--- a/app/config.py
+++ b/app/config.py
@@ -218,11 +218,11 @@ RAG_CHECK_EMBEDDING_CTX_LENGTH = True if env_value == "true" else False
 ## Embeddings
 
 
-def init_embeddings(provider, model):
+def init_embeddings(provider, model, dimensions=None):
     if provider == EmbeddingsProvider.OPENAI:
         from langchain_openai import OpenAIEmbeddings
 
-        return OpenAIEmbeddings(
+        kwargs = dict(
             model=model,
             api_key=RAG_OPENAI_API_KEY,
             openai_api_base=RAG_OPENAI_BASEURL,
@@ -230,10 +230,13 @@ def init_embeddings(provider, model):
             chunk_size=EMBEDDINGS_CHUNK_SIZE,
             check_embedding_ctx_length=RAG_CHECK_EMBEDDING_CTX_LENGTH,
         )
+        if dimensions is not None:
+            kwargs["dimensions"] = dimensions
+        return OpenAIEmbeddings(**kwargs)
     elif provider == EmbeddingsProvider.AZURE:
         from langchain_openai import AzureOpenAIEmbeddings
 
-        return AzureOpenAIEmbeddings(
+        kwargs = dict(
             azure_deployment=model,
             api_key=RAG_AZURE_OPENAI_API_KEY,
             azure_endpoint=RAG_AZURE_OPENAI_ENDPOINT,
@@ -241,6 +244,9 @@ def init_embeddings(provider, model):
             chunk_size=EMBEDDINGS_CHUNK_SIZE,
             check_embedding_ctx_length=RAG_CHECK_EMBEDDING_CTX_LENGTH,
         )
+        if dimensions is not None:
+            kwargs["dimensions"] = dimensions
+        return AzureOpenAIEmbeddings(**kwargs)
     elif provider == EmbeddingsProvider.HUGGINGFACE:
         from langchain_huggingface import HuggingFaceEmbeddings
 
@@ -298,6 +304,13 @@ EMBEDDINGS_PROVIDER = EmbeddingsProvider(
     get_env_variable("EMBEDDINGS_PROVIDER", EmbeddingsProvider.OPENAI.value).lower()
 )
 
+_embeddings_dimensions_raw = get_env_variable("EMBEDDINGS_DIMENSIONS", None)
+EMBEDDINGS_DIMENSIONS = (
+    int(_embeddings_dimensions_raw)
+    if _embeddings_dimensions_raw not in (None, "")
+    else None
+)
+
 if EMBEDDINGS_PROVIDER == EmbeddingsProvider.OPENAI:
     EMBEDDINGS_MODEL = get_env_variable("EMBEDDINGS_MODEL", "text-embedding-3-small")
     # 1000 is the default chunk size for OpenAI, but this causes API rate limits to be hit
@@ -328,7 +341,9 @@ elif EMBEDDINGS_PROVIDER == EmbeddingsProvider.BEDROCK:
 else:
     raise ValueError(f"Unsupported embeddings provider: {EMBEDDINGS_PROVIDER}")
 
-embeddings = init_embeddings(EMBEDDINGS_PROVIDER, EMBEDDINGS_MODEL)
+embeddings = init_embeddings(
+    EMBEDDINGS_PROVIDER, EMBEDDINGS_MODEL, dimensions=EMBEDDINGS_DIMENSIONS
+)
 
 logger.info(f"Initialized embeddings of type: {type(embeddings)}")
 


### PR DESCRIPTION
## Summary

Adds a new `EMBEDDINGS_DIMENSIONS` environment variable that lets users request a reduced output vector size from `text-embedding-3-small` / `text-embedding-3-large`. OpenAI and Azure both support the `dimensions` parameter on these models; lower dimensionality reduces pgvector storage and makes similarity search faster, at some retrieval-quality trade-off.

- Plumbed through `init_embeddings` for the `openai` and `azure` providers only (other providers don't accept the parameter and silently ignore it).
- Unset by default — uses the model's native dimensionality (1536 / 3072).

Closes #67.

## Caveat documented in README

Cannot be changed on an existing collection — all vectors in a `pgvector` column must share the same dimensionality. Changing it requires dropping and re-embedding the collection.

## Test plan

- [ ] Deploy with `EMBEDDINGS_PROVIDER=openai`, `EMBEDDINGS_MODEL=text-embedding-3-small`, `EMBEDDINGS_DIMENSIONS=512` on a fresh collection; verify stored vectors have 512 dimensions and retrieval works.
- [ ] Omit `EMBEDDINGS_DIMENSIONS`; verify behavior matches pre-change (native dimensionality).
- [ ] CI (`build-and-test`) should pass.