### PR TITLE
fix: surface storage failures in /local/embed and /embed-upload

### DIFF
--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -817,18 +817,26 @@ async def embed_local_file(
             executor=request.app.state.thread_pool,
         )
 
-        if result:
-            return {
-                "status": True,
-                "file_id": document.file_id,
-                "filename": document.filename,
-                "known_type": known_type,
-            }
-        else:
+        # store_data_in_vector_db always returns a dict, with an "error" key on
+        # failure. Treat that (or a falsy result) as a real failure instead of
+        # reporting status:True for documents that were never persisted.
+        if not result or "error" in result:
+            error_detail = (
+                result["error"]
+                if isinstance(result, dict) and isinstance(result.get("error"), str)
+                else ERROR_MESSAGES.DEFAULT()
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=ERROR_MESSAGES.DEFAULT(),
+                detail=error_detail,
             )
+
+        return {
+            "status": True,
+            "file_id": document.file_id,
+            "filename": document.filename,
+            "known_type": known_type,
+        }
     except HTTPException as http_exc:
         logger.error(
             "HTTP Exception in embed_local_file | Status: %d | Detail: %s",
@@ -1029,10 +1037,18 @@ async def embed_file_upload(
             executor=request.app.state.thread_pool,
         )
 
-        if not result:
+        # store_data_in_vector_db always returns a dict, with an "error" key on
+        # failure. Treat that (or a falsy result) as a real failure instead of
+        # reporting success for documents that were never persisted.
+        if not result or "error" in result:
+            error_detail = (
+                result["error"]
+                if isinstance(result, dict) and isinstance(result.get("error"), str)
+                else "Failed to process/store the file data."
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to process/store the file data.",
+                detail=error_detail,
             )
     except HTTPException as http_exc:
         logger.error(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -279,3 +279,49 @@ def test_extract_text_from_file(tmp_path, auth_headers):
     assert json_data["file_id"] == "test_text_123"
     assert json_data["filename"] == "test_text_extraction.txt"
     assert json_data["known_type"] is True  # text files are known types
+
+
+def test_embed_local_file_storage_error_returns_500(tmp_path, auth_headers, monkeypatch):
+    """A storage failure must surface as an error, not a false success.
+
+    Regression: embed_local_file used `if result:` and store_data_in_vector_db
+    always returns a (truthy) dict, so it returned status:True even when the
+    documents were never persisted.
+    """
+    monkeypatch.setattr(document_routes, "RAG_UPLOAD_DIR", str(tmp_path))
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("This is a test document.")
+
+    async def failing_store(*args, **kwargs):
+        return {"message": "An error occurred while adding documents.", "error": "boom"}
+
+    monkeypatch.setattr(document_routes, "store_data_in_vector_db", failing_store)
+
+    data = {
+        "filepath": "test.txt",
+        "filename": "test.txt",
+        "file_content_type": "text/plain",
+        "file_id": "testid1",
+    }
+    response = client.post("/local/embed", json=data, headers=auth_headers)
+    assert response.status_code == 500, f"Response: {response.text}"
+
+
+def test_embed_file_upload_storage_error_returns_500(tmp_path, auth_headers, monkeypatch):
+    """embed-upload must not report success when nothing was persisted."""
+    test_file = tmp_path / "upload_test.txt"
+    test_file.write_text("Test content for embed upload.")
+
+    async def failing_store(*args, **kwargs):
+        return {"message": "An error occurred while adding documents.", "error": "boom"}
+
+    monkeypatch.setattr(document_routes, "store_data_in_vector_db", failing_store)
+
+    with test_file.open("rb") as f:
+        response = client.post(
+            "/embed-upload",
+            data={"file_id": "testid1", "entity_id": "testuser"},
+            files={"uploaded_file": ("upload_test.txt", f, "text/plain")},
+            headers=auth_headers,
+        )
+    assert response.status_code == 500, f"Response: {response.text}"


### PR DESCRIPTION
### What

Make `POST /local/embed` and `POST /embed-upload` surface a storage failure (HTTP 500) instead of reporting success.

### Why

Fixes #305. `store_data_in_vector_db` always returns a dict (with an `"error"` key on failure), but `embed_local_file` used `if result:` and `embed_file_upload` used `if not result:` — a failure dict is truthy / not-falsy, so both reported `status:True` / 200 while nothing was persisted.

### Change

Both endpoints now treat `not result or "error" in result` as a failure and raise HTTP 500 with the error detail:

```python
if not result or "error" in result:
    error_detail = (
        result["error"]
        if isinstance(result, dict) and isinstance(result.get("error"), str)
        else <endpoint default>
    )
    raise HTTPException(status_code=500, detail=error_detail)
```

`POST /embed` already performs this check and is unchanged. The success path is unchanged.

### Testing

- New `tests/test_main.py`: `test_embed_local_file_storage_error_returns_500` and `test_embed_file_upload_storage_error_returns_500` (store returns an `{"error": ...}` dict → endpoint returns 500).
- Existing success-path embed tests still pass. `tests/test_main.py`: **12 passed**.
