### PR TITLE
fix: strip NUL bytes from document metadata before pgvector insert

### DIFF
--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -89,6 +89,7 @@ from app.services.vector_store.async_pg_vector import AsyncPgVector
 from app.utils.document_loader import (
     get_loader,
     clean_text,
+    clean_metadata,
     process_documents,
     cleanup_temp_encoding_file,
 )
@@ -718,7 +719,7 @@ def _prepare_documents_sync(
                 "file_id": file_id,
                 "user_id": user_id,
                 "digest": generate_digest(doc.page_content),
-                **(doc.metadata or {}),
+                **clean_metadata(doc.metadata or {}),
             },
         )
         for doc in documents

--- a/app/utils/document_loader.py
+++ b/app/utils/document_loader.py
@@ -193,6 +193,31 @@ def clean_text(text: str) -> str:
     return text
 
 
+def clean_metadata(metadata: dict) -> dict:
+    """Strip NUL bytes from metadata values so they survive JSONB insertion.
+
+    PostgreSQL cannot store ``\\u0000`` in text/JSONB columns; PDF producers
+    (e.g. Canon/Adobe PSL drivers) sometimes embed NUL in fields like
+    ``producer``. The same constraint that the existing text cleaning guards
+    against applies identically to the JSONB ``cmetadata`` column, so recurse
+    into nested dict/list values to cover every string.
+
+    :param metadata: The original document metadata.
+    :return: A new metadata dict with NUL bytes removed from all string values.
+    """
+
+    def _clean(value):
+        if isinstance(value, str):
+            return remove_null(value)
+        if isinstance(value, dict):
+            return {k: _clean(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_clean(v) for v in value]
+        return value
+
+    return {k: _clean(v) for k, v in metadata.items()}
+
+
 def remove_null(text: str) -> str:
     """
     Remove NUL (0x00) characters from a string.

--- a/tests/utils/test_document_loader.py
+++ b/tests/utils/test_document_loader.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.utils.document_loader import get_loader, clean_text, process_documents
+from app.utils.document_loader import (
+    get_loader,
+    clean_text,
+    clean_metadata,
+    process_documents,
+)
 from langchain_community.document_loaders import (
     TextLoader,
     UnstructuredMarkdownLoader,
@@ -17,6 +22,42 @@ def test_clean_text():
     cleaned = clean_text(text)
     assert "\x00" not in cleaned
     assert cleaned == "HelloWorld"
+
+
+def test_clean_metadata_strips_nul_from_string_value():
+    """Failure NUL in `producer` from a Canon/Adobe-PSL PDF."""
+    metadata = {"producer": "Adobe PSL 1.3e for Canon\x00"}
+    cleaned = clean_metadata(metadata)
+    assert "\x00" not in cleaned["producer"]
+    assert cleaned["producer"] == "Adobe PSL 1.3e for Canon"
+
+
+def test_clean_metadata_recurses_into_nested_dict_and_list():
+    metadata = {
+        "title": "Doc\x00",
+        "nested": {"creator": "Tool\x00", "level": {"deep": "x\x00y"}},
+        "tags": ["a\x00", "b", {"k": "c\x00"}],
+    }
+    cleaned = clean_metadata(metadata)
+    assert cleaned["title"] == "Doc"
+    assert cleaned["nested"]["creator"] == "Tool"
+    assert cleaned["nested"]["level"]["deep"] == "xy"
+    assert cleaned["tags"][0] == "a"
+    assert cleaned["tags"][1] == "b"
+    assert cleaned["tags"][2]["k"] == "c"
+
+
+def test_clean_metadata_preserves_non_string_values():
+    """No over-stripping: ints, floats, bools, None and clean strings pass through."""
+    metadata = {
+        "page": 1,
+        "score": 0.5,
+        "flag": True,
+        "missing": None,
+        "source": "report.pdf",
+    }
+    cleaned = clean_metadata(metadata)
+    assert cleaned == metadata
 
 
 def test_get_loader_text(tmp_path):


### PR DESCRIPTION
## What

Strip NUL bytes (`\u0000`) from document **metadata** before it reaches the
pgvector `cmetadata` JSONB column, so PDFs with a NUL in fields like `producer`
can be embedded instead of failing the whole batch insert.

Fixes #295.

## Why

`cmetadata` is JSONB and PostgreSQL cannot store `\u0000` in text/JSONB.
PDFs produced by Canon / Adobe PSL PostScript drivers (and some Google-Docs
exports) pad `producer`/`creator`/`title` with a trailing NUL. The unsanitized
metadata merge in `_prepare_documents_sync` lets that NUL flow into the insert,
which PostgreSQL rejects with:

```
psycopg2.errors.UntranslatableCharacter: unsupported Unicode escape sequence
DETAIL:  \u0000 cannot be converted to text.
```

The entire multi-row batch INSERT is rolled back, so the file is silently never
stored or searchable (and the embedding provider cost is already spent).

rag_api already strips NUL from document **text** via `clean_text` /
`remove_null` (the LibreChat Discussion #2243 fix). This PR extends the same
protection to metadata fields, which JSONB rejects identically.

## Changes

- `app/utils/document_loader.py`: add `clean_metadata()` â€” recursively strips
  NUL from all string values (including nested dict/list), reusing
  `remove_null`.
- `app/routes/document_routes.py`: apply `clean_metadata()` at the metadata
  merge in `_prepare_documents_sync` (the single choke point both the async
  pipeline and batched-sync insert paths flow through). Applied
  **unconditionally**, not gated behind the PDF-only `clean_content` flag,
  since the JSONB NUL constraint holds for every loader and file type. The
  known-clean keys (`file_id` / `user_id` / `digest`) stay outside the
  sanitizer.
- `tests/utils/test_document_loader.py`: unit tests for producer NUL, nested
  dict/list values, and no over-stripping of non-string/clean values.

## Testing

- Unit tests: the full `tests/utils/test_document_loader.py` suite passes
  (25/25) in the project's Python 3.10 Docker image.
- End-to-end against pgvector + Azure OpenAI embeddings: a real PDF with a NUL
  in `producer` now embeds successfully (`status: true`) and is searchable via
  `POST /query`.
- Negative control: with the change stashed, the same PDF reproduces the
  original `UntranslatableCharacter` failure; with the change applied it
  succeeds. A normal PDF still embeds with intact metadata (no over-stripping).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)