### PR TITLE
feat: add parallel ingestion consumers and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The following environment variables are required to run the application:
 - `CHUNK_OVERLAP`: (Optional) The overlap between chunks during text processing. Default value is "100".
 - `EMBEDDING_BATCH_SIZE`: (Optional) Number of document chunks to process per batch. Set to `0` (default) to disable batching. Recommended value is `750` for `text-embedding-3-small`.
 - `EMBEDDING_MAX_QUEUE_SIZE`: (Optional) Maximum number of batches to buffer in memory during async processing. Default value is "3".
+- `PARALLEL_EXECUTION`: (Optional) Maximum number of async embedding/database insertion consumers to run per file when batching is enabled. Default value is "2".
 - `RAG_DISTANCE_THRESHOLD`: (Optional, `VECTOR_DB_TYPE=pgvector` only) Drop results whose vector distance is greater than this value, after the top-`k` search. Unset by default (no filtering). Lower distance = more similar, so e.g. `0.5` keeps only hits with distance ≤ 0.5 and discards weaker matches. Useful for reducing downstream LLM token cost when the top-`k` call returns loosely-related chunks. Appropriate values depend on the embedding model and distance strategy — inspect your actual scores before choosing one. Ignored (with a startup warning) under `VECTOR_DB_TYPE=atlas-mongo`, because Atlas returns a similarity score (higher = better) with inverted semantics.
 - `RAG_UPLOAD_DIR`: (Optional) The directory where uploaded files are stored. Default value is "./uploads/".
 - `PDF_EXTRACT_IMAGES`: (Optional) A boolean value indicating whether to extract images from PDF files. Default value is "False".

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ When `EMBEDDING_BATCH_SIZE > 0`:
 - Documents are processed in batches of the specified size
 - Up to `PARALLEL_EXECUTION` batches for the same file can be embedded and inserted concurrently
 - `PARALLEL_EXECUTION` is per request/file. Total process concurrency can be roughly `active uploads * PARALLEL_EXECUTION`, bounded indirectly by `RAG_THREAD_POOL_SIZE` and downstream provider/database limits
-- On failure, successfully inserted documents are rolled back
+- On failure, remaining batch work is stopped and successfully inserted documents are rolled back
 - Memory usage is bounded by queued plus active batches, roughly `EMBEDDING_BATCH_SIZE * (EMBEDDING_MAX_QUEUE_SIZE + PARALLEL_EXECUTION)`
 - Ingestion lifecycle logs include route, user, file, chunk count, file size, elapsed time, and selected process memory context. Per-batch queue/insert progress is logged at debug level
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ For large files, you can enable batched embedding processing to reduce memory co
 |----------|---------|-------------|
 | `EMBEDDING_BATCH_SIZE` | `0` | Number of document chunks to process per batch. `0` disables batching (original behavior). |
 | `EMBEDDING_MAX_QUEUE_SIZE` | `3` | Maximum number of batches to buffer in memory during async processing. |
+| `PARALLEL_EXECUTION` | `2` | Maximum number of async embedding/database insertion consumers per file when batching is enabled. |
 
 #### Recommended Settings
 
@@ -156,14 +157,17 @@ For memory-constrained environments (< 2GB RAM):
 For high-throughput environments:
 - `EMBEDDING_BATCH_SIZE=1000-2000`
 - `EMBEDDING_MAX_QUEUE_SIZE=5`
+- Increase `PARALLEL_EXECUTION` cautiously; it applies per active file upload.
 
 #### Behavior
 
 When `EMBEDDING_BATCH_SIZE > 0`:
 - Documents are processed in batches of the specified size
-- Each batch is embedded and inserted before the next batch starts
+- Up to `PARALLEL_EXECUTION` batches for the same file can be embedded and inserted concurrently
+- `PARALLEL_EXECUTION` is per request/file. Total process concurrency can be roughly `active uploads * PARALLEL_EXECUTION`, bounded indirectly by `RAG_THREAD_POOL_SIZE` and downstream provider/database limits
 - On failure, successfully inserted documents are rolled back
-- Memory usage is bounded by `EMBEDDING_BATCH_SIZE * EMBEDDING_MAX_QUEUE_SIZE`
+- Memory usage is bounded by queued plus active batches, roughly `EMBEDDING_BATCH_SIZE * (EMBEDDING_MAX_QUEUE_SIZE + PARALLEL_EXECUTION)`
+- Ingestion lifecycle logs include route, user, file, chunk count, file size, elapsed time, and selected process memory context. Per-batch queue/insert progress is logged at debug level
 
 When `EMBEDDING_BATCH_SIZE = 0` (default):
 - All documents are processed at once (original behavior)

--- a/app/config.py
+++ b/app/config.py
@@ -80,6 +80,7 @@ MONGO_VECTOR_COLLECTION = get_env_variable(
 )  # Deprecated, backwards compatability
 CHUNK_SIZE = int(get_env_variable("CHUNK_SIZE", "1500"))
 CHUNK_OVERLAP = int(get_env_variable("CHUNK_OVERLAP", "100"))
+PARALLEL_EXECUTION = int(get_env_variable("PARALLEL_EXECUTION", "2"))
 
 # Batch processing configuration for memory-constrained environments.
 # When EMBEDDING_BATCH_SIZE > 0, documents are processed in batches to reduce

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -167,6 +167,7 @@ def build_ingestion_context(
     known_type: Optional[str] = None,
     file_ext: Optional[str] = None,
     chunk_count: Optional[int] = None,
+    include_memory: bool = False,
 ) -> str:
     """Build a compact ingestion context string for logs."""
     parts = [
@@ -178,7 +179,6 @@ def build_ingestion_context(
     if content_type:
         parts.append(f"content_type={content_type}")
     if temp_file_path:
-        parts.append(f"temp_path={temp_file_path}")
         file_size_bytes = get_file_size_bytes(temp_file_path)
         if file_size_bytes is not None:
             parts.append(f"file_size_bytes={file_size_bytes}")
@@ -188,7 +188,8 @@ def build_ingestion_context(
         parts.append(f"file_ext={file_ext}")
     if chunk_count is not None:
         parts.append(f"chunk_count={chunk_count}")
-    parts.append(get_process_memory_details())
+    if include_memory:
+        parts.append(get_process_memory_details())
     return " | ".join(parts)
 
 
@@ -577,8 +578,8 @@ async def _process_documents_async_pipeline(
                 batch_documents = documents[start_idx:end_idx]
                 batch_ids = [file_id] * len(batch_documents)
 
-                logger.info(
-                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d | %s",
+                logger.debug(
+                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d",
                     user_id,
                     file_id,
                     batch_idx + 1,
@@ -586,7 +587,6 @@ async def _process_documents_async_pipeline(
                     start_idx,
                     end_idx - 1,
                     len(batch_documents),
-                    get_process_memory_details(),
                 )
 
                 # Put batch in queue for processing
@@ -612,14 +612,13 @@ async def _process_documents_async_pipeline(
 
                 batch_documents, batch_ids, batch_num, total_batches = item
 
-                logger.info(
-                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d | %s",
+                logger.debug(
+                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d",
                     user_id,
                     file_id,
                     batch_num,
                     total_batches,
                     len(batch_documents),
-                    get_process_memory_details(),
                 )
 
                 try:
@@ -888,6 +887,7 @@ async def store_data_in_vector_db(
             content_type=content_type,
             temp_file_path=temp_file_path,
             chunk_count=len(docs),
+            include_memory=True,
         ),
     )
 
@@ -930,6 +930,7 @@ async def store_data_in_vector_db(
                 content_type=content_type,
                 temp_file_path=temp_file_path,
                 chunk_count=len(docs),
+                include_memory=True,
             ),
             len(ids),
             int((time.perf_counter() - start_time) * 1000),
@@ -947,6 +948,7 @@ async def store_data_in_vector_db(
                 content_type=content_type,
                 temp_file_path=temp_file_path,
                 chunk_count=len(docs),
+                include_memory=True,
             ),
             int((time.perf_counter() - start_time) * 1000),
             str(e),

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -545,6 +545,7 @@ async def _process_documents_async_pipeline(
     successful_batch_ids = {}
     failure_event = asyncio.Event()
     in_flight_insert_tasks = set()
+    cleanup_needed = False
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -600,6 +601,8 @@ async def _process_documents_async_pipeline(
         batch_documents: List[Document], batch_ids: List[str]
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
+        nonlocal cleanup_needed
+        cleanup_needed = True
         insert_task = asyncio.create_task(
             vector_store.aadd_documents(
                 batch_documents, ids=batch_ids, executor=executor
@@ -727,28 +730,29 @@ async def _process_documents_async_pipeline(
 
         await wait_for_in_flight_inserts()
 
-        try:
-            logger.warning(
-                "Performing rollback | user_id=%s | file_id=%s | %s",
-                user_id,
-                file_id,
-                get_process_memory_details(),
-            )
-            await vector_store.delete(ids=[file_id], executor=executor)
-            logger.info(
-                "Rollback completed | user_id=%s | file_id=%s | %s",
-                user_id,
-                file_id,
-                get_process_memory_details(),
-            )
-        except Exception as cleanup_error:
-            logger.error(
-                "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
-                user_id,
-                file_id,
-                cleanup_error,
-                get_process_memory_details(),
-            )
+        if cleanup_needed:
+            try:
+                logger.warning(
+                    "Performing rollback | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
+                await vector_store.delete(ids=[file_id], executor=executor)
+                logger.info(
+                    "Rollback completed | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
+            except Exception as cleanup_error:
+                logger.error(
+                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                    user_id,
+                    file_id,
+                    cleanup_error,
+                    get_process_memory_details(),
+                )
 
         # Re-raise the original error
         raise

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -614,6 +614,11 @@ async def _process_documents_async_pipeline(
             return batch_result_ids
         finally:
             if insert_task.done():
+                try:
+                    insert_task.result()
+                    cleanup_needed = True
+                except BaseException:
+                    pass
                 in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -9,7 +9,7 @@ import aiofiles.os
 import asyncio
 import time
 from shutil import copyfileobj
-from typing import Dict, List, Iterable, Optional, Union, TYPE_CHECKING
+from typing import List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import (
     APIRouter,
@@ -114,16 +114,6 @@ def get_user_id(request: Request, entity_id: str = None) -> str:
         return entity_id if entity_id else request.state.user.get("id")
 
 
-def get_file_size_bytes(file_path: Optional[str]) -> Optional[int]:
-    """Return file size in bytes when available."""
-    if not file_path:
-        return None
-    try:
-        return os.path.getsize(file_path)
-    except OSError:
-        return None
-
-
 def get_process_memory_details() -> str:
     """Return lightweight process memory details for logging."""
     parts = []
@@ -179,9 +169,11 @@ def build_ingestion_context(
     if content_type:
         parts.append(f"content_type={content_type}")
     if temp_file_path:
-        file_size_bytes = get_file_size_bytes(temp_file_path)
-        if file_size_bytes is not None:
+        try:
+            file_size_bytes = os.path.getsize(temp_file_path)
             parts.append(f"file_size_bytes={file_size_bytes}")
+        except OSError:
+            pass
     if known_type:
         parts.append(f"known_type={known_type}")
     if file_ext:
@@ -548,15 +540,11 @@ async def _process_documents_async_pipeline(
 
     # Create queues for producer-consumer pattern
     # embedding_queue is bounded to limit document data held in memory.
-    # results_queue is unbounded — it holds only small UUID lists, and the
-    # drain loop runs after gather(), so bounding it would deadlock when
-    # num_batches > maxsize.
     embedding_queue = asyncio.Queue(maxsize=EMBEDDING_MAX_QUEUE_SIZE)
-    results_queue = asyncio.Queue()
     all_ids = []
     successful_batch_ids = {}
     failure_event = asyncio.Event()
-    in_flight_insert_tasks: Dict[asyncio.Task, int] = {}
+    in_flight_insert_tasks = set()
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -609,7 +597,7 @@ async def _process_documents_async_pipeline(
                     await embedding_queue.put(None)
 
     async def insert_batch(
-        batch_documents: List[Document], batch_ids: List[str], batch_num: int
+        batch_documents: List[Document], batch_ids: List[str]
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
         insert_task = asyncio.create_task(
@@ -617,16 +605,12 @@ async def _process_documents_async_pipeline(
                 batch_documents, ids=batch_ids, executor=executor
             )
         )
-        in_flight_insert_tasks[insert_task] = batch_num
+        in_flight_insert_tasks.add(insert_task)
         try:
             return await asyncio.shield(insert_task)
         finally:
             if insert_task.done():
-                in_flight_insert_tasks.pop(insert_task, None)
-                try:
-                    successful_batch_ids.setdefault(batch_num, insert_task.result())
-                except BaseException:
-                    pass
+                in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:
         """Wait for started inserts before rollback can delete inserted vectors."""
@@ -641,12 +625,9 @@ async def _process_documents_async_pipeline(
             len(pending_tasks),
             get_process_memory_details(),
         )
-        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
-        for insert_task, result in zip(pending_tasks, results):
-            batch_num = in_flight_insert_tasks.pop(insert_task, None)
-            if batch_num is None or isinstance(result, BaseException):
-                continue
-            successful_batch_ids[batch_num] = result
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task in pending_tasks:
+            in_flight_insert_tasks.discard(insert_task)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -670,11 +651,8 @@ async def _process_documents_async_pipeline(
 
                 try:
                     # Insert batch into database
-                    batch_result_ids = await insert_batch(
-                        batch_documents, batch_ids, batch_num
-                    )
+                    batch_result_ids = await insert_batch(batch_documents, batch_ids)
                     successful_batch_ids[batch_num] = batch_result_ids
-                    await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
                     failure_event.set()
                     logger.error(
@@ -686,7 +664,6 @@ async def _process_documents_async_pipeline(
                         e,
                         get_process_memory_details(),
                     )
-                    await results_queue.put((batch_num, e))  # Put exception object
                     raise
                 finally:
                     embedding_queue.task_done()
@@ -695,7 +672,6 @@ async def _process_documents_async_pipeline(
             if not failure_event.is_set():
                 failure_event.set()
                 logger.error("Fatal error in embedding consumer: %s", e)
-                await results_queue.put((None, e))
             raise
 
     producer_task = None
@@ -710,12 +686,6 @@ async def _process_documents_async_pipeline(
 
         # Wait for all tasks to complete
         await asyncio.gather(producer_task, *consumer_tasks, return_exceptions=False)
-
-        # Collect results from all batches
-        for _ in range(num_batches):
-            batch_num, result = await results_queue.get()
-            if isinstance(result, Exception):
-                raise result
 
         for batch_num in range(1, num_batches + 1):
             all_ids.extend(successful_batch_ids[batch_num])
@@ -757,30 +727,28 @@ async def _process_documents_async_pipeline(
 
         await wait_for_in_flight_inserts()
 
-        # Attempt rollback only if we inserted something
-        if successful_batch_ids:
-            try:
-                logger.warning(
-                    "Performing rollback | user_id=%s | file_id=%s | %s",
-                    user_id,
-                    file_id,
-                    get_process_memory_details(),
-                )
-                await vector_store.delete(ids=[file_id], executor=executor)
-                logger.info(
-                    "Rollback completed | user_id=%s | file_id=%s | %s",
-                    user_id,
-                    file_id,
-                    get_process_memory_details(),
-                )
-            except Exception as cleanup_error:
-                logger.error(
-                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
-                    user_id,
-                    file_id,
-                    cleanup_error,
-                    get_process_memory_details(),
-                )
+        try:
+            logger.warning(
+                "Performing rollback | user_id=%s | file_id=%s | %s",
+                user_id,
+                file_id,
+                get_process_memory_details(),
+            )
+            await vector_store.delete(ids=[file_id], executor=executor)
+            logger.info(
+                "Rollback completed | user_id=%s | file_id=%s | %s",
+                user_id,
+                file_id,
+                get_process_memory_details(),
+            )
+        except Exception as cleanup_error:
+            logger.error(
+                "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                user_id,
+                file_id,
+                cleanup_error,
+                get_process_memory_details(),
+            )
 
         # Re-raise the original error
         raise

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -6,6 +6,8 @@ import hashlib
 import traceback
 import aiofiles
 import aiofiles.os
+import asyncio
+import time
 from shutil import copyfileobj
 from typing import List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
@@ -23,7 +25,6 @@ from fastapi import (
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from functools import lru_cache
-import asyncio
 
 if TYPE_CHECKING:
     from app.services.vector_store.async_pg_vector import AsyncPgVector
@@ -40,6 +41,7 @@ from app.config import (
     CHUNK_OVERLAP,
     EMBEDDING_BATCH_SIZE,
     EMBEDDING_MAX_QUEUE_SIZE,
+    PARALLEL_EXECUTION,
     RAG_DISTANCE_THRESHOLD,
 )
 
@@ -110,6 +112,84 @@ def get_user_id(request: Request, entity_id: str = None) -> str:
         return entity_id if entity_id else "public"
     else:
         return entity_id if entity_id else request.state.user.get("id")
+
+
+def get_file_size_bytes(file_path: Optional[str]) -> Optional[int]:
+    """Return file size in bytes when available."""
+    if not file_path:
+        return None
+    try:
+        return os.path.getsize(file_path)
+    except OSError:
+        return None
+
+
+def get_process_memory_details() -> str:
+    """Return lightweight process memory details for logging."""
+    parts = []
+
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as status_file:
+            for line in status_file:
+                if line.startswith("VmRSS:"):
+                    rss_kib = int(line.split()[1])
+                    parts.append(f"rss_mb={rss_kib / 1024:.1f}")
+                elif line.startswith("VmHWM:"):
+                    hwm_kib = int(line.split()[1])
+                    parts.append(f"rss_peak_mb={hwm_kib / 1024:.1f}")
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        pass
+
+    try:
+        import resource
+
+        max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if os.name == "posix":
+            max_rss_mb = max_rss / 1024
+        else:
+            max_rss_mb = max_rss / (1024 * 1024)
+
+        if not any(part.startswith("rss_peak_mb=") for part in parts):
+            parts.append(f"rss_peak_mb={max_rss_mb:.1f}")
+    except (ImportError, AttributeError, OSError, ValueError):
+        pass
+
+    return " | ".join(parts) if parts else "rss_mb=unknown"
+
+
+def build_ingestion_context(
+    route_name: str,
+    user_id: str,
+    file_id: str,
+    filename: str,
+    content_type: Optional[str] = None,
+    temp_file_path: Optional[str] = None,
+    known_type: Optional[str] = None,
+    file_ext: Optional[str] = None,
+    chunk_count: Optional[int] = None,
+) -> str:
+    """Build a compact ingestion context string for logs."""
+    parts = [
+        f"route={route_name}",
+        f"user_id={user_id}",
+        f"file_id={file_id}",
+        f"filename={filename}",
+    ]
+    if content_type:
+        parts.append(f"content_type={content_type}")
+    if temp_file_path:
+        parts.append(f"temp_path={temp_file_path}")
+        file_size_bytes = get_file_size_bytes(temp_file_path)
+        if file_size_bytes is not None:
+            parts.append(f"file_size_bytes={file_size_bytes}")
+    if known_type:
+        parts.append(f"known_type={known_type}")
+    if file_ext:
+        parts.append(f"file_ext={file_ext}")
+    if chunk_count is not None:
+        parts.append(f"chunk_count={chunk_count}")
+    parts.append(get_process_memory_details())
+    return " | ".join(parts)
 
 
 async def save_upload_file_async(file: UploadFile, temp_file_path: str) -> None:
@@ -446,6 +526,8 @@ async def _process_documents_async_pipeline(
     file_id: str,
     vector_store: "AsyncPgVector",
     executor: "ThreadPoolExecutor",
+    parallel_execution: int = 1,
+    user_id: str = "",
 ) -> List[str]:
     """
     Process documents using async producer-consumer pattern for batched embedding and insertion.
@@ -471,14 +553,19 @@ async def _process_documents_async_pipeline(
     embedding_queue = asyncio.Queue(maxsize=EMBEDDING_MAX_QUEUE_SIZE)
     results_queue = asyncio.Queue()
     all_ids = []
+    successful_batch_ids = {}
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
+    consumer_count = max(1, min(parallel_execution, num_batches))
 
     logger.info(
-        "Starting async pipeline for file %s: %d chunks with %d batch size",
+        "Starting async pipeline | user_id=%s | file_id=%s | total_chunks=%d | batch_size=%d | consumers=%d | %s",
+        user_id,
         file_id,
         total_chunks,
         EMBEDDING_BATCH_SIZE,
+        consumer_count,
+        get_process_memory_details(),
     )
 
     async def batch_producer():
@@ -491,11 +578,15 @@ async def _process_documents_async_pipeline(
                 batch_ids = [file_id] * len(batch_documents)
 
                 logger.info(
-                    "Generating embeddings for batch %d/%d: chunks %d-%d",
+                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d | %s",
+                    user_id,
+                    file_id,
                     batch_idx + 1,
                     num_batches,
                     start_idx,
                     end_idx - 1,
+                    len(batch_documents),
+                    get_process_memory_details(),
                 )
 
                 # Put batch in queue for processing
@@ -507,7 +598,8 @@ async def _process_documents_async_pipeline(
             raise
         finally:
             # Always signal end of production
-            await embedding_queue.put(None)
+            for _ in range(consumer_count):
+                await embedding_queue.put(None)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -521,10 +613,13 @@ async def _process_documents_async_pipeline(
                 batch_documents, batch_ids, batch_num, total_batches = item
 
                 logger.info(
-                    "Inserting batch %d/%d into database (%d chunks)",
+                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d | %s",
+                    user_id,
+                    file_id,
                     batch_num,
                     total_batches,
                     len(batch_documents),
+                    get_process_memory_details(),
                 )
 
                 try:
@@ -532,73 +627,108 @@ async def _process_documents_async_pipeline(
                     batch_result_ids = await vector_store.aadd_documents(
                         batch_documents, ids=batch_ids, executor=executor
                     )
-                    await results_queue.put(batch_result_ids)
+                    successful_batch_ids[batch_num] = batch_result_ids
+                    await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
                     logger.error(
-                        "Error processing batch %d/%d: %s", batch_num, total_batches, e
+                        "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
+                        user_id,
+                        file_id,
+                        batch_num,
+                        total_batches,
+                        e,
+                        get_process_memory_details(),
                     )
-                    await results_queue.put(e)  # Put exception object
+                    await results_queue.put((batch_num, e))  # Put exception object
                 finally:
                     embedding_queue.task_done()
 
         except Exception as e:
             logger.error("Fatal error in embedding consumer: %s", e)
-            await results_queue.put(e)
+            await results_queue.put((None, e))
             raise
 
     producer_task = None
-    consumer_task = None
+    consumer_tasks: List[asyncio.Task] = []
 
     try:
-        # Start producer and consumer concurrently
+        # Start producer and consumers concurrently
         producer_task = asyncio.create_task(batch_producer())
-        consumer_task = asyncio.create_task(embedding_consumer())
+        consumer_tasks = [
+            asyncio.create_task(embedding_consumer()) for _ in range(consumer_count)
+        ]
 
-        # Wait for both to complete
-        await asyncio.gather(producer_task, consumer_task, return_exceptions=False)
+        # Wait for all tasks to complete
+        await asyncio.gather(producer_task, *consumer_tasks, return_exceptions=False)
 
         # Collect results from all batches
         for _ in range(num_batches):
-            result = await results_queue.get()
+            batch_num, result = await results_queue.get()
             if isinstance(result, Exception):
                 raise result
-            all_ids.extend(result)
+
+        for batch_num in range(1, num_batches + 1):
+            all_ids.extend(successful_batch_ids[batch_num])
 
         logger.info(
-            "Async pipeline completed for file %s: %d embeddings created",
+            "Async pipeline completed | user_id=%s | file_id=%s | inserted_ids=%d | %s",
+            user_id,
             file_id,
             len(all_ids),
+            get_process_memory_details(),
         )
 
         return all_ids
 
     except Exception as e:
-        logger.error("Pipeline failed for file %s: %s", file_id, e)
-        if consumer_task is not None or producer_task is not None:
+        logger.error(
+            "Pipeline failed | user_id=%s | file_id=%s | inserted_batches=%d | error=%s | %s",
+            user_id,
+            file_id,
+            len(successful_batch_ids),
+            e,
+            get_process_memory_details(),
+        )
+        if producer_task is not None or consumer_tasks:
             # if one of the tasks is still running, cancel it
-            if consumer_task is not None and not consumer_task.done():
-                consumer_task.cancel()
             if producer_task is not None and not producer_task.done():
                 producer_task.cancel()
+            for consumer_task in consumer_tasks:
+                if not consumer_task.done():
+                    consumer_task.cancel()
 
             # Await cancelled tasks to ensure proper cleanup
-            if consumer_task is None:
-                await asyncio.gather(producer_task, return_exceptions=True)
-            elif producer_task is None:
-                await asyncio.gather(consumer_task, return_exceptions=True)
-            else:
-                await asyncio.gather(
-                    consumer_task, producer_task, return_exceptions=True
-                )
+            tasks_to_await = []
+            if producer_task is not None:
+                tasks_to_await.append(producer_task)
+            tasks_to_await.extend(consumer_tasks)
+            if tasks_to_await:
+                await asyncio.gather(*tasks_to_await, return_exceptions=True)
 
         # Attempt rollback only if we inserted something
-        if all_ids:
+        if successful_batch_ids:
             try:
-                logger.warning("Performing rollback of file %s", file_id)
+                logger.warning(
+                    "Performing rollback | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
                 await vector_store.delete(ids=[file_id], executor=executor)
-                logger.info("Rollback completed for file %s", file_id)
+                logger.info(
+                    "Rollback completed | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
             except Exception as cleanup_error:
-                logger.error("Rollback failed for file %s: %s", file_id, cleanup_error)
+                logger.error(
+                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                    user_id,
+                    file_id,
+                    cleanup_error,
+                    get_process_memory_details(),
+                )
 
         # Re-raise the original error
         raise
@@ -731,7 +861,12 @@ async def store_data_in_vector_db(
     user_id: str = "",
     clean_content: bool = False,
     executor=None,
+    route_name: str = "unknown",
+    filename: Optional[str] = None,
+    content_type: Optional[str] = None,
+    temp_file_path: Optional[str] = None,
 ) -> bool:
+    start_time = time.perf_counter()
     # Run document preparation in executor to avoid blocking the event loop
     loop = asyncio.get_running_loop()
     docs = await loop.run_in_executor(
@@ -741,6 +876,19 @@ async def store_data_in_vector_db(
         file_id,
         user_id,
         clean_content,
+    )
+
+    logger.info(
+        "Documents prepared | %s",
+        build_ingestion_context(
+            route_name=route_name,
+            user_id=user_id,
+            file_id=file_id,
+            filename=filename or file_id,
+            content_type=content_type,
+            temp_file_path=temp_file_path,
+            chunk_count=len(docs),
+        ),
     )
 
     try:
@@ -759,7 +907,12 @@ async def store_data_in_vector_db(
 
             if isinstance(vector_store, AsyncPgVector):
                 ids = await _process_documents_async_pipeline(
-                    docs, file_id, vector_store, executor
+                    docs,
+                    file_id,
+                    vector_store,
+                    executor,
+                    parallel_execution=max(1, PARALLEL_EXECUTION),
+                    user_id=user_id,
                 )
             else:
                 # Fallback to batched processing for sync vector stores
@@ -767,13 +920,35 @@ async def store_data_in_vector_db(
                     docs, file_id, vector_store, executor
                 )
 
+        logger.info(
+            "Ingestion completed | %s | inserted_ids=%d | elapsed_ms=%d",
+            build_ingestion_context(
+                route_name=route_name,
+                user_id=user_id,
+                file_id=file_id,
+                filename=filename or file_id,
+                content_type=content_type,
+                temp_file_path=temp_file_path,
+                chunk_count=len(docs),
+            ),
+            len(ids),
+            int((time.perf_counter() - start_time) * 1000),
+        )
         return {"message": "Documents added successfully", "ids": ids}
 
     except Exception as e:
         logger.error(
-            "Failed to store data in vector DB | File ID: %s | User ID: %s | Error: %s | Traceback: %s",
-            file_id,
-            user_id,
+            "Failed to store data in vector DB | %s | elapsed_ms=%d | Error: %s | Traceback: %s",
+            build_ingestion_context(
+                route_name=route_name,
+                user_id=user_id,
+                file_id=file_id,
+                filename=filename or file_id,
+                content_type=content_type,
+                temp_file_path=temp_file_path,
+                chunk_count=len(docs),
+            ),
+            int((time.perf_counter() - start_time) * 1000),
             str(e),
             traceback.format_exc(),
         )
@@ -784,23 +959,36 @@ async def store_data_in_vector_db(
 async def embed_local_file(
     document: StoreDocument, request: Request, entity_id: str = None
 ):
+    user_id = get_user_id(request, entity_id)
     file_path = validate_file_path(RAG_UPLOAD_DIR, document.filepath)
 
     # Check if the file exists and if it is within the allowed upload directory
     if file_path is None or not os.path.exists(file_path):
-        logger.warning("Path validation failed for local embed: %s", document.filepath)
+        logger.warning(
+            "Path validation failed for local embed | route=local_embed | user_id=%s | file_id=%s | filename=%s | requested_path=%s",
+            user_id,
+            document.file_id,
+            document.filename,
+            document.filepath,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.FILE_NOT_FOUND,
         )
 
-    if not hasattr(request.state, "user"):
-        user_id = entity_id if entity_id else "public"
-    else:
-        user_id = entity_id if entity_id else request.state.user.get("id")
-
     loader = None
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="local_embed",
+                user_id=user_id,
+                file_id=document.file_id,
+                filename=document.filename,
+                content_type=document.file_content_type,
+                temp_file_path=file_path,
+            ),
+        )
         loader, known_type, file_ext = get_loader(
             document.filename, document.file_content_type, file_path
         )
@@ -815,6 +1003,10 @@ async def embed_local_file(
             user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="local_embed",
+            filename=document.filename,
+            content_type=document.file_content_type,
+            temp_file_path=file_path,
         )
 
         if result:
@@ -831,13 +1023,23 @@ async def embed_local_file(
             )
     except HTTPException as http_exc:
         logger.error(
-            "HTTP Exception in embed_local_file | Status: %d | Detail: %s",
+            "HTTP Exception in embed_local_file | route=local_embed | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            document.file_id,
+            document.filename,
             http_exc.status_code,
             http_exc.detail,
         )
         raise http_exc
     except Exception as e:
-        logger.error(e)
+        logger.error(
+            "Unhandled exception in embed_local_file | route=local_embed | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            document.file_id,
+            document.filename,
+            str(e),
+            traceback.format_exc(),
+        )
         if "No pandoc was found" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -869,13 +1071,29 @@ async def embed_file(
     validated_file_path = _make_unique_temp_path(user_id, file.filename)
 
     if validated_file_path is None:
-        logger.warning("Path validation failed for embed: %s", file.filename)
+        logger.warning(
+            "Path validation failed for embed | route=embed | user_id=%s | file_id=%s | filename=%s",
+            user_id,
+            file_id,
+            file.filename,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT("Invalid request"),
         )
 
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="embed",
+                user_id=user_id,
+                file_id=file_id,
+                filename=file.filename,
+                content_type=file.content_type,
+                temp_file_path=validated_file_path,
+            ),
+        )
         os.makedirs(os.path.dirname(validated_file_path), exist_ok=True)
         await save_upload_file_async(file, validated_file_path)
         data, known_type, file_ext = await load_file_content(
@@ -885,12 +1103,18 @@ async def embed_file(
             request.app.state.thread_pool,
         )
 
+        logger.debug(f"Loading Filename:{file.filename} - ContentType:{file.content_type} - FileExt:{file_ext} - KnownType:{known_type}")
+
         result = await store_data_in_vector_db(
             data=data,
             file_id=file_id,
             user_id=user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="embed",
+            filename=file.filename,
+            content_type=file.content_type,
+            temp_file_path=validated_file_path,
         )
 
         if not result:
@@ -914,7 +1138,10 @@ async def embed_file(
         response_status = False
         response_message = f"HTTP Exception: {http_exc.detail}"
         logger.error(
-            "HTTP Exception in embed_file | Status: %d | Detail: %s",
+            "HTTP Exception in embed_file | route=embed | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            file_id,
+            file.filename,
             http_exc.status_code,
             http_exc.detail,
         )
@@ -923,7 +1150,10 @@ async def embed_file(
         response_status = False
         response_message = f"Error during file processing: {str(e)}"
         logger.error(
-            "Error during file processing: %s\nTraceback: %s",
+            "Error during file processing | route=embed | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            file_id,
+            file.filename,
             str(e),
             traceback.format_exc(),
         )
@@ -1004,7 +1234,10 @@ async def embed_file_upload(
 
     if validated_temp_file_path is None:
         logger.warning(
-            "Path validation failed for embed-upload: %s", uploaded_file.filename
+            "Path validation failed for embed-upload | route=embed_upload | user_id=%s | file_id=%s | filename=%s",
+            user_id,
+            file_id,
+            uploaded_file.filename,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1012,6 +1245,17 @@ async def embed_file_upload(
         )
 
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="embed_upload",
+                user_id=user_id,
+                file_id=file_id,
+                filename=uploaded_file.filename,
+                content_type=uploaded_file.content_type,
+                temp_file_path=validated_temp_file_path,
+            ),
+        )
         os.makedirs(os.path.dirname(validated_temp_file_path), exist_ok=True)
         await save_upload_file_async(uploaded_file, validated_temp_file_path)
         data, known_type, file_ext = await load_file_content(
@@ -1027,6 +1271,10 @@ async def embed_file_upload(
             user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="embed_upload",
+            filename=uploaded_file.filename,
+            content_type=uploaded_file.content_type,
+            temp_file_path=validated_temp_file_path,
         )
 
         if not result:
@@ -1036,14 +1284,19 @@ async def embed_file_upload(
             )
     except HTTPException as http_exc:
         logger.error(
-            "HTTP Exception in embed_file_upload | Status: %d | Detail: %s",
+            "HTTP Exception in embed_file_upload | route=embed_upload | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            file_id,
+            uploaded_file.filename,
             http_exc.status_code,
             http_exc.detail,
         )
         raise http_exc
     except Exception as e:
         logger.error(
-            "Error during file processing | File: %s | Error: %s | Traceback: %s",
+            "Error during file processing | route=embed_upload | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            file_id,
             uploaded_file.filename,
             str(e),
             traceback.format_exc(),

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -9,7 +9,7 @@ import aiofiles.os
 import asyncio
 import time
 from shutil import copyfileobj
-from typing import List, Iterable, Optional, Union, TYPE_CHECKING
+from typing import Dict, List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import (
     APIRouter,
@@ -556,6 +556,7 @@ async def _process_documents_async_pipeline(
     all_ids = []
     successful_batch_ids = {}
     failure_event = asyncio.Event()
+    in_flight_insert_tasks: Dict[asyncio.Task, int] = {}
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -607,6 +608,46 @@ async def _process_documents_async_pipeline(
                 for _ in range(consumer_count):
                     await embedding_queue.put(None)
 
+    async def insert_batch(
+        batch_documents: List[Document], batch_ids: List[str], batch_num: int
+    ) -> List[str]:
+        """Track started inserts so rollback waits for executor-backed work."""
+        insert_task = asyncio.create_task(
+            vector_store.aadd_documents(
+                batch_documents, ids=batch_ids, executor=executor
+            )
+        )
+        in_flight_insert_tasks[insert_task] = batch_num
+        try:
+            return await asyncio.shield(insert_task)
+        finally:
+            if insert_task.done():
+                in_flight_insert_tasks.pop(insert_task, None)
+                try:
+                    successful_batch_ids.setdefault(batch_num, insert_task.result())
+                except BaseException:
+                    pass
+
+    async def wait_for_in_flight_inserts() -> None:
+        """Wait for started inserts before rollback can delete inserted vectors."""
+        if not in_flight_insert_tasks:
+            return
+
+        pending_tasks = list(in_flight_insert_tasks)
+        logger.warning(
+            "Waiting for in-flight inserts before rollback | user_id=%s | file_id=%s | inserts=%d | %s",
+            user_id,
+            file_id,
+            len(pending_tasks),
+            get_process_memory_details(),
+        )
+        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task, result in zip(pending_tasks, results):
+            batch_num = in_flight_insert_tasks.pop(insert_task, None)
+            if batch_num is None or isinstance(result, BaseException):
+                continue
+            successful_batch_ids[batch_num] = result
+
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
         try:
@@ -629,8 +670,8 @@ async def _process_documents_async_pipeline(
 
                 try:
                     # Insert batch into database
-                    batch_result_ids = await vector_store.aadd_documents(
-                        batch_documents, ids=batch_ids, executor=executor
+                    batch_result_ids = await insert_batch(
+                        batch_documents, batch_ids, batch_num
                     )
                     successful_batch_ids[batch_num] = batch_result_ids
                     await results_queue.put((batch_num, batch_result_ids))
@@ -713,6 +754,8 @@ async def _process_documents_async_pipeline(
             tasks_to_await.extend(consumer_tasks)
             if tasks_to_await:
                 await asyncio.gather(*tasks_to_await, return_exceptions=True)
+
+        await wait_for_in_flight_inserts()
 
         # Attempt rollback only if we inserted something
         if successful_batch_ids:

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -555,6 +555,7 @@ async def _process_documents_async_pipeline(
     results_queue = asyncio.Queue()
     all_ids = []
     successful_batch_ids = {}
+    failure_event = asyncio.Event()
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -573,6 +574,9 @@ async def _process_documents_async_pipeline(
         """Produce document batches and put them in the queue."""
         try:
             for batch_idx in range(num_batches):
+                if failure_event.is_set():
+                    break
+
                 start_idx = batch_idx * EMBEDDING_BATCH_SIZE
                 end_idx = min(start_idx + EMBEDDING_BATCH_SIZE, total_chunks)
                 batch_documents = documents[start_idx:end_idx]
@@ -594,12 +598,14 @@ async def _process_documents_async_pipeline(
                     (batch_documents, batch_ids, batch_idx + 1, num_batches)
                 )
         except Exception as e:
+            failure_event.set()
             logger.error("Error in batch producer: %s", e)
             raise
         finally:
-            # Always signal end of production
-            for _ in range(consumer_count):
-                await embedding_queue.put(None)
+            # Signal normal completion; failure paths are cancelled by the caller.
+            if not failure_event.is_set():
+                for _ in range(consumer_count):
+                    await embedding_queue.put(None)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -629,6 +635,7 @@ async def _process_documents_async_pipeline(
                     successful_batch_ids[batch_num] = batch_result_ids
                     await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
+                    failure_event.set()
                     logger.error(
                         "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
                         user_id,
@@ -639,12 +646,15 @@ async def _process_documents_async_pipeline(
                         get_process_memory_details(),
                     )
                     await results_queue.put((batch_num, e))  # Put exception object
+                    raise
                 finally:
                     embedding_queue.task_done()
 
         except Exception as e:
-            logger.error("Fatal error in embedding consumer: %s", e)
-            await results_queue.put((None, e))
+            if not failure_event.is_set():
+                failure_event.set()
+                logger.error("Fatal error in embedding consumer: %s", e)
+                await results_queue.put((None, e))
             raise
 
     producer_task = None

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -602,7 +602,6 @@ async def _process_documents_async_pipeline(
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
         nonlocal cleanup_needed
-        cleanup_needed = True
         insert_task = asyncio.create_task(
             vector_store.aadd_documents(
                 batch_documents, ids=batch_ids, executor=executor
@@ -610,13 +609,16 @@ async def _process_documents_async_pipeline(
         )
         in_flight_insert_tasks.add(insert_task)
         try:
-            return await asyncio.shield(insert_task)
+            batch_result_ids = await asyncio.shield(insert_task)
+            cleanup_needed = True
+            return batch_result_ids
         finally:
             if insert_task.done():
                 in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:
         """Wait for started inserts before rollback can delete inserted vectors."""
+        nonlocal cleanup_needed
         if not in_flight_insert_tasks:
             return
 
@@ -628,9 +630,11 @@ async def _process_documents_async_pipeline(
             len(pending_tasks),
             get_process_memory_details(),
         )
-        await asyncio.gather(*pending_tasks, return_exceptions=True)
-        for insert_task in pending_tasks:
+        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task, result in zip(pending_tasks, results):
             in_flight_insert_tasks.discard(insert_task)
+            if not isinstance(result, BaseException):
+                cleanup_needed = True
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -414,6 +414,53 @@ class TestProducerConsumerPattern:
                 )
 
     @pytest.mark.asyncio
+    async def test_rollback_waits_for_in_flight_parallel_insert(self):
+        """Rollback must not run while another batch insert can still commit."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        insert_started = asyncio.Event()
+        events = []
+
+        async def add_documents(docs, ids=None, executor=None):
+            idx = docs[0].metadata["idx"]
+            if idx == 0:
+                events.append("slow_insert_started")
+                insert_started.set()
+                await asyncio.sleep(0.05)
+                events.append("slow_insert_finished")
+                return ["slow_id"]
+
+            await insert_started.wait()
+            events.append("failing_insert")
+            raise ValueError("Test error")
+
+        async def delete(ids=None, executor=None):
+            events.append("rollback")
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = add_documents
+        mock_store.delete = delete
+
+        docs = [
+            Document(page_content="slow", metadata={"idx": 0}),
+            Document(page_content="fail", metadata={"idx": 1}),
+        ]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            with pytest.raises(ValueError, match="Test error"):
+                await _process_documents_async_pipeline(
+                    documents=docs,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                    parallel_execution=2,
+                )
+
+        assert events.index("slow_insert_finished") < events.index("rollback")
+
+    @pytest.mark.asyncio
     async def test_all_ids_collected_across_batches(self):
         """Test that IDs from all batches are collected."""
         from app.routes.document_routes import _process_documents_async_pipeline

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -434,6 +434,51 @@ class TestProducerConsumerPattern:
         assert len(result) == 5
         assert result == ["id1", "id2", "id3", "id4", "id5"]
 
+    @pytest.mark.asyncio
+    async def test_parallel_execution_processes_batches_concurrently_in_order(self):
+        """Multiple consumers should process batches concurrently and return IDs in batch order."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        active_batches = 0
+        max_active_batches = 0
+        active_lock = asyncio.Lock()
+
+        async def tracking_add_documents(docs, ids=None, executor=None):
+            nonlocal active_batches, max_active_batches
+            async with active_lock:
+                active_batches += 1
+                max_active_batches = max(max_active_batches, active_batches)
+
+            await asyncio.sleep(0.01)
+
+            async with active_lock:
+                active_batches -= 1
+
+            return [f"id_{doc.metadata['idx']}" for doc in docs]
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = tracking_add_documents
+        mock_store.delete = AsyncMock()
+
+        docs = [
+            Document(page_content=f"doc_{i}", metadata={"idx": i}) for i in range(6)
+        ]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            result = await _process_documents_async_pipeline(
+                documents=docs,
+                file_id="test",
+                vector_store=mock_store,
+                executor=None,
+                parallel_execution=3,
+                user_id="test_user",
+            )
+
+        assert max_active_batches > 1
+        assert result == [f"id_{i}" for i in range(6)]
+
 
 class TestSyncBatchedMongoCompat:
     """Regression tests for MongoDB-compatible batch processing (PR #266)."""

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -121,10 +121,10 @@ class TestBatchProcessing:
         mock_async_vector_store.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_pipeline_rolls_back_on_first_batch_error(
+    async def test_async_pipeline_no_rollback_before_insert_starts(
         self, mock_documents, mock_async_vector_store
     ):
-        """Test failed async ingestion always cleans up by file_id."""
+        """Test failed async ingestion does not delete existing vectors if no insert started."""
         from app.routes.document_routes import _process_documents_async_pipeline
 
         mock_async_vector_store.aadd_documents = AsyncMock(
@@ -140,7 +140,7 @@ class TestBatchProcessing:
                     executor=None,
                 )
 
-        mock_async_vector_store.delete.assert_called_once()
+        assert not mock_async_vector_store.delete.called
 
     # --- Sync Batched Tests ---
 

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -121,10 +121,10 @@ class TestBatchProcessing:
         mock_async_vector_store.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_pipeline_no_rollback_on_first_batch_error(
+    async def test_async_pipeline_rolls_back_on_first_batch_error(
         self, mock_documents, mock_async_vector_store
     ):
-        """Test that no rollback occurs if first batch fails (nothing inserted)."""
+        """Test failed async ingestion always cleans up by file_id."""
         from app.routes.document_routes import _process_documents_async_pipeline
 
         mock_async_vector_store.aadd_documents = AsyncMock(
@@ -140,8 +140,7 @@ class TestBatchProcessing:
                     executor=None,
                 )
 
-        # Should not attempt rollback since nothing was inserted
-        assert not mock_async_vector_store.delete.called
+        mock_async_vector_store.delete.assert_called_once()
 
     # --- Sync Batched Tests ---
 


### PR DESCRIPTION
**Summary**
This PR adds configurable parallel processing for batched document ingestion and improves observability around file embedding.

**Why**
Large file ingestion can be slow and hard to diagnose. The existing batching pipeline reduced memory pressure, but processed embedding/database batches with a single consumer. This change allows multiple async consumers per file so batches can be embedded and inserted in parallel, while adding detailed logs to understand file size, chunk count, route, user/file identifiers, elapsed time, and memory usage during ingestion.

**What Changed**
- Added `PARALLEL_EXECUTION` env config, defaulting to `2`.
- Updated the async ingestion pipeline to run multiple batch consumers when batching is enabled.
- Preserved deterministic result ordering by collecting batch results by batch number.
- Added rollback tracking for successfully inserted batches.
- Added detailed ingestion logging for `/embed`, `/embed-upload`, and `/local/embed`.
- Added process memory details to ingestion logs.
- Documented the new env var in `README.md`.
- Added a regression test covering concurrent batch processing and ordered results.

Peter Rothlaender [ginkgo.rothlaender@external.daimlertruck.com](mailto:ginkgo.rothlaender@external.daimlertruck.com) on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) {2026} Daimler Truck AG