### PR TITLE
🏭 feat: Add Safe Parallel Ingestion Consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The following environment variables are required to run the application:
 - `CHUNK_OVERLAP`: (Optional) The overlap between chunks during text processing. Default value is "100".
 - `EMBEDDING_BATCH_SIZE`: (Optional) Number of document chunks to process per batch. Set to `0` (default) to disable batching. Recommended value is `750` for `text-embedding-3-small`.
 - `EMBEDDING_MAX_QUEUE_SIZE`: (Optional) Maximum number of batches to buffer in memory during async processing. Default value is "3".
+- `PARALLEL_EXECUTION`: (Optional) Maximum number of async embedding/database insertion consumers to run per file when batching is enabled. Default value is "2".
 - `RAG_DISTANCE_THRESHOLD`: (Optional, `VECTOR_DB_TYPE=pgvector` only) Drop results whose vector distance is greater than this value, after the top-`k` search. Unset by default (no filtering). Lower distance = more similar, so e.g. `0.5` keeps only hits with distance ≤ 0.5 and discards weaker matches. Useful for reducing downstream LLM token cost when the top-`k` call returns loosely-related chunks. Appropriate values depend on the embedding model and distance strategy — inspect your actual scores before choosing one. Ignored (with a startup warning) under `VECTOR_DB_TYPE=atlas-mongo`, because Atlas returns a similarity score (higher = better) with inverted semantics.
 - `RAG_UPLOAD_DIR`: (Optional) The directory where uploaded files are stored. Default value is "./uploads/".
 - `PDF_EXTRACT_IMAGES`: (Optional) A boolean value indicating whether to extract images from PDF files. Default value is "False".

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ When `EMBEDDING_BATCH_SIZE > 0`:
 - Documents are processed in batches of the specified size
 - Up to `PARALLEL_EXECUTION` batches for the same file can be embedded and inserted concurrently
 - `PARALLEL_EXECUTION` is per request/file. Total process concurrency can be roughly `active uploads * PARALLEL_EXECUTION`, bounded indirectly by `RAG_THREAD_POOL_SIZE` and downstream provider/database limits
-- On failure, successfully inserted documents are rolled back
+- On failure, remaining batch work is stopped and successfully inserted documents are rolled back
 - Memory usage is bounded by queued plus active batches, roughly `EMBEDDING_BATCH_SIZE * (EMBEDDING_MAX_QUEUE_SIZE + PARALLEL_EXECUTION)`
 - Ingestion lifecycle logs include route, user, file, chunk count, file size, elapsed time, and selected process memory context. Per-batch queue/insert progress is logged at debug level
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ For large files, you can enable batched embedding processing to reduce memory co
 |----------|---------|-------------|
 | `EMBEDDING_BATCH_SIZE` | `0` | Number of document chunks to process per batch. `0` disables batching (original behavior). |
 | `EMBEDDING_MAX_QUEUE_SIZE` | `3` | Maximum number of batches to buffer in memory during async processing. |
+| `PARALLEL_EXECUTION` | `2` | Maximum number of async embedding/database insertion consumers per file when batching is enabled. |
 
 #### Recommended Settings
 
@@ -156,14 +157,17 @@ For memory-constrained environments (< 2GB RAM):
 For high-throughput environments:
 - `EMBEDDING_BATCH_SIZE=1000-2000`
 - `EMBEDDING_MAX_QUEUE_SIZE=5`
+- Increase `PARALLEL_EXECUTION` cautiously; it applies per active file upload.
 
 #### Behavior
 
 When `EMBEDDING_BATCH_SIZE > 0`:
 - Documents are processed in batches of the specified size
-- Each batch is embedded and inserted before the next batch starts
+- Up to `PARALLEL_EXECUTION` batches for the same file can be embedded and inserted concurrently
+- `PARALLEL_EXECUTION` is per request/file. Total process concurrency can be roughly `active uploads * PARALLEL_EXECUTION`, bounded indirectly by `RAG_THREAD_POOL_SIZE` and downstream provider/database limits
 - On failure, successfully inserted documents are rolled back
-- Memory usage is bounded by `EMBEDDING_BATCH_SIZE * EMBEDDING_MAX_QUEUE_SIZE`
+- Memory usage is bounded by queued plus active batches, roughly `EMBEDDING_BATCH_SIZE * (EMBEDDING_MAX_QUEUE_SIZE + PARALLEL_EXECUTION)`
+- Ingestion lifecycle logs include route, user, file, chunk count, file size, elapsed time, and selected process memory context. Per-batch queue/insert progress is logged at debug level
 
 When `EMBEDDING_BATCH_SIZE = 0` (default):
 - All documents are processed at once (original behavior)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following environment variables are required to run the application:
 - `COLLECTION_NAME`: (Optional) The name of the collection in the vector store. Default value is "testcollection".
 - `CHUNK_SIZE`: (Optional) The size of the chunks for text processing. Default value is "1500".
 - `CHUNK_OVERLAP`: (Optional) The overlap between chunks during text processing. Default value is "100".
-- `EMBEDDING_BATCH_SIZE`: (Optional) Number of document chunks to process per batch. Set to `0` (default) to disable batching. Recommended value is `750` for `text-embedding-3-small`.
+- `EMBEDDING_BATCH_SIZE`: (Optional) Number of document chunks to process per batch. Defaults to `500`; set to `0` to disable batching. Recommended value is `750` for `text-embedding-3-small`.
 - `EMBEDDING_MAX_QUEUE_SIZE`: (Optional) Maximum number of batches to buffer in memory during async processing. Default value is "3".
 - `PARALLEL_EXECUTION`: (Optional) Maximum number of async embedding/database insertion consumers to run per file when batching is enabled. Default value is "2".
 - `RAG_DISTANCE_THRESHOLD`: (Optional, `VECTOR_DB_TYPE=pgvector` only) Drop results whose vector distance is greater than this value, after the top-`k` search. Unset by default (no filtering). Lower distance = more similar, so e.g. `0.5` keeps only hits with distance ≤ 0.5 and discards weaker matches. Useful for reducing downstream LLM token cost when the top-`k` call returns loosely-related chunks. Appropriate values depend on the embedding model and distance strategy — inspect your actual scores before choosing one. Ignored (with a startup warning) under `VECTOR_DB_TYPE=atlas-mongo`, because Atlas returns a similarity score (higher = better) with inverted semantics.
@@ -142,7 +142,7 @@ For large files, you can enable batched embedding processing to reduce memory co
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EMBEDDING_BATCH_SIZE` | `0` | Number of document chunks to process per batch. `0` disables batching (original behavior). |
+| `EMBEDDING_BATCH_SIZE` | `500` | Number of document chunks to process per batch. `0` disables batching (original behavior). |
 | `EMBEDDING_MAX_QUEUE_SIZE` | `3` | Maximum number of batches to buffer in memory during async processing. |
 | `PARALLEL_EXECUTION` | `2` | Maximum number of async embedding/database insertion consumers per file when batching is enabled. |
 
@@ -169,7 +169,7 @@ When `EMBEDDING_BATCH_SIZE > 0`:
 - Memory usage is bounded by queued plus active batches, roughly `EMBEDDING_BATCH_SIZE * (EMBEDDING_MAX_QUEUE_SIZE + PARALLEL_EXECUTION)`
 - Ingestion lifecycle logs include route, user, file, chunk count, file size, elapsed time, and selected process memory context. Per-batch queue/insert progress is logged at debug level
 
-When `EMBEDDING_BATCH_SIZE = 0` (default):
+When `EMBEDDING_BATCH_SIZE <= 0`:
 - All documents are processed at once (original behavior)
 - Better for small files or memory-rich environments
 

--- a/app/config.py
+++ b/app/config.py
@@ -80,6 +80,7 @@ MONGO_VECTOR_COLLECTION = get_env_variable(
 )  # Deprecated, backwards compatability
 CHUNK_SIZE = int(get_env_variable("CHUNK_SIZE", "1500"))
 CHUNK_OVERLAP = int(get_env_variable("CHUNK_OVERLAP", "100"))
+PARALLEL_EXECUTION = int(get_env_variable("PARALLEL_EXECUTION", "2"))
 
 # Batch processing configuration for memory-constrained environments.
 # When EMBEDDING_BATCH_SIZE > 0, documents are processed in batches to reduce

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -167,6 +167,7 @@ def build_ingestion_context(
     known_type: Optional[str] = None,
     file_ext: Optional[str] = None,
     chunk_count: Optional[int] = None,
+    include_memory: bool = False,
 ) -> str:
     """Build a compact ingestion context string for logs."""
     parts = [
@@ -178,7 +179,6 @@ def build_ingestion_context(
     if content_type:
         parts.append(f"content_type={content_type}")
     if temp_file_path:
-        parts.append(f"temp_path={temp_file_path}")
         file_size_bytes = get_file_size_bytes(temp_file_path)
         if file_size_bytes is not None:
             parts.append(f"file_size_bytes={file_size_bytes}")
@@ -188,7 +188,8 @@ def build_ingestion_context(
         parts.append(f"file_ext={file_ext}")
     if chunk_count is not None:
         parts.append(f"chunk_count={chunk_count}")
-    parts.append(get_process_memory_details())
+    if include_memory:
+        parts.append(get_process_memory_details())
     return " | ".join(parts)
 
 
@@ -577,8 +578,8 @@ async def _process_documents_async_pipeline(
                 batch_documents = documents[start_idx:end_idx]
                 batch_ids = [file_id] * len(batch_documents)
 
-                logger.info(
-                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d | %s",
+                logger.debug(
+                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d",
                     user_id,
                     file_id,
                     batch_idx + 1,
@@ -586,7 +587,6 @@ async def _process_documents_async_pipeline(
                     start_idx,
                     end_idx - 1,
                     len(batch_documents),
-                    get_process_memory_details(),
                 )
 
                 # Put batch in queue for processing
@@ -612,14 +612,13 @@ async def _process_documents_async_pipeline(
 
                 batch_documents, batch_ids, batch_num, total_batches = item
 
-                logger.info(
-                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d | %s",
+                logger.debug(
+                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d",
                     user_id,
                     file_id,
                     batch_num,
                     total_batches,
                     len(batch_documents),
-                    get_process_memory_details(),
                 )
 
                 try:
@@ -888,6 +887,7 @@ async def store_data_in_vector_db(
             content_type=content_type,
             temp_file_path=temp_file_path,
             chunk_count=len(docs),
+            include_memory=True,
         ),
     )
 
@@ -930,6 +930,7 @@ async def store_data_in_vector_db(
                 content_type=content_type,
                 temp_file_path=temp_file_path,
                 chunk_count=len(docs),
+                include_memory=True,
             ),
             len(ids),
             int((time.perf_counter() - start_time) * 1000),
@@ -947,6 +948,7 @@ async def store_data_in_vector_db(
                 content_type=content_type,
                 temp_file_path=temp_file_path,
                 chunk_count=len(docs),
+                include_memory=True,
             ),
             int((time.perf_counter() - start_time) * 1000),
             str(e),

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -545,6 +545,7 @@ async def _process_documents_async_pipeline(
     successful_batch_ids = {}
     failure_event = asyncio.Event()
     in_flight_insert_tasks = set()
+    cleanup_needed = False
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -600,6 +601,8 @@ async def _process_documents_async_pipeline(
         batch_documents: List[Document], batch_ids: List[str]
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
+        nonlocal cleanup_needed
+        cleanup_needed = True
         insert_task = asyncio.create_task(
             vector_store.aadd_documents(
                 batch_documents, ids=batch_ids, executor=executor
@@ -727,28 +730,29 @@ async def _process_documents_async_pipeline(
 
         await wait_for_in_flight_inserts()
 
-        try:
-            logger.warning(
-                "Performing rollback | user_id=%s | file_id=%s | %s",
-                user_id,
-                file_id,
-                get_process_memory_details(),
-            )
-            await vector_store.delete(ids=[file_id], executor=executor)
-            logger.info(
-                "Rollback completed | user_id=%s | file_id=%s | %s",
-                user_id,
-                file_id,
-                get_process_memory_details(),
-            )
-        except Exception as cleanup_error:
-            logger.error(
-                "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
-                user_id,
-                file_id,
-                cleanup_error,
-                get_process_memory_details(),
-            )
+        if cleanup_needed:
+            try:
+                logger.warning(
+                    "Performing rollback | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
+                await vector_store.delete(ids=[file_id], executor=executor)
+                logger.info(
+                    "Rollback completed | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
+            except Exception as cleanup_error:
+                logger.error(
+                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                    user_id,
+                    file_id,
+                    cleanup_error,
+                    get_process_memory_details(),
+                )
 
         # Re-raise the original error
         raise

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -614,6 +614,11 @@ async def _process_documents_async_pipeline(
             return batch_result_ids
         finally:
             if insert_task.done():
+                try:
+                    insert_task.result()
+                    cleanup_needed = True
+                except BaseException:
+                    pass
                 in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -9,7 +9,7 @@ import aiofiles.os
 import asyncio
 import time
 from shutil import copyfileobj
-from typing import Dict, List, Iterable, Optional, Union, TYPE_CHECKING
+from typing import List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import (
     APIRouter,
@@ -114,16 +114,6 @@ def get_user_id(request: Request, entity_id: str = None) -> str:
         return entity_id if entity_id else request.state.user.get("id")
 
 
-def get_file_size_bytes(file_path: Optional[str]) -> Optional[int]:
-    """Return file size in bytes when available."""
-    if not file_path:
-        return None
-    try:
-        return os.path.getsize(file_path)
-    except OSError:
-        return None
-
-
 def get_process_memory_details() -> str:
     """Return lightweight process memory details for logging."""
     parts = []
@@ -179,9 +169,11 @@ def build_ingestion_context(
     if content_type:
         parts.append(f"content_type={content_type}")
     if temp_file_path:
-        file_size_bytes = get_file_size_bytes(temp_file_path)
-        if file_size_bytes is not None:
+        try:
+            file_size_bytes = os.path.getsize(temp_file_path)
             parts.append(f"file_size_bytes={file_size_bytes}")
+        except OSError:
+            pass
     if known_type:
         parts.append(f"known_type={known_type}")
     if file_ext:
@@ -548,15 +540,11 @@ async def _process_documents_async_pipeline(
 
     # Create queues for producer-consumer pattern
     # embedding_queue is bounded to limit document data held in memory.
-    # results_queue is unbounded — it holds only small UUID lists, and the
-    # drain loop runs after gather(), so bounding it would deadlock when
-    # num_batches > maxsize.
     embedding_queue = asyncio.Queue(maxsize=EMBEDDING_MAX_QUEUE_SIZE)
-    results_queue = asyncio.Queue()
     all_ids = []
     successful_batch_ids = {}
     failure_event = asyncio.Event()
-    in_flight_insert_tasks: Dict[asyncio.Task, int] = {}
+    in_flight_insert_tasks = set()
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -609,7 +597,7 @@ async def _process_documents_async_pipeline(
                     await embedding_queue.put(None)
 
     async def insert_batch(
-        batch_documents: List[Document], batch_ids: List[str], batch_num: int
+        batch_documents: List[Document], batch_ids: List[str]
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
         insert_task = asyncio.create_task(
@@ -617,16 +605,12 @@ async def _process_documents_async_pipeline(
                 batch_documents, ids=batch_ids, executor=executor
             )
         )
-        in_flight_insert_tasks[insert_task] = batch_num
+        in_flight_insert_tasks.add(insert_task)
         try:
             return await asyncio.shield(insert_task)
         finally:
             if insert_task.done():
-                in_flight_insert_tasks.pop(insert_task, None)
-                try:
-                    successful_batch_ids.setdefault(batch_num, insert_task.result())
-                except BaseException:
-                    pass
+                in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:
         """Wait for started inserts before rollback can delete inserted vectors."""
@@ -641,12 +625,9 @@ async def _process_documents_async_pipeline(
             len(pending_tasks),
             get_process_memory_details(),
         )
-        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
-        for insert_task, result in zip(pending_tasks, results):
-            batch_num = in_flight_insert_tasks.pop(insert_task, None)
-            if batch_num is None or isinstance(result, BaseException):
-                continue
-            successful_batch_ids[batch_num] = result
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task in pending_tasks:
+            in_flight_insert_tasks.discard(insert_task)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -670,11 +651,8 @@ async def _process_documents_async_pipeline(
 
                 try:
                     # Insert batch into database
-                    batch_result_ids = await insert_batch(
-                        batch_documents, batch_ids, batch_num
-                    )
+                    batch_result_ids = await insert_batch(batch_documents, batch_ids)
                     successful_batch_ids[batch_num] = batch_result_ids
-                    await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
                     failure_event.set()
                     logger.error(
@@ -686,7 +664,6 @@ async def _process_documents_async_pipeline(
                         e,
                         get_process_memory_details(),
                     )
-                    await results_queue.put((batch_num, e))  # Put exception object
                     raise
                 finally:
                     embedding_queue.task_done()
@@ -695,7 +672,6 @@ async def _process_documents_async_pipeline(
             if not failure_event.is_set():
                 failure_event.set()
                 logger.error("Fatal error in embedding consumer: %s", e)
-                await results_queue.put((None, e))
             raise
 
     producer_task = None
@@ -710,12 +686,6 @@ async def _process_documents_async_pipeline(
 
         # Wait for all tasks to complete
         await asyncio.gather(producer_task, *consumer_tasks, return_exceptions=False)
-
-        # Collect results from all batches
-        for _ in range(num_batches):
-            batch_num, result = await results_queue.get()
-            if isinstance(result, Exception):
-                raise result
 
         for batch_num in range(1, num_batches + 1):
             all_ids.extend(successful_batch_ids[batch_num])
@@ -757,30 +727,28 @@ async def _process_documents_async_pipeline(
 
         await wait_for_in_flight_inserts()
 
-        # Attempt rollback only if we inserted something
-        if successful_batch_ids:
-            try:
-                logger.warning(
-                    "Performing rollback | user_id=%s | file_id=%s | %s",
-                    user_id,
-                    file_id,
-                    get_process_memory_details(),
-                )
-                await vector_store.delete(ids=[file_id], executor=executor)
-                logger.info(
-                    "Rollback completed | user_id=%s | file_id=%s | %s",
-                    user_id,
-                    file_id,
-                    get_process_memory_details(),
-                )
-            except Exception as cleanup_error:
-                logger.error(
-                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
-                    user_id,
-                    file_id,
-                    cleanup_error,
-                    get_process_memory_details(),
-                )
+        try:
+            logger.warning(
+                "Performing rollback | user_id=%s | file_id=%s | %s",
+                user_id,
+                file_id,
+                get_process_memory_details(),
+            )
+            await vector_store.delete(ids=[file_id], executor=executor)
+            logger.info(
+                "Rollback completed | user_id=%s | file_id=%s | %s",
+                user_id,
+                file_id,
+                get_process_memory_details(),
+            )
+        except Exception as cleanup_error:
+            logger.error(
+                "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                user_id,
+                file_id,
+                cleanup_error,
+                get_process_memory_details(),
+            )
 
         # Re-raise the original error
         raise

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -6,6 +6,8 @@ import hashlib
 import traceback
 import aiofiles
 import aiofiles.os
+import asyncio
+import time
 from shutil import copyfileobj
 from typing import List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
@@ -23,7 +25,6 @@ from fastapi import (
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from functools import lru_cache
-import asyncio
 
 if TYPE_CHECKING:
     from app.services.vector_store.async_pg_vector import AsyncPgVector
@@ -40,6 +41,7 @@ from app.config import (
     CHUNK_OVERLAP,
     EMBEDDING_BATCH_SIZE,
     EMBEDDING_MAX_QUEUE_SIZE,
+    PARALLEL_EXECUTION,
     RAG_DISTANCE_THRESHOLD,
 )
 
@@ -110,6 +112,84 @@ def get_user_id(request: Request, entity_id: str = None) -> str:
         return entity_id if entity_id else "public"
     else:
         return entity_id if entity_id else request.state.user.get("id")
+
+
+def get_file_size_bytes(file_path: Optional[str]) -> Optional[int]:
+    """Return file size in bytes when available."""
+    if not file_path:
+        return None
+    try:
+        return os.path.getsize(file_path)
+    except OSError:
+        return None
+
+
+def get_process_memory_details() -> str:
+    """Return lightweight process memory details for logging."""
+    parts = []
+
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as status_file:
+            for line in status_file:
+                if line.startswith("VmRSS:"):
+                    rss_kib = int(line.split()[1])
+                    parts.append(f"rss_mb={rss_kib / 1024:.1f}")
+                elif line.startswith("VmHWM:"):
+                    hwm_kib = int(line.split()[1])
+                    parts.append(f"rss_peak_mb={hwm_kib / 1024:.1f}")
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        pass
+
+    try:
+        import resource
+
+        max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if os.name == "posix":
+            max_rss_mb = max_rss / 1024
+        else:
+            max_rss_mb = max_rss / (1024 * 1024)
+
+        if not any(part.startswith("rss_peak_mb=") for part in parts):
+            parts.append(f"rss_peak_mb={max_rss_mb:.1f}")
+    except (ImportError, AttributeError, OSError, ValueError):
+        pass
+
+    return " | ".join(parts) if parts else "rss_mb=unknown"
+
+
+def build_ingestion_context(
+    route_name: str,
+    user_id: str,
+    file_id: str,
+    filename: str,
+    content_type: Optional[str] = None,
+    temp_file_path: Optional[str] = None,
+    known_type: Optional[str] = None,
+    file_ext: Optional[str] = None,
+    chunk_count: Optional[int] = None,
+) -> str:
+    """Build a compact ingestion context string for logs."""
+    parts = [
+        f"route={route_name}",
+        f"user_id={user_id}",
+        f"file_id={file_id}",
+        f"filename={filename}",
+    ]
+    if content_type:
+        parts.append(f"content_type={content_type}")
+    if temp_file_path:
+        parts.append(f"temp_path={temp_file_path}")
+        file_size_bytes = get_file_size_bytes(temp_file_path)
+        if file_size_bytes is not None:
+            parts.append(f"file_size_bytes={file_size_bytes}")
+    if known_type:
+        parts.append(f"known_type={known_type}")
+    if file_ext:
+        parts.append(f"file_ext={file_ext}")
+    if chunk_count is not None:
+        parts.append(f"chunk_count={chunk_count}")
+    parts.append(get_process_memory_details())
+    return " | ".join(parts)
 
 
 async def save_upload_file_async(file: UploadFile, temp_file_path: str) -> None:
@@ -446,6 +526,8 @@ async def _process_documents_async_pipeline(
     file_id: str,
     vector_store: "AsyncPgVector",
     executor: "ThreadPoolExecutor",
+    parallel_execution: int = 1,
+    user_id: str = "",
 ) -> List[str]:
     """
     Process documents using async producer-consumer pattern for batched embedding and insertion.
@@ -471,14 +553,19 @@ async def _process_documents_async_pipeline(
     embedding_queue = asyncio.Queue(maxsize=EMBEDDING_MAX_QUEUE_SIZE)
     results_queue = asyncio.Queue()
     all_ids = []
+    successful_batch_ids = {}
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
+    consumer_count = max(1, min(parallel_execution, num_batches))
 
     logger.info(
-        "Starting async pipeline for file %s: %d chunks with %d batch size",
+        "Starting async pipeline | user_id=%s | file_id=%s | total_chunks=%d | batch_size=%d | consumers=%d | %s",
+        user_id,
         file_id,
         total_chunks,
         EMBEDDING_BATCH_SIZE,
+        consumer_count,
+        get_process_memory_details(),
     )
 
     async def batch_producer():
@@ -491,11 +578,15 @@ async def _process_documents_async_pipeline(
                 batch_ids = [file_id] * len(batch_documents)
 
                 logger.info(
-                    "Generating embeddings for batch %d/%d: chunks %d-%d",
+                    "Queueing batch | user_id=%s | file_id=%s | batch=%d/%d | chunk_range=%d-%d | batch_chunks=%d | %s",
+                    user_id,
+                    file_id,
                     batch_idx + 1,
                     num_batches,
                     start_idx,
                     end_idx - 1,
+                    len(batch_documents),
+                    get_process_memory_details(),
                 )
 
                 # Put batch in queue for processing
@@ -507,7 +598,8 @@ async def _process_documents_async_pipeline(
             raise
         finally:
             # Always signal end of production
-            await embedding_queue.put(None)
+            for _ in range(consumer_count):
+                await embedding_queue.put(None)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -521,10 +613,13 @@ async def _process_documents_async_pipeline(
                 batch_documents, batch_ids, batch_num, total_batches = item
 
                 logger.info(
-                    "Inserting batch %d/%d into database (%d chunks)",
+                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d | %s",
+                    user_id,
+                    file_id,
                     batch_num,
                     total_batches,
                     len(batch_documents),
+                    get_process_memory_details(),
                 )
 
                 try:
@@ -532,73 +627,108 @@ async def _process_documents_async_pipeline(
                     batch_result_ids = await vector_store.aadd_documents(
                         batch_documents, ids=batch_ids, executor=executor
                     )
-                    await results_queue.put(batch_result_ids)
+                    successful_batch_ids[batch_num] = batch_result_ids
+                    await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
                     logger.error(
-                        "Error processing batch %d/%d: %s", batch_num, total_batches, e
+                        "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
+                        user_id,
+                        file_id,
+                        batch_num,
+                        total_batches,
+                        e,
+                        get_process_memory_details(),
                     )
-                    await results_queue.put(e)  # Put exception object
+                    await results_queue.put((batch_num, e))  # Put exception object
                 finally:
                     embedding_queue.task_done()
 
         except Exception as e:
             logger.error("Fatal error in embedding consumer: %s", e)
-            await results_queue.put(e)
+            await results_queue.put((None, e))
             raise
 
     producer_task = None
-    consumer_task = None
+    consumer_tasks: List[asyncio.Task] = []
 
     try:
-        # Start producer and consumer concurrently
+        # Start producer and consumers concurrently
         producer_task = asyncio.create_task(batch_producer())
-        consumer_task = asyncio.create_task(embedding_consumer())
+        consumer_tasks = [
+            asyncio.create_task(embedding_consumer()) for _ in range(consumer_count)
+        ]
 
-        # Wait for both to complete
-        await asyncio.gather(producer_task, consumer_task, return_exceptions=False)
+        # Wait for all tasks to complete
+        await asyncio.gather(producer_task, *consumer_tasks, return_exceptions=False)
 
         # Collect results from all batches
         for _ in range(num_batches):
-            result = await results_queue.get()
+            batch_num, result = await results_queue.get()
             if isinstance(result, Exception):
                 raise result
-            all_ids.extend(result)
+
+        for batch_num in range(1, num_batches + 1):
+            all_ids.extend(successful_batch_ids[batch_num])
 
         logger.info(
-            "Async pipeline completed for file %s: %d embeddings created",
+            "Async pipeline completed | user_id=%s | file_id=%s | inserted_ids=%d | %s",
+            user_id,
             file_id,
             len(all_ids),
+            get_process_memory_details(),
         )
 
         return all_ids
 
     except Exception as e:
-        logger.error("Pipeline failed for file %s: %s", file_id, e)
-        if consumer_task is not None or producer_task is not None:
+        logger.error(
+            "Pipeline failed | user_id=%s | file_id=%s | inserted_batches=%d | error=%s | %s",
+            user_id,
+            file_id,
+            len(successful_batch_ids),
+            e,
+            get_process_memory_details(),
+        )
+        if producer_task is not None or consumer_tasks:
             # if one of the tasks is still running, cancel it
-            if consumer_task is not None and not consumer_task.done():
-                consumer_task.cancel()
             if producer_task is not None and not producer_task.done():
                 producer_task.cancel()
+            for consumer_task in consumer_tasks:
+                if not consumer_task.done():
+                    consumer_task.cancel()
 
             # Await cancelled tasks to ensure proper cleanup
-            if consumer_task is None:
-                await asyncio.gather(producer_task, return_exceptions=True)
-            elif producer_task is None:
-                await asyncio.gather(consumer_task, return_exceptions=True)
-            else:
-                await asyncio.gather(
-                    consumer_task, producer_task, return_exceptions=True
-                )
+            tasks_to_await = []
+            if producer_task is not None:
+                tasks_to_await.append(producer_task)
+            tasks_to_await.extend(consumer_tasks)
+            if tasks_to_await:
+                await asyncio.gather(*tasks_to_await, return_exceptions=True)
 
         # Attempt rollback only if we inserted something
-        if all_ids:
+        if successful_batch_ids:
             try:
-                logger.warning("Performing rollback of file %s", file_id)
+                logger.warning(
+                    "Performing rollback | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
                 await vector_store.delete(ids=[file_id], executor=executor)
-                logger.info("Rollback completed for file %s", file_id)
+                logger.info(
+                    "Rollback completed | user_id=%s | file_id=%s | %s",
+                    user_id,
+                    file_id,
+                    get_process_memory_details(),
+                )
             except Exception as cleanup_error:
-                logger.error("Rollback failed for file %s: %s", file_id, cleanup_error)
+                logger.error(
+                    "Rollback failed | user_id=%s | file_id=%s | error=%s | %s",
+                    user_id,
+                    file_id,
+                    cleanup_error,
+                    get_process_memory_details(),
+                )
 
         # Re-raise the original error
         raise
@@ -731,7 +861,12 @@ async def store_data_in_vector_db(
     user_id: str = "",
     clean_content: bool = False,
     executor=None,
+    route_name: str = "unknown",
+    filename: Optional[str] = None,
+    content_type: Optional[str] = None,
+    temp_file_path: Optional[str] = None,
 ) -> bool:
+    start_time = time.perf_counter()
     # Run document preparation in executor to avoid blocking the event loop
     loop = asyncio.get_running_loop()
     docs = await loop.run_in_executor(
@@ -741,6 +876,19 @@ async def store_data_in_vector_db(
         file_id,
         user_id,
         clean_content,
+    )
+
+    logger.info(
+        "Documents prepared | %s",
+        build_ingestion_context(
+            route_name=route_name,
+            user_id=user_id,
+            file_id=file_id,
+            filename=filename or file_id,
+            content_type=content_type,
+            temp_file_path=temp_file_path,
+            chunk_count=len(docs),
+        ),
     )
 
     try:
@@ -759,7 +907,12 @@ async def store_data_in_vector_db(
 
             if isinstance(vector_store, AsyncPgVector):
                 ids = await _process_documents_async_pipeline(
-                    docs, file_id, vector_store, executor
+                    docs,
+                    file_id,
+                    vector_store,
+                    executor,
+                    parallel_execution=max(1, PARALLEL_EXECUTION),
+                    user_id=user_id,
                 )
             else:
                 # Fallback to batched processing for sync vector stores
@@ -767,13 +920,35 @@ async def store_data_in_vector_db(
                     docs, file_id, vector_store, executor
                 )
 
+        logger.info(
+            "Ingestion completed | %s | inserted_ids=%d | elapsed_ms=%d",
+            build_ingestion_context(
+                route_name=route_name,
+                user_id=user_id,
+                file_id=file_id,
+                filename=filename or file_id,
+                content_type=content_type,
+                temp_file_path=temp_file_path,
+                chunk_count=len(docs),
+            ),
+            len(ids),
+            int((time.perf_counter() - start_time) * 1000),
+        )
         return {"message": "Documents added successfully", "ids": ids}
 
     except Exception as e:
         logger.error(
-            "Failed to store data in vector DB | File ID: %s | User ID: %s | Error: %s | Traceback: %s",
-            file_id,
-            user_id,
+            "Failed to store data in vector DB | %s | elapsed_ms=%d | Error: %s | Traceback: %s",
+            build_ingestion_context(
+                route_name=route_name,
+                user_id=user_id,
+                file_id=file_id,
+                filename=filename or file_id,
+                content_type=content_type,
+                temp_file_path=temp_file_path,
+                chunk_count=len(docs),
+            ),
+            int((time.perf_counter() - start_time) * 1000),
             str(e),
             traceback.format_exc(),
         )
@@ -784,23 +959,36 @@ async def store_data_in_vector_db(
 async def embed_local_file(
     document: StoreDocument, request: Request, entity_id: str = None
 ):
+    user_id = get_user_id(request, entity_id)
     file_path = validate_file_path(RAG_UPLOAD_DIR, document.filepath)
 
     # Check if the file exists and if it is within the allowed upload directory
     if file_path is None or not os.path.exists(file_path):
-        logger.warning("Path validation failed for local embed: %s", document.filepath)
+        logger.warning(
+            "Path validation failed for local embed | route=local_embed | user_id=%s | file_id=%s | filename=%s | requested_path=%s",
+            user_id,
+            document.file_id,
+            document.filename,
+            document.filepath,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.FILE_NOT_FOUND,
         )
 
-    if not hasattr(request.state, "user"):
-        user_id = entity_id if entity_id else "public"
-    else:
-        user_id = entity_id if entity_id else request.state.user.get("id")
-
     loader = None
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="local_embed",
+                user_id=user_id,
+                file_id=document.file_id,
+                filename=document.filename,
+                content_type=document.file_content_type,
+                temp_file_path=file_path,
+            ),
+        )
         loader, known_type, file_ext = get_loader(
             document.filename, document.file_content_type, file_path
         )
@@ -815,6 +1003,10 @@ async def embed_local_file(
             user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="local_embed",
+            filename=document.filename,
+            content_type=document.file_content_type,
+            temp_file_path=file_path,
         )
 
         if result:
@@ -831,13 +1023,23 @@ async def embed_local_file(
             )
     except HTTPException as http_exc:
         logger.error(
-            "HTTP Exception in embed_local_file | Status: %d | Detail: %s",
+            "HTTP Exception in embed_local_file | route=local_embed | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            document.file_id,
+            document.filename,
             http_exc.status_code,
             http_exc.detail,
         )
         raise http_exc
     except Exception as e:
-        logger.error(e)
+        logger.error(
+            "Unhandled exception in embed_local_file | route=local_embed | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            document.file_id,
+            document.filename,
+            str(e),
+            traceback.format_exc(),
+        )
         if "No pandoc was found" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -869,13 +1071,29 @@ async def embed_file(
     validated_file_path = _make_unique_temp_path(user_id, file.filename)
 
     if validated_file_path is None:
-        logger.warning("Path validation failed for embed: %s", file.filename)
+        logger.warning(
+            "Path validation failed for embed | route=embed | user_id=%s | file_id=%s | filename=%s",
+            user_id,
+            file_id,
+            file.filename,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT("Invalid request"),
         )
 
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="embed",
+                user_id=user_id,
+                file_id=file_id,
+                filename=file.filename,
+                content_type=file.content_type,
+                temp_file_path=validated_file_path,
+            ),
+        )
         os.makedirs(os.path.dirname(validated_file_path), exist_ok=True)
         await save_upload_file_async(file, validated_file_path)
         data, known_type, file_ext = await load_file_content(
@@ -885,12 +1103,18 @@ async def embed_file(
             request.app.state.thread_pool,
         )
 
+        logger.debug(f"Loading Filename:{file.filename} - ContentType:{file.content_type} - FileExt:{file_ext} - KnownType:{known_type}")
+
         result = await store_data_in_vector_db(
             data=data,
             file_id=file_id,
             user_id=user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="embed",
+            filename=file.filename,
+            content_type=file.content_type,
+            temp_file_path=validated_file_path,
         )
 
         if not result:
@@ -914,7 +1138,10 @@ async def embed_file(
         response_status = False
         response_message = f"HTTP Exception: {http_exc.detail}"
         logger.error(
-            "HTTP Exception in embed_file | Status: %d | Detail: %s",
+            "HTTP Exception in embed_file | route=embed | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            file_id,
+            file.filename,
             http_exc.status_code,
             http_exc.detail,
         )
@@ -923,7 +1150,10 @@ async def embed_file(
         response_status = False
         response_message = f"Error during file processing: {str(e)}"
         logger.error(
-            "Error during file processing: %s\nTraceback: %s",
+            "Error during file processing | route=embed | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            file_id,
+            file.filename,
             str(e),
             traceback.format_exc(),
         )
@@ -1004,7 +1234,10 @@ async def embed_file_upload(
 
     if validated_temp_file_path is None:
         logger.warning(
-            "Path validation failed for embed-upload: %s", uploaded_file.filename
+            "Path validation failed for embed-upload | route=embed_upload | user_id=%s | file_id=%s | filename=%s",
+            user_id,
+            file_id,
+            uploaded_file.filename,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1012,6 +1245,17 @@ async def embed_file_upload(
         )
 
     try:
+        logger.info(
+            "Ingestion started | %s",
+            build_ingestion_context(
+                route_name="embed_upload",
+                user_id=user_id,
+                file_id=file_id,
+                filename=uploaded_file.filename,
+                content_type=uploaded_file.content_type,
+                temp_file_path=validated_temp_file_path,
+            ),
+        )
         os.makedirs(os.path.dirname(validated_temp_file_path), exist_ok=True)
         await save_upload_file_async(uploaded_file, validated_temp_file_path)
         data, known_type, file_ext = await load_file_content(
@@ -1027,6 +1271,10 @@ async def embed_file_upload(
             user_id,
             clean_content=file_ext == "pdf",
             executor=request.app.state.thread_pool,
+            route_name="embed_upload",
+            filename=uploaded_file.filename,
+            content_type=uploaded_file.content_type,
+            temp_file_path=validated_temp_file_path,
         )
 
         if not result:
@@ -1036,14 +1284,19 @@ async def embed_file_upload(
             )
     except HTTPException as http_exc:
         logger.error(
-            "HTTP Exception in embed_file_upload | Status: %d | Detail: %s",
+            "HTTP Exception in embed_file_upload | route=embed_upload | user_id=%s | file_id=%s | filename=%s | status=%d | detail=%s",
+            user_id,
+            file_id,
+            uploaded_file.filename,
             http_exc.status_code,
             http_exc.detail,
         )
         raise http_exc
     except Exception as e:
         logger.error(
-            "Error during file processing | File: %s | Error: %s | Traceback: %s",
+            "Error during file processing | route=embed_upload | user_id=%s | file_id=%s | filename=%s | error=%s | traceback=%s",
+            user_id,
+            file_id,
             uploaded_file.filename,
             str(e),
             traceback.format_exc(),

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -9,7 +9,7 @@ import aiofiles.os
 import asyncio
 import time
 from shutil import copyfileobj
-from typing import List, Iterable, Optional, Union, TYPE_CHECKING
+from typing import Dict, List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import (
     APIRouter,
@@ -556,6 +556,7 @@ async def _process_documents_async_pipeline(
     all_ids = []
     successful_batch_ids = {}
     failure_event = asyncio.Event()
+    in_flight_insert_tasks: Dict[asyncio.Task, int] = {}
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -607,6 +608,46 @@ async def _process_documents_async_pipeline(
                 for _ in range(consumer_count):
                     await embedding_queue.put(None)
 
+    async def insert_batch(
+        batch_documents: List[Document], batch_ids: List[str], batch_num: int
+    ) -> List[str]:
+        """Track started inserts so rollback waits for executor-backed work."""
+        insert_task = asyncio.create_task(
+            vector_store.aadd_documents(
+                batch_documents, ids=batch_ids, executor=executor
+            )
+        )
+        in_flight_insert_tasks[insert_task] = batch_num
+        try:
+            return await asyncio.shield(insert_task)
+        finally:
+            if insert_task.done():
+                in_flight_insert_tasks.pop(insert_task, None)
+                try:
+                    successful_batch_ids.setdefault(batch_num, insert_task.result())
+                except BaseException:
+                    pass
+
+    async def wait_for_in_flight_inserts() -> None:
+        """Wait for started inserts before rollback can delete inserted vectors."""
+        if not in_flight_insert_tasks:
+            return
+
+        pending_tasks = list(in_flight_insert_tasks)
+        logger.warning(
+            "Waiting for in-flight inserts before rollback | user_id=%s | file_id=%s | inserts=%d | %s",
+            user_id,
+            file_id,
+            len(pending_tasks),
+            get_process_memory_details(),
+        )
+        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task, result in zip(pending_tasks, results):
+            batch_num = in_flight_insert_tasks.pop(insert_task, None)
+            if batch_num is None or isinstance(result, BaseException):
+                continue
+            successful_batch_ids[batch_num] = result
+
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
         try:
@@ -629,8 +670,8 @@ async def _process_documents_async_pipeline(
 
                 try:
                     # Insert batch into database
-                    batch_result_ids = await vector_store.aadd_documents(
-                        batch_documents, ids=batch_ids, executor=executor
+                    batch_result_ids = await insert_batch(
+                        batch_documents, batch_ids, batch_num
                     )
                     successful_batch_ids[batch_num] = batch_result_ids
                     await results_queue.put((batch_num, batch_result_ids))
@@ -713,6 +754,8 @@ async def _process_documents_async_pipeline(
             tasks_to_await.extend(consumer_tasks)
             if tasks_to_await:
                 await asyncio.gather(*tasks_to_await, return_exceptions=True)
+
+        await wait_for_in_flight_inserts()
 
         # Attempt rollback only if we inserted something
         if successful_batch_ids:

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -555,6 +555,7 @@ async def _process_documents_async_pipeline(
     results_queue = asyncio.Queue()
     all_ids = []
     successful_batch_ids = {}
+    failure_event = asyncio.Event()
 
     num_batches = calculate_num_batches(total_chunks, EMBEDDING_BATCH_SIZE)
     consumer_count = max(1, min(parallel_execution, num_batches))
@@ -573,6 +574,9 @@ async def _process_documents_async_pipeline(
         """Produce document batches and put them in the queue."""
         try:
             for batch_idx in range(num_batches):
+                if failure_event.is_set():
+                    break
+
                 start_idx = batch_idx * EMBEDDING_BATCH_SIZE
                 end_idx = min(start_idx + EMBEDDING_BATCH_SIZE, total_chunks)
                 batch_documents = documents[start_idx:end_idx]
@@ -594,12 +598,14 @@ async def _process_documents_async_pipeline(
                     (batch_documents, batch_ids, batch_idx + 1, num_batches)
                 )
         except Exception as e:
+            failure_event.set()
             logger.error("Error in batch producer: %s", e)
             raise
         finally:
-            # Always signal end of production
-            for _ in range(consumer_count):
-                await embedding_queue.put(None)
+            # Signal normal completion; failure paths are cancelled by the caller.
+            if not failure_event.is_set():
+                for _ in range(consumer_count):
+                    await embedding_queue.put(None)
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""
@@ -629,6 +635,7 @@ async def _process_documents_async_pipeline(
                     successful_batch_ids[batch_num] = batch_result_ids
                     await results_queue.put((batch_num, batch_result_ids))
                 except Exception as e:
+                    failure_event.set()
                     logger.error(
                         "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
                         user_id,
@@ -639,12 +646,15 @@ async def _process_documents_async_pipeline(
                         get_process_memory_details(),
                     )
                     await results_queue.put((batch_num, e))  # Put exception object
+                    raise
                 finally:
                     embedding_queue.task_done()
 
         except Exception as e:
-            logger.error("Fatal error in embedding consumer: %s", e)
-            await results_queue.put((None, e))
+            if not failure_event.is_set():
+                failure_event.set()
+                logger.error("Fatal error in embedding consumer: %s", e)
+                await results_queue.put((None, e))
             raise
 
     producer_task = None

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -602,7 +602,6 @@ async def _process_documents_async_pipeline(
     ) -> List[str]:
         """Track started inserts so rollback waits for executor-backed work."""
         nonlocal cleanup_needed
-        cleanup_needed = True
         insert_task = asyncio.create_task(
             vector_store.aadd_documents(
                 batch_documents, ids=batch_ids, executor=executor
@@ -610,13 +609,16 @@ async def _process_documents_async_pipeline(
         )
         in_flight_insert_tasks.add(insert_task)
         try:
-            return await asyncio.shield(insert_task)
+            batch_result_ids = await asyncio.shield(insert_task)
+            cleanup_needed = True
+            return batch_result_ids
         finally:
             if insert_task.done():
                 in_flight_insert_tasks.discard(insert_task)
 
     async def wait_for_in_flight_inserts() -> None:
         """Wait for started inserts before rollback can delete inserted vectors."""
+        nonlocal cleanup_needed
         if not in_flight_insert_tasks:
             return
 
@@ -628,9 +630,11 @@ async def _process_documents_async_pipeline(
             len(pending_tasks),
             get_process_memory_details(),
         )
-        await asyncio.gather(*pending_tasks, return_exceptions=True)
-        for insert_task in pending_tasks:
+        results = await asyncio.gather(*pending_tasks, return_exceptions=True)
+        for insert_task, result in zip(pending_tasks, results):
             in_flight_insert_tasks.discard(insert_task)
+            if not isinstance(result, BaseException):
+                cleanup_needed = True
 
     async def embedding_consumer():
         """Consume batches from queue, embed and insert into database."""

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -101,6 +101,38 @@ from app.utils.health import is_health_ok
 router = APIRouter()
 
 _INGESTION_ATTEMPT_ID_KEY = "_rag_ingestion_attempt_id"
+_INGESTION_CHUNK_INDEX_KEY = "_rag_chunk_index"
+
+
+def _order_documents_by_chunk_index(documents: List[Document]) -> List[Document]:
+    """Restore source order for documents carrying ingestion chunk indexes.
+
+    Legacy or mixed-version rows may not have a trustworthy index. Preserve their
+    existing iteration order instead of guessing when an index is missing, invalid,
+    or duplicated.
+    """
+    ordered_documents = list(documents)
+    chunk_indexes = []
+
+    for document in ordered_documents:
+        chunk_index = (document.metadata or {}).get(_INGESTION_CHUNK_INDEX_KEY)
+        if (
+            isinstance(chunk_index, bool)
+            or not isinstance(chunk_index, int)
+            or chunk_index < 0
+        ):
+            return ordered_documents
+        chunk_indexes.append(chunk_index)
+
+    if len(set(chunk_indexes)) != len(chunk_indexes):
+        return ordered_documents
+
+    return [
+        document
+        for _, document in sorted(
+            zip(chunk_indexes, ordered_documents), key=lambda item: item[0]
+        )
+    ]
 
 
 def calculate_num_batches(total: int, batch_size: int) -> int:
@@ -543,9 +575,11 @@ async def _process_documents_async_pipeline(
         return []
 
     ingestion_attempt_id = uuid.uuid4().hex
-    for document in documents:
+    for chunk_index, document in enumerate(documents):
         document.metadata = {
             **(document.metadata or {}),
+            "file_id": file_id,
+            _INGESTION_CHUNK_INDEX_KEY: chunk_index,
             _INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id,
         }
 
@@ -766,7 +800,10 @@ async def _process_documents_async_pipeline(
                     get_process_memory_details(),
                 )
                 await vector_store.delete_by_metadata(
-                    {_INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id},
+                    {
+                        "file_id": file_id,
+                        _INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id,
+                    },
                     executor=executor,
                 )
                 logger.info(
@@ -1263,7 +1300,7 @@ async def load_document_context(request: Request, id: str):
                 status_code=404, detail="No document found for the given ID"
             )
 
-        return process_documents(documents)
+        return process_documents(_order_documents_by_chunk_index(documents))
     except HTTPException as http_exc:
         logger.error(
             "HTTP Exception in load_document_context | Status: %d | Detail: %s",

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -712,7 +712,7 @@ async def _process_documents_async_pipeline(
 
         return all_ids
 
-    except Exception as e:
+    except (Exception, asyncio.CancelledError) as e:
         logger.error(
             "Pipeline failed | user_id=%s | file_id=%s | inserted_batches=%d | error=%s | %s",
             user_id,
@@ -1139,7 +1139,13 @@ async def embed_file(
             request.app.state.thread_pool,
         )
 
-        logger.debug(f"Loading Filename:{file.filename} - ContentType:{file.content_type} - FileExt:{file_ext} - KnownType:{known_type}")
+        logger.debug(
+            "Loading file | filename=%s | content_type=%s | file_ext=%s | known_type=%s",
+            file.filename,
+            file.content_type,
+            file_ext,
+            known_type,
+        )
 
         result = await store_data_in_vector_db(
             data=data,

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -101,38 +101,85 @@ from app.utils.health import is_health_ok
 router = APIRouter()
 
 _INGESTION_ATTEMPT_ID_KEY = "_rag_ingestion_attempt_id"
+_INGESTION_ATTEMPT_STARTED_AT_NS_KEY = "_rag_ingestion_attempt_started_at_ns"
 _INGESTION_CHUNK_INDEX_KEY = "_rag_chunk_index"
 
 
+def _tag_documents_for_ingestion(documents: List[Document], file_id: str) -> str:
+    """Attach one attempt identity and source position to every document."""
+    ingestion_attempt_id = uuid.uuid4().hex
+    ingestion_attempt_started_at_ns = time.time_ns()
+
+    for chunk_index, document in enumerate(documents):
+        document.metadata = {
+            **(document.metadata or {}),
+            "file_id": file_id,
+            _INGESTION_CHUNK_INDEX_KEY: chunk_index,
+            _INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id,
+            _INGESTION_ATTEMPT_STARTED_AT_NS_KEY: ingestion_attempt_started_at_ns,
+        }
+
+    return ingestion_attempt_id
+
+
 def _order_documents_by_chunk_index(documents: List[Document]) -> List[Document]:
-    """Restore source order for documents carrying ingestion chunk indexes.
+    """Group ingestion attempts and restore source order within each group.
 
-    Legacy or mixed-version rows may not have a trustworthy index. Preserve their
-    existing iteration order instead of guessing when an index is missing, invalid,
-    or duplicated.
+    Repeated ingestions intentionally retain every row currently returned by the
+    vector store. Legacy rows stay first in their received order, followed by marked
+    attempts in start-time order. Within a group, preserve received order instead of
+    guessing when a chunk index is missing, invalid, or duplicated.
     """
-    ordered_documents = list(documents)
-    chunk_indexes = []
 
-    for document in ordered_documents:
-        chunk_index = (document.metadata or {}).get(_INGESTION_CHUNK_INDEX_KEY)
+    def order_group(group: List[Document]) -> List[Document]:
+        received_group = list(group)
+        chunk_indexes = []
+
+        for document in received_group:
+            chunk_index = (document.metadata or {}).get(_INGESTION_CHUNK_INDEX_KEY)
+            if (
+                isinstance(chunk_index, bool)
+                or not isinstance(chunk_index, int)
+                or chunk_index < 0
+            ):
+                return received_group
+            chunk_indexes.append(chunk_index)
+
+        if len(set(chunk_indexes)) != len(chunk_indexes):
+            return received_group
+
+        return [
+            document
+            for _, document in sorted(
+                zip(chunk_indexes, received_group), key=lambda item: item[0]
+            )
+        ]
+
+    attempt_groups = {}
+    legacy_documents = []
+    for document in documents:
+        metadata = document.metadata or {}
+        attempt_id = metadata.get(_INGESTION_ATTEMPT_ID_KEY)
+        started_at_ns = metadata.get(_INGESTION_ATTEMPT_STARTED_AT_NS_KEY)
         if (
-            isinstance(chunk_index, bool)
-            or not isinstance(chunk_index, int)
-            or chunk_index < 0
+            not isinstance(attempt_id, str)
+            or not attempt_id
+            or isinstance(started_at_ns, bool)
+            or not isinstance(started_at_ns, int)
+            or started_at_ns < 0
         ):
-            return ordered_documents
-        chunk_indexes.append(chunk_index)
+            legacy_documents.append(document)
+            continue
 
-    if len(set(chunk_indexes)) != len(chunk_indexes):
-        return ordered_documents
+        attempt_groups.setdefault((started_at_ns, attempt_id), []).append(document)
 
-    return [
-        document
-        for _, document in sorted(
-            zip(chunk_indexes, ordered_documents), key=lambda item: item[0]
-        )
-    ]
+    if not attempt_groups:
+        return legacy_documents
+
+    ordered_documents = list(legacy_documents)
+    for attempt_key in sorted(attempt_groups):
+        ordered_documents.extend(order_group(attempt_groups[attempt_key]))
+    return ordered_documents
 
 
 def calculate_num_batches(total: int, batch_size: int) -> int:
@@ -574,14 +621,7 @@ async def _process_documents_async_pipeline(
     if total_chunks == 0:
         return []
 
-    ingestion_attempt_id = uuid.uuid4().hex
-    for chunk_index, document in enumerate(documents):
-        document.metadata = {
-            **(document.metadata or {}),
-            "file_id": file_id,
-            _INGESTION_CHUNK_INDEX_KEY: chunk_index,
-            _INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id,
-        }
+    ingestion_attempt_id = _tag_documents_for_ingestion(documents, file_id)
 
     # Create queues for producer-consumer pattern
     # embedding_queue is bounded to limit document data held in memory.
@@ -632,15 +672,18 @@ async def _process_documents_async_pipeline(
                 await embedding_queue.put(
                     (batch_documents, batch_ids, batch_idx + 1, num_batches)
                 )
+            # Signal normal completion. Failure and cancellation paths are
+            # cancelled by the caller and must never block enqueueing sentinels.
+            if not failure_event.is_set():
+                for _ in range(consumer_count):
+                    await embedding_queue.put(None)
+        except asyncio.CancelledError:
+            failure_event.set()
+            raise
         except Exception as e:
             failure_event.set()
             logger.error("Error in batch producer: %s", e)
             raise
-        finally:
-            # Signal normal completion; failure paths are cancelled by the caller.
-            if not failure_event.is_set():
-                for _ in range(consumer_count):
-                    await embedding_queue.put(None)
 
     async def insert_batch(
         batch_documents: List[Document], batch_ids: List[str]
@@ -765,6 +808,7 @@ async def _process_documents_async_pipeline(
         return all_ids
 
     except (Exception, asyncio.CancelledError) as e:
+        failure_event.set()
         logger.error(
             "Pipeline failed | user_id=%s | file_id=%s | inserted_batches=%d | error=%s | %s",
             user_id,
@@ -987,6 +1031,7 @@ async def store_data_in_vector_db(
         if EMBEDDING_BATCH_SIZE <= 0:
             # synchronously embed the file and insert into vector store in one go
             if isinstance(vector_store, AsyncPgVector):
+                _tag_documents_for_ingestion(docs, file_id)
                 ids = await vector_store.aadd_documents(
                     docs, ids=[file_id] * len(docs), executor=executor
                 )

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -1,5 +1,6 @@
 # app/routes/document_routes.py
 import os
+import sys
 import uuid
 from pathlib import Path
 import hashlib
@@ -56,10 +57,9 @@ from app.config import (
 # (so non-numeric stale values don't break startup), which means the parsed
 # value is always None for Atlas — and relying on it would suppress the
 # warning we want operators to see.
-if (
-    VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO
-    and os.getenv("RAG_DISTANCE_THRESHOLD") not in (None, "")
-):
+if VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO and os.getenv(
+    "RAG_DISTANCE_THRESHOLD"
+) not in (None, ""):
     logger.warning(
         "RAG_DISTANCE_THRESHOLD is set but VECTOR_DB_TYPE=atlas-mongo; "
         "Atlas returns similarity scores (higher = better) which would "
@@ -80,6 +80,8 @@ def _apply_distance_threshold(documents):
     if VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO:
         return documents
     return [(doc, score) for doc, score in documents if score <= RAG_DISTANCE_THRESHOLD]
+
+
 from app.constants import ERROR_MESSAGES
 from app.models import (
     StoreDocument,
@@ -97,6 +99,8 @@ from app.utils.document_loader import (
 from app.utils.health import is_health_ok
 
 router = APIRouter()
+
+_INGESTION_ATTEMPT_ID_KEY = "_rag_ingestion_attempt_id"
 
 
 def calculate_num_batches(total: int, batch_size: int) -> int:
@@ -134,10 +138,10 @@ def get_process_memory_details() -> str:
         import resource
 
         max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        if os.name == "posix":
-            max_rss_mb = max_rss / 1024
-        else:
-            max_rss_mb = max_rss / (1024 * 1024)
+        # Darwin reports ru_maxrss in bytes; Linux reports it in KiB.
+        max_rss_mb = (
+            max_rss / (1024 * 1024) if sys.platform == "darwin" else max_rss / 1024
+        )
 
         if not any(part.startswith("rss_peak_mb=") for part in parts):
             parts.append(f"rss_peak_mb={max_rss_mb:.1f}")
@@ -538,6 +542,13 @@ async def _process_documents_async_pipeline(
     if total_chunks == 0:
         return []
 
+    ingestion_attempt_id = uuid.uuid4().hex
+    for document in documents:
+        document.metadata = {
+            **(document.metadata or {}),
+            _INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id,
+        }
+
     # Create queues for producer-consumer pattern
     # embedding_queue is bounded to limit document data held in memory.
     embedding_queue = asyncio.Queue(maxsize=EMBEDDING_MAX_QUEUE_SIZE)
@@ -646,37 +657,44 @@ async def _process_documents_async_pipeline(
         try:
             while True:
                 item = await embedding_queue.get()
-                if item is None:  # End signal
-                    embedding_queue.task_done()
-                    break
-
-                batch_documents, batch_ids, batch_num, total_batches = item
-
-                logger.debug(
-                    "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d",
-                    user_id,
-                    file_id,
-                    batch_num,
-                    total_batches,
-                    len(batch_documents),
-                )
-
                 try:
-                    # Insert batch into database
-                    batch_result_ids = await insert_batch(batch_documents, batch_ids)
-                    successful_batch_ids[batch_num] = batch_result_ids
-                except Exception as e:
-                    failure_event.set()
-                    logger.error(
-                        "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
+                    if item is None:  # End signal
+                        break
+
+                    # A peer can fail before gather() resumes and cancels this task.
+                    # Acknowledge already-queued work without starting another insert.
+                    if failure_event.is_set():
+                        continue
+
+                    batch_documents, batch_ids, batch_num, total_batches = item
+
+                    logger.debug(
+                        "Inserting batch | user_id=%s | file_id=%s | batch=%d/%d | batch_chunks=%d",
                         user_id,
                         file_id,
                         batch_num,
                         total_batches,
-                        e,
-                        get_process_memory_details(),
+                        len(batch_documents),
                     )
-                    raise
+
+                    try:
+                        # Insert batch into database
+                        batch_result_ids = await insert_batch(
+                            batch_documents, batch_ids
+                        )
+                        successful_batch_ids[batch_num] = batch_result_ids
+                    except Exception as e:
+                        failure_event.set()
+                        logger.error(
+                            "Error processing batch | user_id=%s | file_id=%s | batch=%d/%d | error=%s | %s",
+                            user_id,
+                            file_id,
+                            batch_num,
+                            total_batches,
+                            e,
+                            get_process_memory_details(),
+                        )
+                        raise
                 finally:
                     embedding_queue.task_done()
 
@@ -747,7 +765,10 @@ async def _process_documents_async_pipeline(
                     file_id,
                     get_process_memory_details(),
                 )
-                await vector_store.delete(ids=[file_id], executor=executor)
+                await vector_store.delete_by_metadata(
+                    {_INGESTION_ATTEMPT_ID_KEY: ingestion_attempt_id},
+                    executor=executor,
+                )
                 logger.info(
                     "Rollback completed | user_id=%s | file_id=%s | %s",
                     user_id,

--- a/app/services/vector_store/async_pg_vector.py
+++ b/app/services/vector_store/async_pg_vector.py
@@ -69,6 +69,13 @@ class AsyncPgVector(ExtendedPgVector):
             executor, self._delete_multiple, ids, collection_only
         )
 
+    async def delete_by_metadata(
+        self, metadata_filter: Dict[str, Any], executor=None
+    ) -> None:
+        """Delete only rows in this collection that match metadata values."""
+        executor = executor or self._get_thread_pool()
+        await self._run_in_executor(executor, self._delete_by_metadata, metadata_filter)
+
     async def asimilarity_search_with_score_by_vector(
         self,
         embedding: List[float],

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -198,6 +198,26 @@ class ExtendedPgVector(PGVector):
                 if result.custom_id in ids
             ]
 
+    def _delete_by_metadata(self, metadata_filter: Dict[str, Any]) -> None:
+        """Delete rows in this collection that exactly match metadata values."""
+        if not metadata_filter:
+            raise ValueError("metadata_filter must not be empty")
+
+        with Session(self._bind) as session:
+            collection = self.get_collection(session)
+            if not collection:
+                self.logger.warning("Collection not found")
+                return
+
+            stmt = delete(self.EmbeddingStore).where(
+                self.EmbeddingStore.collection_id == collection.uuid
+            )
+            for field, value in metadata_filter.items():
+                stmt = stmt.where(self._handle_field_filter(field, value))
+
+            session.execute(stmt)
+            session.commit()
+
     def _delete_multiple(
         self, ids: Optional[list[str]] = None, collection_only: bool = False
     ) -> None:

--- a/tests/integration/test_pgvector_filter.py
+++ b/tests/integration/test_pgvector_filter.py
@@ -180,6 +180,38 @@ class TestQueryPlanRegression:
             f"Got plan: {json.dumps(plan_json, indent=2)}"
         )
 
+    def test_rollback_predicate_uses_file_id_index(
+        self, engine, collection_id, seeded_data
+    ):
+        """Attempt rollback can narrow by file ID before checking its marker."""
+        _, target_file_id = seeded_data
+
+        with engine.begin() as conn:
+            plan_json = conn.execute(
+                text(
+                    "EXPLAIN (FORMAT JSON) "
+                    "DELETE FROM langchain_pg_embedding "
+                    "WHERE collection_id = :cid "
+                    "AND (cmetadata->>'file_id') = :fid "
+                    "AND (cmetadata->>'_rag_ingestion_attempt_id') = :attempt"
+                ),
+                {
+                    "cid": collection_id,
+                    "fid": target_file_id,
+                    "attempt": uuid.uuid4().hex,
+                },
+            ).scalar()
+
+        index_names = {
+            node.get("Index Name")
+            for node in _walk_plan_nodes(plan_json)
+            if node.get("Index Name")
+        }
+        assert "idx_langchain_pg_embedding_file_id" in index_names, (
+            "Expected rollback DELETE to use the file_id expression index.\n"
+            f"Got plan: {json.dumps(plan_json, indent=2)}"
+        )
+
     def test_jsonb_path_match_forces_seq_scan(self, engine, seeded_data):
         """The bug: jsonb_path_match() cannot use the expression index."""
         _, target_file_id = seeded_data
@@ -402,6 +434,7 @@ class TestExtendedPgVectorSQL:
     ):
         """Attempt-scoped rollback must preserve prior and concurrent rows."""
         file_id = f"file-{uuid.uuid4().hex[:8]}"
+        other_file_id = f"file-{uuid.uuid4().hex[:8]}"
         cancelled_attempt = uuid.uuid4().hex
         successful_attempt = uuid.uuid4().hex
 
@@ -421,6 +454,13 @@ class TestExtendedPgVectorSQL:
                     "_rag_ingestion_attempt_id": cancelled_attempt,
                 },
             ),
+            (
+                "other-file-same-attempt",
+                {
+                    "file_id": other_file_id,
+                    "_rag_ingestion_attempt_id": cancelled_attempt,
+                },
+            ),
         ]
         with engine.begin() as conn:
             for document, metadata in rows:
@@ -435,13 +475,18 @@ class TestExtendedPgVectorSQL:
                         "emb": "[0.1,0.2,0.3]",
                         "doc": document,
                         "meta": json.dumps(metadata),
-                        "cust": file_id,
+                        "cust": metadata["file_id"],
                     },
                 )
 
         store._bind = engine
         store.get_collection = lambda session: SimpleNamespace(uuid=collection_id)
-        store._delete_by_metadata({"_rag_ingestion_attempt_id": cancelled_attempt})
+        store._delete_by_metadata(
+            {
+                "file_id": file_id,
+                "_rag_ingestion_attempt_id": cancelled_attempt,
+            }
+        )
 
         with engine.begin() as conn:
             remaining = (
@@ -449,16 +494,20 @@ class TestExtendedPgVectorSQL:
                     text(
                         "SELECT document FROM langchain_pg_embedding "
                         "WHERE collection_id = :cid "
-                        "AND cmetadata->>'file_id' = :fid "
+                        "AND cmetadata->>'file_id' IN (:fid, :other_fid) "
                         "ORDER BY document"
                     ),
-                    {"cid": collection_id, "fid": file_id},
+                    {
+                        "cid": collection_id,
+                        "fid": file_id,
+                        "other_fid": other_file_id,
+                    },
                 )
                 .scalars()
                 .all()
             )
 
-        assert remaining == ["existing", "successful"]
+        assert remaining == ["existing", "other-file-same-attempt", "successful"]
 
     def test_ne_clause_runs_on_real_pg(self, engine, collection_id, store):
         target_file = f"file-{uuid.uuid4().hex[:8]}"

--- a/tests/integration/test_pgvector_filter.py
+++ b/tests/integration/test_pgvector_filter.py
@@ -11,6 +11,7 @@ import json
 import math
 import random
 import uuid
+from types import SimpleNamespace
 
 import pytest
 import sqlalchemy
@@ -395,6 +396,69 @@ class TestExtendedPgVectorSQL:
             results = query.all()
             assert len(results) == 10
             assert all(r.cmetadata["file_id"] == target_file for r in results)
+
+    def test_delete_by_metadata_preserves_same_file_rows(
+        self, engine, collection_id, store
+    ):
+        """Attempt-scoped rollback must preserve prior and concurrent rows."""
+        file_id = f"file-{uuid.uuid4().hex[:8]}"
+        cancelled_attempt = uuid.uuid4().hex
+        successful_attempt = uuid.uuid4().hex
+
+        rows = [
+            ("existing", {"file_id": file_id}),
+            (
+                "successful",
+                {
+                    "file_id": file_id,
+                    "_rag_ingestion_attempt_id": successful_attempt,
+                },
+            ),
+            (
+                "cancelled",
+                {
+                    "file_id": file_id,
+                    "_rag_ingestion_attempt_id": cancelled_attempt,
+                },
+            ),
+        ]
+        with engine.begin() as conn:
+            for document, metadata in rows:
+                conn.execute(
+                    text(
+                        "INSERT INTO langchain_pg_embedding "
+                        "(collection_id, embedding, document, cmetadata, custom_id) "
+                        "VALUES (:cid, :emb, :doc, :meta, :cust)"
+                    ),
+                    {
+                        "cid": collection_id,
+                        "emb": "[0.1,0.2,0.3]",
+                        "doc": document,
+                        "meta": json.dumps(metadata),
+                        "cust": file_id,
+                    },
+                )
+
+        store._bind = engine
+        store.get_collection = lambda session: SimpleNamespace(uuid=collection_id)
+        store._delete_by_metadata({"_rag_ingestion_attempt_id": cancelled_attempt})
+
+        with engine.begin() as conn:
+            remaining = (
+                conn.execute(
+                    text(
+                        "SELECT document FROM langchain_pg_embedding "
+                        "WHERE collection_id = :cid "
+                        "AND cmetadata->>'file_id' = :fid "
+                        "ORDER BY document"
+                    ),
+                    {"cid": collection_id, "fid": file_id},
+                )
+                .scalars()
+                .all()
+            )
+
+        assert remaining == ["existing", "successful"]
 
     def test_ne_clause_runs_on_real_pg(self, engine, collection_id, store):
         target_file = f"file-{uuid.uuid4().hex[:8]}"

--- a/tests/services/test_async_pg_vector.py
+++ b/tests/services/test_async_pg_vector.py
@@ -59,6 +59,14 @@ async def test_delete_passes_args(store):
 
 
 @pytest.mark.asyncio
+async def test_delete_by_metadata_passes_filter(store):
+    metadata_filter = {"_rag_ingestion_attempt_id": "attempt-123"}
+    with patch.object(ExtendedPgVector, "_delete_by_metadata") as mock:
+        await store.delete_by_metadata(metadata_filter)
+    mock.assert_called_once_with(metadata_filter)
+
+
+@pytest.mark.asyncio
 async def test_asimilarity_search_passes_args(store):
     expected = [(Document(page_content="test", metadata={}), 0.9)]
     with patch.object(

--- a/tests/services/test_vector_store.py
+++ b/tests/services/test_vector_store.py
@@ -41,13 +41,20 @@ def test_delete_by_metadata_is_collection_scoped():
 
     with patch("app.services.vector_store.extended_pg_vector.Session") as session_class:
         session = session_class.return_value.__enter__.return_value
-        store._delete_by_metadata({"_rag_ingestion_attempt_id": "attempt-123"})
+        store._delete_by_metadata(
+            {
+                "file_id": "file-123",
+                "_rag_ingestion_attempt_id": "attempt-123",
+            }
+        )
 
     statement = session.execute.call_args.args[0]
     sql = _compile(statement)
     assert "DELETE FROM langchain_pg_embedding" in sql
     assert "collection_id" in sql
     assert "->>" in sql
+    assert "file_id" in sql
+    assert "file-123" in sql
     assert "_rag_ingestion_attempt_id" in sql
     assert "attempt-123" in sql
     session.commit.assert_called_once_with()

--- a/tests/services/test_vector_store.py
+++ b/tests/services/test_vector_store.py
@@ -1,5 +1,7 @@
 import pytest
 import sqlalchemy
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 from sqlalchemy.dialects import postgresql
 from langchain_community.vectorstores.pgvector import _get_embedding_collection_store
 
@@ -30,6 +32,30 @@ def _compile(clause):
             dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
         )
     )
+
+
+def test_delete_by_metadata_is_collection_scoped():
+    store = DummyPgVector()
+    collection_id = "00000000-0000-0000-0000-000000000123"
+    store.get_collection = Mock(return_value=SimpleNamespace(uuid=collection_id))
+
+    with patch("app.services.vector_store.extended_pg_vector.Session") as session_class:
+        session = session_class.return_value.__enter__.return_value
+        store._delete_by_metadata({"_rag_ingestion_attempt_id": "attempt-123"})
+
+    statement = session.execute.call_args.args[0]
+    sql = _compile(statement)
+    assert "DELETE FROM langchain_pg_embedding" in sql
+    assert "collection_id" in sql
+    assert "->>" in sql
+    assert "_rag_ingestion_attempt_id" in sql
+    assert "attempt-123" in sql
+    session.commit.assert_called_once_with()
+
+
+def test_delete_by_metadata_rejects_empty_filter():
+    with pytest.raises(ValueError, match="must not be empty"):
+        DummyPgVector()._delete_by_metadata({})
 
 
 class TestHandleFieldFilter:

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -414,6 +414,53 @@ class TestProducerConsumerPattern:
                 )
 
     @pytest.mark.asyncio
+    async def test_rollback_waits_for_in_flight_parallel_insert(self):
+        """Rollback must not run while another batch insert can still commit."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        insert_started = asyncio.Event()
+        events = []
+
+        async def add_documents(docs, ids=None, executor=None):
+            idx = docs[0].metadata["idx"]
+            if idx == 0:
+                events.append("slow_insert_started")
+                insert_started.set()
+                await asyncio.sleep(0.05)
+                events.append("slow_insert_finished")
+                return ["slow_id"]
+
+            await insert_started.wait()
+            events.append("failing_insert")
+            raise ValueError("Test error")
+
+        async def delete(ids=None, executor=None):
+            events.append("rollback")
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = add_documents
+        mock_store.delete = delete
+
+        docs = [
+            Document(page_content="slow", metadata={"idx": 0}),
+            Document(page_content="fail", metadata={"idx": 1}),
+        ]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            with pytest.raises(ValueError, match="Test error"):
+                await _process_documents_async_pipeline(
+                    documents=docs,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                    parallel_execution=2,
+                )
+
+        assert events.index("slow_insert_finished") < events.index("rollback")
+
+    @pytest.mark.asyncio
     async def test_all_ids_collected_across_batches(self):
         """Test that IDs from all batches are collected."""
         from app.routes.document_routes import _process_documents_async_pipeline

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -434,6 +434,51 @@ class TestProducerConsumerPattern:
         assert len(result) == 5
         assert result == ["id1", "id2", "id3", "id4", "id5"]
 
+    @pytest.mark.asyncio
+    async def test_parallel_execution_processes_batches_concurrently_in_order(self):
+        """Multiple consumers should process batches concurrently and return IDs in batch order."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        active_batches = 0
+        max_active_batches = 0
+        active_lock = asyncio.Lock()
+
+        async def tracking_add_documents(docs, ids=None, executor=None):
+            nonlocal active_batches, max_active_batches
+            async with active_lock:
+                active_batches += 1
+                max_active_batches = max(max_active_batches, active_batches)
+
+            await asyncio.sleep(0.01)
+
+            async with active_lock:
+                active_batches -= 1
+
+            return [f"id_{doc.metadata['idx']}" for doc in docs]
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = tracking_add_documents
+        mock_store.delete = AsyncMock()
+
+        docs = [
+            Document(page_content=f"doc_{i}", metadata={"idx": i}) for i in range(6)
+        ]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            result = await _process_documents_async_pipeline(
+                documents=docs,
+                file_id="test",
+                vector_store=mock_store,
+                executor=None,
+                parallel_execution=3,
+                user_id="test_user",
+            )
+
+        assert max_active_batches > 1
+        assert result == [f"id_{i}" for i in range(6)]
+
 
 class TestSyncBatchedMongoCompat:
     """Regression tests for MongoDB-compatible batch processing (PR #266)."""

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -121,10 +121,10 @@ class TestBatchProcessing:
         mock_async_vector_store.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_pipeline_rolls_back_on_first_batch_error(
+    async def test_async_pipeline_no_rollback_before_insert_starts(
         self, mock_documents, mock_async_vector_store
     ):
-        """Test failed async ingestion always cleans up by file_id."""
+        """Test failed async ingestion does not delete existing vectors if no insert started."""
         from app.routes.document_routes import _process_documents_async_pipeline
 
         mock_async_vector_store.aadd_documents = AsyncMock(
@@ -140,7 +140,7 @@ class TestBatchProcessing:
                     executor=None,
                 )
 
-        mock_async_vector_store.delete.assert_called_once()
+        assert not mock_async_vector_store.delete.called
 
     # --- Sync Batched Tests ---
 

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -121,10 +121,10 @@ class TestBatchProcessing:
         mock_async_vector_store.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_pipeline_no_rollback_on_first_batch_error(
+    async def test_async_pipeline_rolls_back_on_first_batch_error(
         self, mock_documents, mock_async_vector_store
     ):
-        """Test that no rollback occurs if first batch fails (nothing inserted)."""
+        """Test failed async ingestion always cleans up by file_id."""
         from app.routes.document_routes import _process_documents_async_pipeline
 
         mock_async_vector_store.aadd_documents = AsyncMock(
@@ -140,8 +140,7 @@ class TestBatchProcessing:
                     executor=None,
                 )
 
-        # Should not attempt rollback since nothing was inserted
-        assert not mock_async_vector_store.delete.called
+        mock_async_vector_store.delete.assert_called_once()
 
     # --- Sync Batched Tests ---
 

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -4,6 +4,34 @@ from unittest.mock import Mock, AsyncMock, patch, MagicMock
 from langchain_core.documents import Document
 
 
+class TestProcessMemoryDetails:
+    """Test process memory details used by ingestion logging."""
+
+    @pytest.mark.parametrize(
+        ("platform_name", "ru_maxrss"),
+        [
+            pytest.param("linux", 1536, id="linux-kib"),
+            pytest.param("darwin", 1536 * 1024, id="darwin-bytes"),
+        ],
+    )
+    def test_fallback_converts_peak_rss_to_mb(self, platform_name, ru_maxrss):
+        """Fallback should normalize native ru_maxrss units to MiB."""
+        from app.routes.document_routes import get_process_memory_details
+
+        mock_resource = MagicMock()
+        mock_resource.RUSAGE_SELF = object()
+        mock_resource.getrusage.return_value = Mock(ru_maxrss=ru_maxrss)
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("app.routes.document_routes.sys.platform", platform_name),
+            patch.dict("sys.modules", {"resource": mock_resource}),
+        ):
+            assert get_process_memory_details() == "rss_peak_mb=1.5"
+
+        mock_resource.getrusage.assert_called_once_with(mock_resource.RUSAGE_SELF)
+
+
 class TestBatchProcessing:
     """Test batch processing functions."""
 
@@ -21,6 +49,7 @@ class TestBatchProcessing:
         store = AsyncMock()
         store.aadd_documents = AsyncMock(return_value=["id1", "id2"])
         store.delete = AsyncMock()
+        store.delete_by_metadata = AsyncMock()
         return store
 
     @pytest.fixture
@@ -118,7 +147,11 @@ class TestBatchProcessing:
                     executor=None,
                 )
 
-        mock_async_vector_store.delete.assert_called_once()
+        mock_async_vector_store.delete.assert_not_called()
+        mock_async_vector_store.delete_by_metadata.assert_called_once()
+        metadata_filter = mock_async_vector_store.delete_by_metadata.call_args.args[0]
+        assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
+        assert metadata_filter["_rag_ingestion_attempt_id"]
 
     @pytest.mark.asyncio
     async def test_async_pipeline_no_rollback_before_insert_starts(
@@ -141,6 +174,7 @@ class TestBatchProcessing:
                 )
 
         assert not mock_async_vector_store.delete.called
+        assert not mock_async_vector_store.delete_by_metadata.called
 
     # --- Sync Batched Tests ---
 
@@ -435,12 +469,13 @@ class TestProducerConsumerPattern:
             events.append("failing_insert")
             raise ValueError("Test error")
 
-        async def delete(ids=None, executor=None):
+        async def delete_by_metadata(metadata_filter, executor=None):
+            assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
             events.append("rollback")
 
         mock_store = AsyncMock()
         mock_store.aadd_documents = add_documents
-        mock_store.delete = delete
+        mock_store.delete_by_metadata = delete_by_metadata
 
         docs = [
             Document(page_content="slow", metadata={"idx": 0}),
@@ -477,12 +512,13 @@ class TestProducerConsumerPattern:
             events.append("insert_finished")
             return ["id"]
 
-        async def delete(ids=None, executor=None):
+        async def delete_by_metadata(metadata_filter, executor=None):
+            assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
             events.append("rollback")
 
         mock_store = AsyncMock()
         mock_store.aadd_documents = add_documents
-        mock_store.delete = delete
+        mock_store.delete_by_metadata = delete_by_metadata
 
         docs = [Document(page_content="test", metadata={})]
 
@@ -504,6 +540,171 @@ class TestProducerConsumerPattern:
                 await pipeline_task
 
         assert events == ["insert_started", "insert_finished", "rollback"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_rollback_preserves_same_file_rows(self):
+        """Rollback removes only rows created by the cancelled ingestion attempt."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        key = "_rag_ingestion_attempt_id"
+        records = [{"content": "existing", "metadata": {"file_id": "test"}}]
+        cancelled_insert_started = asyncio.Event()
+        release_cancelled_insert = asyncio.Event()
+
+        class TrackingStore:
+            async def aadd_documents(self, docs, ids=None, executor=None):
+                document = docs[0]
+                if document.page_content == "cancelled":
+                    cancelled_insert_started.set()
+                    await release_cancelled_insert.wait()
+
+                records.append(
+                    {
+                        "content": document.page_content,
+                        "metadata": dict(document.metadata),
+                    }
+                )
+                return ids
+
+            async def delete_by_metadata(self, metadata_filter, executor=None):
+                records[:] = [
+                    record
+                    for record in records
+                    if not all(
+                        record["metadata"].get(field) == value
+                        for field, value in metadata_filter.items()
+                    )
+                ]
+
+            async def delete(self, ids=None, executor=None):
+                raise AssertionError("rollback must not delete by file_id")
+
+        store = TrackingStore()
+        cancelled_docs = [Document(page_content="cancelled", metadata={})]
+        successful_docs = [Document(page_content="successful", metadata={})]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            cancelled_task = asyncio.create_task(
+                _process_documents_async_pipeline(
+                    documents=cancelled_docs,
+                    file_id="test",
+                    vector_store=store,
+                    executor=None,
+                )
+            )
+            await asyncio.wait_for(cancelled_insert_started.wait(), timeout=1)
+
+            await _process_documents_async_pipeline(
+                documents=successful_docs,
+                file_id="test",
+                vector_store=store,
+                executor=None,
+            )
+
+            cancelled_task.cancel()
+            await asyncio.sleep(0)
+            release_cancelled_insert.set()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(cancelled_task, timeout=1)
+
+        assert [record["content"] for record in records] == [
+            "existing",
+            "successful",
+        ]
+        assert key not in records[0]["metadata"]
+        assert key in records[1]["metadata"]
+        assert cancelled_docs[0].metadata[key] != successful_docs[0].metadata[key]
+
+    @pytest.mark.asyncio
+    async def test_peer_consumer_skips_queued_batch_after_failure(self):
+        """A peer must acknowledge, but not start, queued work after a failure."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        created_queues = []
+
+        class TrackingQueue(asyncio.Queue):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.get_count = 0
+                self.task_done_count = 0
+                self.checked_out = {}
+                self.completed = []
+                created_queues.append(self)
+
+            async def get(self):
+                item = await super().get()
+                self.get_count += 1
+                self.checked_out[asyncio.current_task()] = item
+                return item
+
+            def task_done(self):
+                self.task_done_count += 1
+                self.completed.append(self.checked_out.pop(asyncio.current_task()))
+                super().task_done()
+
+        loop = asyncio.get_running_loop()
+        failing_result = loop.create_future()
+        successful_result = loop.create_future()
+        first_two_started = asyncio.Event()
+        started_batches = []
+
+        async def add_documents(docs, ids=None, executor=None):
+            batch_idx = docs[0].metadata["idx"]
+            started_batches.append(batch_idx)
+
+            if len(started_batches) == 2:
+                first_two_started.set()
+
+            if batch_idx == 0:
+                return await failing_result
+            if batch_idx == 1:
+                return await successful_result
+            return [f"id_{batch_idx}"]
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = add_documents
+        mock_store.delete_by_metadata = AsyncMock()
+
+        docs = [
+            Document(page_content=f"doc_{idx}", metadata={"idx": idx})
+            for idx in range(3)
+        ]
+
+        with (
+            patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1),
+            patch("app.routes.document_routes.EMBEDDING_MAX_QUEUE_SIZE", 3),
+            patch("app.routes.document_routes.asyncio.Queue", TrackingQueue),
+        ):
+            pipeline_task = asyncio.create_task(
+                _process_documents_async_pipeline(
+                    documents=docs,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                    parallel_execution=2,
+                )
+            )
+
+            await asyncio.wait_for(first_two_started.wait(), timeout=1)
+            failing_result.set_exception(ValueError("Test error"))
+            successful_result.set_result(["id_1"])
+
+            with pytest.raises(ValueError, match="Test error"):
+                await asyncio.wait_for(pipeline_task, timeout=1)
+
+        assert set(started_batches) == {0, 1}
+
+        queue = created_queues[0]
+        completed_batch_numbers = [
+            item[2] for item in queue.completed if item is not None
+        ]
+        assert 3 in completed_batch_numbers
+        assert queue.get_count == queue.task_done_count
+        assert queue.checked_out == {}
 
     @pytest.mark.asyncio
     async def test_all_ids_collected_across_batches(self):

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -32,6 +32,68 @@ class TestProcessMemoryDetails:
         mock_resource.getrusage.assert_called_once_with(mock_resource.RUSAGE_SELF)
 
 
+class TestDocumentChunkOrdering:
+    """Test source-order restoration for parallel pgvector ingestion."""
+
+    def test_orders_documents_by_ingestion_chunk_index(self):
+        from app.routes.document_routes import _order_documents_by_chunk_index
+
+        documents = [
+            Document(page_content="third", metadata={"_rag_chunk_index": 2}),
+            Document(page_content="first", metadata={"_rag_chunk_index": 0}),
+            Document(page_content="second", metadata={"_rag_chunk_index": 1}),
+        ]
+
+        ordered = _order_documents_by_chunk_index(documents)
+
+        assert [document.page_content for document in ordered] == [
+            "first",
+            "second",
+            "third",
+        ]
+        assert documents[0].page_content == "third"
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            pytest.param([{}, {}, {}], id="legacy-missing-index"),
+            pytest.param(
+                [
+                    {"_rag_chunk_index": 0},
+                    {"_rag_chunk_index": 0},
+                    {"_rag_chunk_index": 1},
+                ],
+                id="duplicate-index",
+            ),
+            pytest.param(
+                [
+                    {"_rag_chunk_index": 2},
+                    {"_rag_chunk_index": "0"},
+                    {"_rag_chunk_index": 1},
+                ],
+                id="invalid-index",
+            ),
+        ],
+    )
+    def test_preserves_received_order_without_trustworthy_indexes(self, metadata):
+        from app.routes.document_routes import _order_documents_by_chunk_index
+
+        documents = [
+            Document(page_content=content, metadata=document_metadata)
+            for content, document_metadata in zip(
+                ["third", "first", "second"], metadata
+            )
+        ]
+
+        ordered = _order_documents_by_chunk_index(documents)
+
+        assert [document.page_content for document in ordered] == [
+            "third",
+            "first",
+            "second",
+        ]
+
+
 class TestBatchProcessing:
     """Test batch processing functions."""
 
@@ -150,8 +212,46 @@ class TestBatchProcessing:
         mock_async_vector_store.delete.assert_not_called()
         mock_async_vector_store.delete_by_metadata.assert_called_once()
         metadata_filter = mock_async_vector_store.delete_by_metadata.call_args.args[0]
-        assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
-        assert metadata_filter["_rag_ingestion_attempt_id"]
+        assert metadata_filter == {
+            "file_id": "test_file",
+            "_rag_ingestion_attempt_id": mock_documents[0].metadata[
+                "_rag_ingestion_attempt_id"
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_pipeline_canonicalizes_file_id_for_rollback(
+        self, mock_async_vector_store
+    ):
+        """Rollback must match the canonical file ID, not loader metadata."""
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        documents = [
+            Document(page_content="inserted", metadata={"file_id": "spoofed"}),
+            Document(page_content="failed", metadata={}),
+        ]
+        mock_async_vector_store.aadd_documents = AsyncMock(
+            side_effect=[["inserted"], ValueError("DB error")]
+        )
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            with pytest.raises(ValueError, match="DB error"):
+                await _process_documents_async_pipeline(
+                    documents=documents,
+                    file_id="canonical-file",
+                    vector_store=mock_async_vector_store,
+                    executor=None,
+                )
+
+        assert all(
+            document.metadata["file_id"] == "canonical-file" for document in documents
+        )
+        assert mock_async_vector_store.delete_by_metadata.call_args.args[0] == {
+            "file_id": "canonical-file",
+            "_rag_ingestion_attempt_id": documents[0].metadata[
+                "_rag_ingestion_attempt_id"
+            ],
+        }
 
     @pytest.mark.asyncio
     async def test_async_pipeline_no_rollback_before_insert_starts(
@@ -470,7 +570,11 @@ class TestProducerConsumerPattern:
             raise ValueError("Test error")
 
         async def delete_by_metadata(metadata_filter, executor=None):
-            assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
+            assert metadata_filter["file_id"] == "test"
+            assert set(metadata_filter) == {
+                "file_id",
+                "_rag_ingestion_attempt_id",
+            }
             events.append("rollback")
 
         mock_store = AsyncMock()
@@ -513,7 +617,11 @@ class TestProducerConsumerPattern:
             return ["id"]
 
         async def delete_by_metadata(metadata_filter, executor=None):
-            assert list(metadata_filter) == ["_rag_ingestion_attempt_id"]
+            assert metadata_filter["file_id"] == "test"
+            assert set(metadata_filter) == {
+                "file_id",
+                "_rag_ingestion_attempt_id",
+            }
             events.append("rollback")
 
         mock_store = AsyncMock()
@@ -771,6 +879,68 @@ class TestProducerConsumerPattern:
 
         assert max_active_batches > 1
         assert result == [f"id_{i}" for i in range(6)]
+
+    @pytest.mark.asyncio
+    async def test_parallel_completion_persists_source_chunk_indexes(self):
+        """Out-of-order commits retain ordinals that reconstruct source order."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        loop = asyncio.get_running_loop()
+        release_batches = [loop.create_future() for _ in range(3)]
+        all_batches_started = asyncio.Event()
+        started_batches = []
+        completion_order = []
+
+        async def controlled_add_documents(docs, ids=None, executor=None):
+            source_index = docs[0].metadata["source_index"]
+            started_batches.append(source_index)
+            if len(started_batches) == 3:
+                all_batches_started.set()
+
+            await release_batches[source_index]
+            completion_order.append(source_index)
+            return [f"id_{source_index}"]
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = controlled_add_documents
+        documents = [
+            Document(
+                page_content=f"doc_{source_index}",
+                metadata={
+                    "source_index": source_index,
+                    "_rag_chunk_index": 99,
+                },
+            )
+            for source_index in range(3)
+        ]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            pipeline_task = asyncio.create_task(
+                _process_documents_async_pipeline(
+                    documents=documents,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                    parallel_execution=3,
+                )
+            )
+
+            await asyncio.wait_for(all_batches_started.wait(), timeout=1)
+            for source_index in (2, 1, 0):
+                release_batches[source_index].set_result(None)
+                await asyncio.sleep(0)
+
+            result = await asyncio.wait_for(pipeline_task, timeout=1)
+
+        assert completion_order == [2, 1, 0]
+        assert result == ["id_0", "id_1", "id_2"]
+        assert [document.metadata["_rag_chunk_index"] for document in documents] == [
+            0,
+            1,
+            2,
+        ]
 
 
 class TestSyncBatchedMongoCompat:

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -460,6 +460,52 @@ class TestProducerConsumerPattern:
         assert events.index("slow_insert_finished") < events.index("rollback")
 
     @pytest.mark.asyncio
+    async def test_cancellation_waits_for_in_flight_insert_before_rollback(self):
+        """Request cancellation must not leave a shielded insert committed."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        insert_started = asyncio.Event()
+        release_insert = asyncio.Event()
+        events = []
+
+        async def add_documents(docs, ids=None, executor=None):
+            events.append("insert_started")
+            insert_started.set()
+            await release_insert.wait()
+            events.append("insert_finished")
+            return ["id"]
+
+        async def delete(ids=None, executor=None):
+            events.append("rollback")
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = add_documents
+        mock_store.delete = delete
+
+        docs = [Document(page_content="test", metadata={})]
+
+        with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
+            pipeline_task = asyncio.create_task(
+                _process_documents_async_pipeline(
+                    documents=docs,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                )
+            )
+            await insert_started.wait()
+            pipeline_task.cancel()
+            await asyncio.sleep(0)
+            release_insert.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await pipeline_task
+
+        assert events == ["insert_started", "insert_finished", "rollback"]
+
+    @pytest.mark.asyncio
     async def test_all_ids_collected_across_batches(self):
         """Test that IDs from all batches are collected."""
         from app.routes.document_routes import _process_documents_async_pipeline

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -39,9 +39,30 @@ class TestDocumentChunkOrdering:
         from app.routes.document_routes import _order_documents_by_chunk_index
 
         documents = [
-            Document(page_content="third", metadata={"_rag_chunk_index": 2}),
-            Document(page_content="first", metadata={"_rag_chunk_index": 0}),
-            Document(page_content="second", metadata={"_rag_chunk_index": 1}),
+            Document(
+                page_content="third",
+                metadata={
+                    "_rag_chunk_index": 2,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
+            Document(
+                page_content="first",
+                metadata={
+                    "_rag_chunk_index": 0,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
+            Document(
+                page_content="second",
+                metadata={
+                    "_rag_chunk_index": 1,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
         ]
 
         ordered = _order_documents_by_chunk_index(documents)
@@ -52,6 +73,40 @@ class TestDocumentChunkOrdering:
             "third",
         ]
         assert documents[0].page_content == "third"
+
+    def test_groups_repeated_attempts_before_ordering_chunks(self):
+        """Chunk indexes from repeated attempts must not collide."""
+        from app.routes.document_routes import _order_documents_by_chunk_index
+
+        def marked(content, chunk_index, attempt_id, started_at_ns):
+            return Document(
+                page_content=content,
+                metadata={
+                    "_rag_chunk_index": chunk_index,
+                    "_rag_ingestion_attempt_id": attempt_id,
+                    "_rag_ingestion_attempt_started_at_ns": started_at_ns,
+                },
+            )
+
+        documents = [
+            Document(page_content="legacy", metadata={}),
+            marked("a2", 2, "attempt-a", 100),
+            marked("b1", 1, "attempt-b", 200),
+            marked("a0", 0, "attempt-a", 100),
+            marked("b0", 0, "attempt-b", 200),
+            marked("a1", 1, "attempt-a", 100),
+        ]
+
+        ordered = _order_documents_by_chunk_index(documents)
+
+        assert [document.page_content for document in ordered] == [
+            "legacy",
+            "a0",
+            "a1",
+            "a2",
+            "b0",
+            "b1",
+        ]
 
     @pytest.mark.parametrize(
         "metadata",
@@ -648,6 +703,82 @@ class TestProducerConsumerPattern:
                 await pipeline_task
 
         assert events == ["insert_started", "insert_finished", "rollback"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("document_count", "blocked_put"),
+        [(3, "batch"), (2, "sentinel")],
+    )
+    async def test_producer_cancellation_does_not_block_on_full_queue(
+        self, document_count, blocked_put
+    ):
+        """One cancellation must release a producer blocked on a full queue."""
+        import asyncio
+
+        from app.routes.document_routes import _process_documents_async_pipeline
+
+        target_put_started = asyncio.Event()
+        sentinel_put_started = asyncio.Event()
+
+        class ObservingQueue(asyncio.Queue):
+            async def put(self, item):
+                if item is None:
+                    sentinel_put_started.set()
+
+                is_target = (blocked_put == "sentinel" and item is None) or (
+                    blocked_put == "batch"
+                    and item is not None
+                    and item[2] == document_count
+                )
+                if is_target:
+                    target_put_started.set()
+                return await super().put(item)
+
+        async def add_documents(docs, ids=None, executor=None):
+            await target_put_started.wait()
+            raise asyncio.CancelledError
+
+        mock_store = AsyncMock()
+        mock_store.aadd_documents = add_documents
+        mock_store.delete_by_metadata = AsyncMock()
+        documents = [
+            Document(
+                page_content=f"doc_{source_index}",
+                metadata={"source_index": source_index},
+            )
+            for source_index in range(document_count)
+        ]
+
+        with (
+            patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1),
+            patch("app.routes.document_routes.EMBEDDING_MAX_QUEUE_SIZE", 1),
+            patch("app.routes.document_routes.asyncio.Queue", ObservingQueue),
+        ):
+            pipeline_task = asyncio.create_task(
+                _process_documents_async_pipeline(
+                    documents=documents,
+                    file_id="test",
+                    vector_store=mock_store,
+                    executor=None,
+                )
+            )
+            try:
+                done, _ = await asyncio.wait({pipeline_task}, timeout=1)
+                assert (
+                    pipeline_task in done
+                ), f"pipeline hung after cancellation during {blocked_put} enqueue"
+                with pytest.raises(asyncio.CancelledError):
+                    await pipeline_task
+            finally:
+                if not pipeline_task.done():
+                    pipeline_task.cancel()
+                    await asyncio.gather(pipeline_task, return_exceptions=True)
+
+        if blocked_put == "batch":
+            assert not sentinel_put_started.is_set()
+        else:
+            assert sentinel_put_started.is_set()
+        mock_store.delete_by_metadata.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cancellation_rollback_preserves_same_file_rows(self):

--- a/tests/test_batch_processing_integration.py
+++ b/tests/test_batch_processing_integration.py
@@ -194,6 +194,7 @@ class TestBatchProcessingResilience:
         mock_store = AsyncMock()
         mock_store.aadd_documents = failing_add_documents
         mock_store.delete = AsyncMock()
+        mock_store.delete_by_metadata = AsyncMock()
 
         docs = [
             Document(page_content=f"doc_{i}", metadata={"idx": i}) for i in range(15)
@@ -209,14 +210,15 @@ class TestBatchProcessingResilience:
                 )
 
         # Verify rollback was called because we had inserted batches
-        mock_store.delete.assert_called_once()
+        mock_store.delete.assert_not_called()
+        mock_store.delete_by_metadata.assert_called_once()
 
         # Verify we inserted 2 batches before failure
         assert len(inserted_batches) == 2
 
     @pytest.mark.asyncio
-    async def test_rollback_called_with_correct_file_id(self):
-        """Test that rollback uses the correct file_id."""
+    async def test_rollback_called_with_current_ingestion_attempt(self):
+        """Test that rollback targets only the current ingestion attempt."""
         from app.routes.document_routes import _process_documents_async_pipeline
 
         async def failing_on_second(docs, ids=None, executor=None):
@@ -227,6 +229,7 @@ class TestBatchProcessingResilience:
         mock_store = AsyncMock()
         mock_store.aadd_documents = failing_on_second
         mock_store.delete = AsyncMock()
+        mock_store.delete_by_metadata = AsyncMock()
 
         docs = [
             Document(page_content=f"doc_{i}", metadata={"idx": i}) for i in range(10)
@@ -241,10 +244,15 @@ class TestBatchProcessingResilience:
                     executor=None,
                 )
 
-        # Verify delete was called with the correct file_id
-        mock_store.delete.assert_called_once()
-        call_kwargs = mock_store.delete.call_args
-        assert call_kwargs[1]["ids"] == ["my_unique_file_id"]
+        mock_store.delete.assert_not_called()
+        mock_store.delete_by_metadata.assert_called_once()
+        metadata_filter = mock_store.delete_by_metadata.call_args.args[0]
+        attempt_id = metadata_filter["_rag_ingestion_attempt_id"]
+        assert attempt_id
+        assert all(
+            document.metadata["_rag_ingestion_attempt_id"] == attempt_id
+            for document in docs
+        )
 
 
 class TestConfigurationBehavior:

--- a/tests/test_batch_processing_integration.py
+++ b/tests/test_batch_processing_integration.py
@@ -286,6 +286,25 @@ class TestConfigurationBehavior:
         # When batch size is 0, aadd_documents should be called directly
         # (not through the pipeline)
         assert mock_store.aadd_documents.called
+        stored_documents = mock_store.aadd_documents.call_args.args[0]
+        assert [
+            document.metadata["_rag_chunk_index"] for document in stored_documents
+        ] == list(range(len(stored_documents)))
+        assert all(
+            document.metadata["file_id"] == "test_file" for document in stored_documents
+        )
+        attempt_ids = {
+            document.metadata["_rag_ingestion_attempt_id"]
+            for document in stored_documents
+        }
+        started_at_values = {
+            document.metadata["_rag_ingestion_attempt_started_at_ns"]
+            for document in stored_documents
+        }
+        assert len(attempt_ids) == 1
+        assert all(attempt_ids)
+        assert len(started_at_values) == 1
+        assert type(next(iter(started_at_values))) is int
 
     @pytest.mark.asyncio
     async def test_different_batch_sizes_produce_correct_batches(self):

--- a/tests/test_batch_processing_integration.py
+++ b/tests/test_batch_processing_integration.py
@@ -247,8 +247,12 @@ class TestBatchProcessingResilience:
         mock_store.delete.assert_not_called()
         mock_store.delete_by_metadata.assert_called_once()
         metadata_filter = mock_store.delete_by_metadata.call_args.args[0]
+        assert metadata_filter["file_id"] == "my_unique_file_id"
         attempt_id = metadata_filter["_rag_ingestion_attempt_id"]
         assert attempt_id
+        assert all(
+            document.metadata["file_id"] == "my_unique_file_id" for document in docs
+        )
         assert all(
             document.metadata["_rag_ingestion_attempt_id"] == attempt_id
             for document in docs

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -223,9 +223,30 @@ def test_load_document_context_restores_parallel_chunk_order(auth_headers, monke
 
     async def out_of_order_documents(self, ids, executor=None):
         return [
-            Document(page_content="third", metadata={"_rag_chunk_index": 2}),
-            Document(page_content="first", metadata={"_rag_chunk_index": 0}),
-            Document(page_content="second", metadata={"_rag_chunk_index": 1}),
+            Document(
+                page_content="third",
+                metadata={
+                    "_rag_chunk_index": 2,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
+            Document(
+                page_content="first",
+                metadata={
+                    "_rag_chunk_index": 0,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
+            Document(
+                page_content="second",
+                metadata={
+                    "_rag_chunk_index": 1,
+                    "_rag_ingestion_attempt_id": "attempt-a",
+                    "_rag_ingestion_attempt_started_at_ns": 100,
+                },
+            ),
         ]
 
     monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", out_of_order_documents)
@@ -234,6 +255,37 @@ def test_load_document_context_restores_parallel_chunk_order(auth_headers, monke
 
     assert response.status_code == 200, f"Response: {response.text}"
     assert response.json() == "firstsecondthird"
+
+
+def test_load_document_context_groups_repeated_ingestion_attempts(
+    auth_headers, monkeypatch
+):
+    from app.services.vector_store.async_pg_vector import AsyncPgVector
+
+    def marked(content, chunk_index, attempt_id, started_at_ns):
+        return Document(
+            page_content=content,
+            metadata={
+                "_rag_chunk_index": chunk_index,
+                "_rag_ingestion_attempt_id": attempt_id,
+                "_rag_ingestion_attempt_started_at_ns": started_at_ns,
+            },
+        )
+
+    async def interleaved_attempts(self, ids, executor=None):
+        return [
+            marked("old-second", 1, "old", 100),
+            marked("new-second", 1, "new", 200),
+            marked("old-first", 0, "old", 100),
+            marked("new-first", 0, "new", 200),
+        ]
+
+    monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", interleaved_attempts)
+
+    response = client.get("/documents/testid1/context", headers=auth_headers)
+
+    assert response.status_code == 200, f"Response: {response.text}"
+    assert response.json() == "old-firstold-secondnew-firstnew-second"
 
 
 def test_embed_file_upload(tmp_path, auth_headers, monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -218,6 +218,24 @@ def test_load_document_context(auth_headers):
     assert "testid1" in content or "Test content" in content
 
 
+def test_load_document_context_restores_parallel_chunk_order(auth_headers, monkeypatch):
+    from app.services.vector_store.async_pg_vector import AsyncPgVector
+
+    async def out_of_order_documents(self, ids, executor=None):
+        return [
+            Document(page_content="third", metadata={"_rag_chunk_index": 2}),
+            Document(page_content="first", metadata={"_rag_chunk_index": 0}),
+            Document(page_content="second", metadata={"_rag_chunk_index": 1}),
+        ]
+
+    monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", out_of_order_documents)
+
+    response = client.get("/documents/testid1/context", headers=auth_headers)
+
+    assert response.status_code == 200, f"Response: {response.text}"
+    assert response.json() == "firstsecondthird"
+
+
 def test_embed_file_upload(tmp_path, auth_headers, monkeypatch):
     file_content = "Test content for embed upload."
     test_file = tmp_path / "upload_test.txt"


### PR DESCRIPTION
## Summary

I carried the complete parallel-ingestion change set from #309 onto a repository-owned branch and completed the ordering, cancellation, rollback, peer-failure, and telemetry fixes identified through independent and Codex review. This PR supersedes #309 because its organization-owned source fork does not permit maintainer pushes.

- Add configurable `PARALLEL_EXECUTION` consumers for concurrent embedding and database insertion.
- Bound queued work through `EMBEDDING_MAX_QUEUE_SIZE` while preserving result IDs in batch order.
- Persist a canonical zero-based chunk index, UUID attempt marker, and start timestamp before pgvector inserts.
- Group repeated ingestion attempts independently and restore source order within each group while retaining all rows and preserving legacy order.
- Apply the same ordering metadata to batched and unbatched AsyncPgVector ingestion paths.
- Stop peers from starting queued batches after an ingestion failure and balance queue acknowledgements for every exit path.
- Send queue sentinels only on normal producer completion so cancellation cannot block against a full queue after consumers stop.
- Wait for shielded in-flight inserts before rollback on both worker failures and `asyncio.CancelledError`.
- Isolate rollback to a private per-attempt metadata UUID so cancellation cannot delete pre-existing or concurrent vectors that share the same `file_id`.
- Canonicalize persisted `file_id` metadata and include it in rollback predicates so PostgreSQL can use the existing expression index before matching the attempt marker.
- Add collection-scoped pgvector metadata deletion while preserving public `file_id` identity and explicit whole-file deletion behavior.
- Add structured ingestion lifecycle logging with route, user, file, chunk, timing, and process-memory context.
- Normalize `ru_maxrss` telemetry correctly for Linux KiB and macOS bytes.
- Correct the documented `EMBEDDING_BATCH_SIZE` default to `500` and clarify concurrency and memory behavior.
- Expand regression coverage for out-of-order commits, repeated attempts, context reconstruction, full-queue cancellation, rollback timing and scope, first-batch failures, same-file preservation, peer failure, queue accounting, index usage, and platform memory units.
- Preserve Peter Rothlaender's original #309 commits and add the independently reviewed fixes as separate commits.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Ran the complete non-integration suite: 217 passed and 6 skipped.
- Ran the complete Docker-backed pgvector integration suite: 23 passed.
- Forced three parallel batches to commit in `2 -> 1 -> 0` order and verified persisted chunk indexes reconstruct the original context.
- Interleaved rows from repeated attempts and verified each attempt remains intact and source ordered.
- Cancelled a consumer while its producer was blocked on both a batch put and a sentinel put in a full one-slot queue and verified the pipeline terminates without a second cancellation.
- Verified real PostgreSQL rollback preserves prior, concurrent same-file, and same-attempt different-file rows.
- Verified `EXPLAIN` selects `idx_langchain_pg_embedding_file_id` for the two-key rollback predicate on a 50,000-row fixture.
- Ran Black 24.4.0 against all changed Python files.
- Compiled all changed Python modules with `py_compile`.
- Verified the complete diff with whitespace checks.

### **Test Configuration**:

- Python 3.12.12
- Docker 29.4.0
- Docker-backed PostgreSQL with pgvector
- Base branch: `main`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
