### PR TITLE
🛡️ fix: Patch pypdf and cryptography Security Alerts

### DIFF
--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -9,7 +9,7 @@ fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
-pypdf==6.13.3
+pypdf==6.14.2
 unstructured==0.18.32
 markdown==3.8.2
 networkx==3.2.1
@@ -25,7 +25,7 @@ rapidocr-onnxruntime==1.4.4
 opencv-python-headless==4.9.0.80
 pymongo>=4.12.0,<5
 langchain-mongodb==0.11.0
-cryptography==46.0.7
+cryptography==48.0.1
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ fastapi==0.115.12
 psycopg2-binary==2.9.9
 pgvector==0.2.5
 uvicorn==0.28.0
-pypdf==6.13.3
+pypdf==6.14.2
 unstructured==0.18.32
 markdown==3.8.2
 networkx==3.2.1
@@ -31,7 +31,7 @@ langchain-mongodb==0.11.0
 langchain-ollama==1.1.0
 langchain-huggingface==1.2.2
 langchain-google-genai==4.2.5
-cryptography==46.0.7
+cryptography==48.0.1
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2


### PR DESCRIPTION
## Summary

I updated `pypdf` and `cryptography` in both Python dependency manifests to address Dependabot alerts 130–139 covering malformed-PDF denial-of-service vectors and vulnerable OpenSSL wheels.

- Bumped `pypdf` from `6.13.3` to `6.14.2` in `requirements.txt` and `requirements.lite.txt`.
- Bumped `cryptography` from `46.0.7` to `48.0.1` in both manifests.
- Kept the change limited to the four vulnerable dependency pins.
- Verified dependency resolution, PDF parsing and encryption, Office decryption, the full test suite, and Docker image compatibility.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Installed `requirements.txt` in a fresh Python 3.12 environment and ran `pip check`.
- Resolved both full and lite manifests on Python 3.12 for macOS ARM64 and Linux.
- Ran the non-integration suite: 196 passed, 6 skipped.
- Ran the Docker-backed integration suite: 21 passed.
- Exercised plain and AES-256-encrypted PDF round trips, LangChain `PyPDFLoader`, Fernet encryption, and encrypted Office document decryption.
- Confirmed `pip-audit` reports no findings for the updated `pypdf` or `cryptography` versions.
- Built and smoke-tested both complete Docker images in isolation with the reviewed NLTK download fix from #311; current `main` otherwise reproduces #311's pre-existing NLTK build failure.

### **Test Configuration**:

- Python 3.12.12
- Docker 29.4.0 on Linux ARM64
- `pypdf==6.14.2`
- `cryptography==48.0.1` with OpenSSL 4.0.1

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes