### PR TITLE
📚 fix: Fail Docker Builds on NLTK Download Errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
-ENV NLTK_DATA=/app/nltk_data
+RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
+RUN python -c "import nltk, sys; packages = ('punkt_tab', 'averaged_perceptron_tagger', 'averaged_perceptron_tagger_eng'); sys.exit(0 if all(nltk.download(package, download_dir='/app/nltk_data') for package in packages) else 1)"
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -13,10 +13,10 @@ RUN apt-get update \
 
 COPY requirements.lite.txt .
 RUN pip install --no-cache-dir -r requirements.lite.txt
+ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
-ENV NLTK_DATA=/app/nltk_data
+RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir -r requirements.lite.txt
 ENV NLTK_DATA=/app/nltk_data
 
 # Download standard NLTK data, to prevent unstructured from downloading packages at runtime
-RUN python -m nltk.downloader --exit-on-error -d /app/nltk_data punkt_tab averaged_perceptron_tagger averaged_perceptron_tagger_eng
+RUN python -c "import nltk, sys; packages = ('punkt_tab', 'averaged_perceptron_tagger', 'averaged_perceptron_tagger_eng'); sys.exit(0 if all(nltk.download(package, download_dir='/app/nltk_data') for package in packages) else 1)"
 
 # Disable Unstructured analytics
 ENV SCARF_NO_ANALYTICS=true


### PR DESCRIPTION
## Summary

I fixed NLTK data provisioning during Docker builds and made both image variants fail immediately when any required package cannot be downloaded.

- Set `NLTK_DATA` before the download layer in `Dockerfile` and `Dockerfile.lite`.
- Replace the NLTK downloader CLI with explicit `nltk.download(...)` result checks and a nonzero process exit on failure.
- Retain build-time installation of `punkt_tab`, `averaged_perceptron_tagger`, and `averaged_perceptron_tagger_eng`.
- Preserve Peter Rothlaender's original #311 commit and add the focused Codex-review fix as a separate commit.
- Supersede #311 because its organization-owned fork does not allow maintainer pushes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Built the full image with `docker build --file Dockerfile .`.
- Built the lite image with `docker build --file Dockerfile.lite .`.
- Confirmed both images contain all three required NLTK resources under `/app/nltk_data`.
- Confirmed a nonexistent package returns status 1 so Docker cannot publish an incomplete image.
- Rebuilt both images with the dependency updates merged in #314.

### **Test Configuration**:

- Docker 29.4.0
- Full image: `python:3.12`
- Lite image: `python:3.12-slim`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local Docker build validation passes with my changes