### PR TITLE
fix: NLTK data download during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
-ENV NLTK_DATA=/app/nltk_data
+RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -13,10 +13,10 @@ RUN apt-get update \
 
 COPY requirements.lite.txt .
 RUN pip install --no-cache-dir -r requirements.lite.txt
+ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
-ENV NLTK_DATA=/app/nltk_data
+RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true


### PR DESCRIPTION
**Description**

This PR fixes the Docker image build failure caused by NLTK 3.10.0 rejecting the temporary download path for `punkt_tab`.

The Dockerfiles already downloaded NLTK data at build time to avoid runtime downloads by `unstructured`, but `NLTK_DATA` was only set after the download command. With newer NLTK path validation, `/app/nltk_data` must be registered before the downloader writes package files there.

**Changes**

- Set `NLTK_DATA=/app/nltk_data` before running `nltk.downloader`.
- Add `--exit-on-error` so Docker builds fail cleanly instead of prompting interactively.
- Apply the same fix to `Dockerfile` and `Dockerfile.lite`.
- Keep the current resolved NLTK version; no dependency rollback or direct download fallback.

**Validation**

- Verified with a clean build of `Dockerfile.lite`:

```powershell
docker build --no-cache -f Dockerfile.lite -t rag-api-lite-nltk-download-fix .
```

The build completed successfully and downloaded `punkt_tab`, `averaged_perceptron_tagger`, and `averaged_perceptron_tagger_eng`.


Peter Rothlaender [ginkgo.rothlaender@external.daimlertruck.com](mailto:ginkgo.rothlaender@external.daimlertruck.com) on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) {2026} Daimler Truck AG