### PR TITLE
fix: apply POSTGRES_SCHEMA search_path to the asyncpg pool

### DIFF
--- a/app/services/database.py
+++ b/app/services/database.py
@@ -1,6 +1,7 @@
 # app/services/database.py
 import asyncpg
-from app.config import DSN, logger
+from app.config import DSN, POSTGRES_SCHEMA, logger
+from app.services.vector_store.factory import _build_search_path, _parse_schemas
 
 
 class PSQLDatabase:
@@ -9,7 +10,21 @@ class PSQLDatabase:
     @classmethod
     async def get_pool(cls):
         if cls.pool is None:
-            cls.pool = await asyncpg.create_pool(dsn=DSN)
+            connect_kwargs = {"dsn": DSN}
+            # Pin the asyncpg pool to the same search_path the SQLAlchemy engine
+            # uses (see get_vector_store). Without this the pool runs with the
+            # default search_path (public) while pgvector's tables live in
+            # POSTGRES_SCHEMA, so ensure_vector_indexes()'s unqualified DDL fails
+            # with "relation langchain_pg_embedding does not exist" (or targets a
+            # stale public table) and the JSONB migration's current_schema()
+            # guard never matches.
+            if POSTGRES_SCHEMA:
+                schemas = _parse_schemas(POSTGRES_SCHEMA)
+                if schemas:
+                    connect_kwargs["server_settings"] = {
+                        "search_path": _build_search_path(schemas)
+                    }
+            cls.pool = await asyncpg.create_pool(**connect_kwargs)
         return cls.pool
 
     @classmethod

--- a/tests/services/test_database.py
+++ b/tests/services/test_database.py
@@ -84,3 +84,44 @@ def test_ensure_vector_indexes_gin_index(monkeypatch):
     gin_stmt = next(s for s in conn.statements if "ix_cmetadata_gin" in s)
     assert "jsonb_path_ops" in gin_stmt
     assert "USING gin" in gin_stmt
+
+
+def _capture_create_pool_kwargs(monkeypatch, schema):
+    """Reset the pool, set POSTGRES_SCHEMA, and return the kwargs that
+    PSQLDatabase.get_pool() passes to asyncpg.create_pool()."""
+    import app.services.database as db
+
+    captured = {}
+
+    async def fake_create_pool(**kwargs):
+        captured.update(kwargs)
+        return object()  # sentinel pool
+
+    monkeypatch.setattr(db.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(db, "POSTGRES_SCHEMA", schema)
+    monkeypatch.setattr(db.PSQLDatabase, "pool", None)
+
+    asyncio.run(db.PSQLDatabase.get_pool())
+    return captured
+
+
+def test_get_pool_pins_search_path_when_schema_configured(monkeypatch):
+    """When POSTGRES_SCHEMA is set the asyncpg pool must receive a matching
+    search_path via server_settings (regression: ensure_vector_indexes ran in
+    the wrong schema because the pool used the bare DSN)."""
+    captured = _capture_create_pool_kwargs(monkeypatch, "myapp")
+    assert captured["server_settings"] == {"search_path": "myapp,public"}
+
+
+def test_get_pool_search_path_multiple_schemas(monkeypatch):
+    """Comma-separated POSTGRES_SCHEMA is honored and `public` is appended,
+    matching the SQLAlchemy engine's _build_search_path."""
+    captured = _capture_create_pool_kwargs(monkeypatch, "myapp, extensions")
+    assert captured["server_settings"] == {"search_path": "myapp,extensions,public"}
+
+
+def test_get_pool_no_search_path_without_schema(monkeypatch):
+    """With no POSTGRES_SCHEMA the pool keeps the default search_path (no
+    server_settings), preserving today's behavior."""
+    captured = _capture_create_pool_kwargs(monkeypatch, None)
+    assert "server_settings" not in captured


### PR DESCRIPTION
### What

Pin the asyncpg pool (`PSQLDatabase.get_pool`) to the same `search_path` the SQLAlchemy engine uses when `POSTGRES_SCHEMA` is set, via asyncpg `server_settings`.

### Why

Fixes #299. The pool was built from the bare DSN, so `ensure_vector_indexes()` ran in `public` while pgvector's tables live in `POSTGRES_SCHEMA` → startup crash (`relation "langchain_pg_embedding" does not exist`) and a silently-skipped JSON→JSONB migration. Full analysis in the issue.

### Change

```python
if POSTGRES_SCHEMA:
    schemas = _parse_schemas(POSTGRES_SCHEMA)
    if schemas:
        connect_kwargs["server_settings"] = {"search_path": _build_search_path(schemas)}
```

Reuses `_build_search_path` / `_parse_schemas` from the vector-store factory so the engine and pool can't drift. **No behavior change when `POSTGRES_SCHEMA` is unset** (no `server_settings` passed).

### Testing

- New unit tests in `tests/services/test_database.py`: the pool receives `server_settings={"search_path": "myapp,public"}` for a single schema, `"myapp,extensions,public"` for a comma-separated list, and no `server_settings` when unset.
- `tests/services/test_database.py` + `tests/services/test_vector_store_factory.py`: **27 passed**.
