### PR TITLE
🔒 fix: close /query and /query_multiple authorization holes; add /v1/embeddings and /v1/rerank

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,9 @@ JWT_SECRET=REPLACE_ME_APPLICATION_JWT_SECRET
 # RAG_CHAT_EMBEDDING_DIMENSIONS=1024
 # RAG_CHAT_EMBEDDING_BASEURL=https://your-gateway.example/v1
 # RAG_CHAT_EMBEDDING_API_KEY=REPLACE_ME_GATEWAY_API_KEY
+#
+# Task prefixes for asymmetric models, applied per request input_type. Both are
+# empty by default. They belong to the space's locked definition: changing one
+# changes every vector the space produces, so stored vectors must be rebuilt.
+# RAG_CHAT_EMBEDDING_QUERY_PREFIX=
+# RAG_CHAT_EMBEDDING_DOCUMENT_PREFIX=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Copy to .env and replace every REPLACE_ME_* placeholder.
+# .env is gitignored; never commit real values. There are no fallback
+# credentials — the service refuses to start without these.
+
+# --- Vector database (required for VECTOR_DB_TYPE=pgvector) -----------------
+POSTGRES_DB=REPLACE_ME_DATABASE_NAME
+POSTGRES_USER=REPLACE_ME_DATABASE_USER
+POSTGRES_PASSWORD=REPLACE_ME_DATABASE_PASSWORD
+DB_HOST=db
+DB_PORT=5432
+
+# --- Embeddings provider ----------------------------------------------------
+RAG_OPENAI_API_KEY=REPLACE_ME_OPENAI_API_KEY
+# RAG_OPENAI_BASEURL=https://your-gateway.example/v1
+
+# --- Request authentication -------------------------------------------------
+# Signing key for tokens minted by the calling application. Required.
+JWT_SECRET=REPLACE_ME_APPLICATION_JWT_SECRET
+
+# --- Search service endpoints (/v1/embeddings, /v1/rerank) ------------------
+# RAG_SEARCH_API_ENABLED=true
+#
+# Dedicated signing key for this service. MUST differ from JWT_SECRET: sharing
+# the key would make every rag_api token a full application session token and
+# vice versa. At least 32 characters. Startup fails if this is missing while
+# the search API is enabled.
+# RAG_JWT_SECRET=REPLACE_ME_RAG_JWT_SECRET
+# RAG_JWT_ISSUER=librechat
+# RAG_JWT_AUDIENCE=rag_api
+#
+# Accept the legacy {"id": ...} token shape during the claim migration. Flip to
+# false once every caller mints issuer/audience/tenant/scopes.
+# RAG_AUTH_ACCEPT_LEGACY=true
+#
+# Backend for the chat-v1 embedding space. Defaults to RAG_OPENAI_* when unset.
+# RAG_CHAT_EMBEDDING_MODEL=qwen3-embedding-8b
+# RAG_CHAT_EMBEDDING_DIMENSIONS=1024
+# RAG_CHAT_EMBEDDING_BASEURL=https://your-gateway.example/v1
+# RAG_CHAT_EMBEDDING_API_KEY=REPLACE_ME_GATEWAY_API_KEY

--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ need them.
 Writes are scoped too: uploading under an `entity_id` the token does not permit
 is refused, so a caller cannot plant content in a knowledge base it cannot read.
 
+The file-addressed routes are scoped by the same builder, because a file id is
+caller-supplied and proves nothing about who may read it:
+
+| Route | Scope |
+| --- | --- |
+| `GET /ids` | lists only the caller's own file ids |
+| `GET /documents?ids=` | chunks the caller owns; anything else is `404` |
+| `GET /documents/{id}/context` | as above, for one file |
+| `DELETE /documents` | deletes only the caller's rows for those ids |
+
+Each accepts an optional `entity_id` query parameter, with the same rule as
+`/query`: strict tokens must list the id in their `entities` claim, legacy
+tokens are taken at face value. A file outside the scope reads as "not found"
+rather than "found but refused", so none of these routes is an existence oracle.
+
+The scope is inside the `DELETE` predicate rather than beside it. Two owners can
+hold rows under one file id — the id is chosen by whoever uploads — so a delete
+that filtered on the id alone would take both.
+
+**Upgrade note.** Files embedded under an `entity_id` (agent knowledge bases)
+are owned by that entity, so deleting or reading them needs `entity_id` on these
+routes just as querying them already does. A client that deletes an agent's file
+with a plain user token and no `entity_id` now gets `404` and leaves the chunks
+in place; pass the entity the file was uploaded under to remove them.
+
 ### Authorize before egress
 
 Rerank and embedding send text to an inference provider. That text has left the

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ docker compose build --no-cache
 
 ### Environment Variables
 
+Copy `.env.example` to `.env` and replace every `REPLACE_ME_*` placeholder. The
+database credentials ship **no fallback defaults** — the service refuses to
+start without them, and the compose files use `${VAR:?}` so `docker compose up`
+fails loudly rather than bringing up a database whose credentials are public in
+this repository:
+
+- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`: **required** when
+  `VECTOR_DB_TYPE=pgvector`. `POSTGRES_PASSWORD` may be empty only when
+  `POSTGRES_USE_UNIX_SOCKET=True`, where peer authentication carries no password.
+
 The following environment variables are required to run the application:
 
 - `RAG_OPENAI_API_KEY`: The API key for OpenAI API Embeddings (if using default settings).
@@ -72,9 +82,9 @@ The following environment variables are required to run the application:
     - Note: When using with LibreChat, you can also set `HTTP_PROXY` and `HTTPS_PROXY` environment variables in the `docker-compose.override.yml` file (see [Proxy Configuration](#proxy-configuration) section below)
 - `VECTOR_DB_TYPE`: (Optional) select vector database type, default to `pgvector`.
 - `POSTGRES_USE_UNIX_SOCKET`: (Optional) Set to "True" when connecting to the PostgreSQL database server with Unix Socket.
-- `POSTGRES_DB`: (Optional) The name of the PostgreSQL database, used when `VECTOR_DB_TYPE=pgvector`.
-- `POSTGRES_USER`: (Optional) The username for connecting to the PostgreSQL database.
-- `POSTGRES_PASSWORD`: (Optional) The password for connecting to the PostgreSQL database.
+- `POSTGRES_DB`: The name of the PostgreSQL database, used when `VECTOR_DB_TYPE=pgvector`. Required, no default.
+- `POSTGRES_USER`: The username for connecting to the PostgreSQL database. Required, no default.
+- `POSTGRES_PASSWORD`: The password for connecting to the PostgreSQL database. Required, no default (may be empty only under `POSTGRES_USE_UNIX_SOCKET=True`).
 - `DB_HOST`: (Optional) The hostname or IP address of the PostgreSQL database server.
 - `DB_PORT`: (Optional) The port number of the PostgreSQL database server.
 - `PGVECTOR_CREATE_EXTENSION`: (Optional) Set to "False" to skip the `CREATE EXTENSION IF NOT EXISTS vector` call on startup. Default is "True". Use this when the `vector` extension is already installed on a managed Postgres (e.g. RDS, Azure Database for PostgreSQL) and the application user is not a superuser.
@@ -173,11 +183,39 @@ agent's knowledge-base files. Strict tokens must list that id in their
 at face value — which is the reason to flip `RAG_AUTH_ACCEPT_LEGACY` off once
 the migration lands.
 
-Retrieval is scoped by document owner. `/query` and `/query_multiple` put that
-scope into the vector-store predicate, so a file belonging to another owner
-matches nothing rather than being filtered out after ranking. Documents written
-before `user_id` was recorded in chunk metadata are no longer visible to any
-caller; re-embed them if you still need them.
+### Retrieval scope
+
+Retrieval is scoped by `(tenant, owner/entity, file_id)`, and all three go into
+the vector-store predicate before ranking. A chunk outside the caller's scope
+matches nothing rather than being filtered out of the result set afterwards.
+There is one scope builder (`app/scope.py`); no route writes its own scope
+clause.
+
+Chunks record the writing caller's `tenant_id` and `user_id`. Chunks written
+before `tenant_id` existed carry no value and normalize to the base tenant
+`__BASE__`, so a single-tenant deployment reads them exactly as before while a
+named tenant never absorbs untagged content. Documents written before `user_id`
+was recorded are no longer visible to any caller; re-embed them if you still
+need them.
+
+Writes are scoped too: uploading under an `entity_id` the token does not permit
+is refused, so a caller cannot plant content in a knowledge base it cannot read.
+
+### Authorize before egress
+
+Rerank and embedding send text to an inference provider. That text has left the
+trust boundary whether or not the caller ever sees a response, so authorization
+happens before the call rather than as a filter on its result:
+
+- `/v1/rerank` probes every candidate id against the store — metadata only, no
+  vectors and no document text. An id that exists but resolves to nothing inside
+  the caller's scope makes the whole request `403`, and nothing is embedded. Ids
+  that match nothing in the store (web-scrape candidates, synthetic ids) are
+  unaffected. If the probe cannot run, the request fails closed with `503`
+  rather than embedding text it could not check.
+- `/v1/embeddings` reads no store at all: it embeds only text the authenticated
+  caller supplied in the request body. Scope, quota and limit rejections all
+  happen before the backend is called.
 
 ### Search service endpoints
 

--- a/README.md
+++ b/README.md
@@ -441,18 +441,43 @@ If your index predates this release:
    this restores exactly the visibility those chunks had before. Run it once,
    after the index reaches **Active**.
 
+5. Make sure the standard `digest` index below exists. The service creates it on
+   startup, so restarting is enough; create it by hand if the database user
+   cannot build indexes. Without it every `/v1/rerank` call scans the whole
+   vector collection twice.
+
 Queries against `file_id` continue to work throughout — only the owner- and
 tenant-scoped paths wait on the rebuild.
 
-#### Create a `file_id` Index (recommended)
+#### Standard indexes
 
-We recommend creating a standard MongoDB index on `file_id` to keep lookups fast. After creating the collection, run the following once (via Atlas UI, Compass, or `mongosh`):
+The Atlas **vector-search** index accelerates `$vectorSearch` and nothing else.
+The document routes and the rerank candidate lookups are ordinary `find` calls,
+so they need ordinary indexes or they scan the collection.
+
+The service creates both on startup, so a fresh deployment needs no manual step.
+`createIndex` is idempotent, and a database user without index privileges only
+produces a warning — the lookups still return the right answers, they just scan.
+To create them yourself (Atlas UI, Compass, or `mongosh`):
 
 ```javascript
 db.getCollection("<COLLECTION_NAME>").createIndex({ file_id: 1 })
+db.getCollection("<COLLECTION_NAME>").createIndex({ digest: 1, user_id: 1, tenant_id: 1 })
 ```
 
-Replace `<COLLECTION_NAME>` with the same collection used by the RAG API. This ensures lookups remain fast even as the number of embedded documents grows.
+Replace `<COLLECTION_NAME>` with the same collection used by the RAG API.
+
+`file_id` serves `/query`, `/documents`, `/documents/{id}/context` and
+`DELETE /documents`. The compound `digest` index serves `/v1/rerank`: candidate
+ids handed back to callers are normally chunk digests rather than Mongo `_id`
+values, and every rerank resolves them twice — once for the authorization probe,
+then again for the stored-vector lookup. Without it each rerank scans the whole
+vector collection twice, and that cost grows with the corpus. The trailing
+`user_id` and `tenant_id` are the scope fields the second lookup filters on, so
+it can be answered from the index instead of fetching rows it then discards.
+
+Existing deployments get both on the next restart; they build in the background
+and need no re-embedding.
 
 
 ### Proxy Configuration

--- a/README.md
+++ b/README.md
@@ -271,7 +271,11 @@ POST /v1/rerank
 ```
 
 Limits: 64 inputs and 256,000 aggregate characters per embeddings call; 50
-candidates and `top_n <= 25` per rerank call. Caller ids are preserved and tie
+candidates, 8,000 query characters and `top_n <= 25` per rerank call. The
+character limits are provider limits, so they bind the payload that is actually
+sent — after NFKC normalization and including the space's task prefix, which
+applies to every input. Over-limit requests are rejected with `422` before any
+text reaches the backend. Caller ids are preserved and tie
 ordering is deterministic (ties break on the candidate's position in the
 request). `content_hash` is the SHA-256 of the NFKC-normalized,
 whitespace-collapsed text that was embedded. Vectors leave the service

--- a/README.md
+++ b/README.md
@@ -183,9 +183,24 @@ unrestricted entity access.
 - `RAG_AUTH_ACCEPT_LEGACY`: (Optional) default `true`. Set to `false` once every
   caller mints the full claim set.
 
-Scopes: `rag:embed` grants `POST /v1/embeddings`, `rag:rerank` grants
-`POST /v1/rerank`. The tenant claim (`tenant`, or `tenant_id`) is required for
-strict tokens; the reserved value `__SYSTEM__` is always refused.
+Scopes name a capability, and none of them substitutes for another:
+
+| Scope | Grants |
+| --- | --- |
+| `rag:embed` | `POST /v1/embeddings` |
+| `rag:rerank` | `POST /v1/rerank` |
+| `rag:documents` | `GET /ids`, `GET /documents`, `GET /documents/{id}/context`, `DELETE /documents` |
+
+The document plane and the inference plane are separate capabilities, so they
+carry separate scopes. `rag:documents` reads and deletes stored chunks and buys
+no inference; `rag:embed` and `rag:rerank` spend inference budget and reach no
+document route. A credential minted to delete one file therefore cannot be
+replayed against an embedding provider, and a leaked embedding credential
+cannot read or destroy stored content. A token carrying neither is refused
+either way — a strict token with no scopes at all is refused outright.
+
+The tenant claim (`tenant`, or `tenant_id`) is required for strict tokens; the
+reserved value `__SYSTEM__` is always refused.
 
 Callers may pass an `entity_id` to `/query` and `/query_multiple` to reach an
 agent's knowledge-base files. Strict tokens must list that id in their
@@ -212,7 +227,9 @@ Writes are scoped too: uploading under an `entity_id` the token does not permit
 is refused, so a caller cannot plant content in a knowledge base it cannot read.
 
 The file-addressed routes are scoped by the same builder, because a file id is
-caller-supplied and proves nothing about who may read it:
+caller-supplied and proves nothing about who may read it. All four require the
+`rag:documents` scope, and holding it is permission to address this plane, never
+permission to address another owner's rows inside it:
 
 | Route | Scope |
 | --- | --- |
@@ -220,6 +237,11 @@ caller-supplied and proves nothing about who may read it:
 | `GET /documents?ids=` | chunks the caller owns; anything else is `404` |
 | `GET /documents/{id}/context` | as above, for one file |
 | `DELETE /documents` | deletes only the caller's rows for those ids |
+
+A token missing `rag:documents` is refused with `403` before the store is
+touched, so the refusal says nothing about whether the file exists. Deployments
+that configure no signing key at all are unauthenticated and unchanged — scope
+enforcement starts where tokens do.
 
 Each accepts an optional `entity_id` query parameter, with the same rule as
 `/query`: strict tokens must list the id in their `entities` claim, legacy
@@ -235,6 +257,24 @@ are owned by that entity, so deleting or reading them needs `entity_id` on these
 routes just as querying them already does. A client that deletes an agent's file
 with a plain user token and no `entity_id` now gets `404` and leaves the chunks
 in place; pass the entity the file was uploaded under to remove them.
+
+**Upgrade note.** These four routes now require `rag:documents`. Strict tokens
+minted for them before the scope existed carried `rag:embed` — the smallest
+scope set that satisfied the non-empty-scopes rule — and are refused with `403`
+now that the plane has a scope of its own. Mint `rag:documents` for the calls
+that read or delete stored chunks and keep `rag:embed` for the ones that
+actually embed. Legacy `{"id": userId}` tokens predate every scope and are
+unaffected while `RAG_AUTH_ACCEPT_LEGACY` is true.
+
+The two directions are not symmetric, so the deploy order matters. Roll the
+minting change out first and this build second, or both together:
+
+- **Client first, service second — safe.** A build that does not yet require
+  `rag:documents` never inspects the scope on these routes, so a token carrying
+  it is simply accepted. The unknown scope is inert.
+- **Service first, client second — breaks.** This build refuses a token that
+  still carries only `rag:embed`, so every document read and delete returns
+  `403` until the client catches up.
 
 ### Authorize before egress
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,18 @@ They are accepted while `RAG_AUTH_ACCEPT_LEGACY` is true. On the `/v1` service
 endpoints the flag relaxes only the *claim shape* — a token signed with the
 application `JWT_SECRET` is never accepted there, in any mode.
 
+Legacy tokens predate scopes and entity lists, so they are grandfathered into
+both. That grandfather is limited to the `{"id": ...}` shape. A token that states
+its own `scopes` or `entities` keeps exactly what it stated even if it fails
+strict validation for some other reason — otherwise dropping `exp`, the tenant or
+the scopes from a `rag:embed`-only token would hand it every scope and
+unrestricted entity access.
+
 - `RAG_JWT_SECRET`: (Optional) dedicated signing secret for this service. At
   least 32 characters for HMAC algorithms. Required when `RAG_SEARCH_API_ENABLED=true`.
+  Whenever it is set the service validates it at startup — the key signs tokens
+  the middleware honours on `/query` and the upload routes regardless of whether
+  the search endpoints are mounted, so a short secret fails startup either way.
 - `RAG_JWT_PUBLIC_KEY`: (Optional) verification key when `RAG_JWT_ALGORITHM` is asymmetric.
 - `RAG_JWT_ALGORITHM`: (Optional) default `HS256`. `HS*`, `RS*`, `ES*` and `EdDSA` are supported.
 - `RAG_JWT_ISSUER`: (Optional) required `iss`, default `librechat`.
@@ -253,6 +263,17 @@ back to another model or space.
 - `RAG_CHAT_EMBEDDING_BASEURL` / `RAG_CHAT_EMBEDDING_API_KEY`: (Optional)
   OpenAI-compatible endpoint for the space, defaulting to `RAG_OPENAI_BASEURL`
   and `RAG_OPENAI_API_KEY`.
+- `RAG_CHAT_EMBEDDING_QUERY_PREFIX` / `RAG_CHAT_EMBEDDING_DOCUMENT_PREFIX`:
+  (Optional) task prefixes applied to `input_type: "query"` and
+  `input_type: "document"` respectively, both empty by default.
+
+`input_type` selects how the text is encoded. Asymmetric models — qwen3-embedding
+among them — expect a query and a passage to be encoded differently, so the space
+applies the matching task prefix and, where the backend exposes a dedicated batch
+query encoder, uses it. The prefixes are part of the space's locked definition:
+changing one changes every vector the space produces, so stored vectors have to
+be rebuilt to match. `content_hash` is always taken over the un-prefixed
+normalized text, so it stays a stable cache key for the same content.
 
 `/v1/rerank` implements the `fast-v1` profile as embed-blend: the query is
 embedded once through the retrieval cache, candidate vectors are read from the
@@ -344,12 +365,55 @@ The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by Lib
     {
       "path": "file_id",
       "type": "filter"
+    },
+    {
+      "path": "user_id",
+      "type": "filter"
+    },
+    {
+      "path": "tenant_id",
+      "type": "filter"
     }
   ]
 }
 ```
 
 Follow one of the [four documented methods](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#procedure) to create the vector index.
+
+#### Migrating an existing Atlas vector index
+
+`/query` and `/query_multiple` scope every search by owner and tenant, and those
+predicates are Atlas **pre-filters**. Atlas rejects a `$vectorSearch` whose filter
+references a path that is not declared as a filter field, so an index created
+before this release — one carrying only `file_id` — makes those endpoints fail
+rather than return results.
+
+If your index predates this release:
+
+1. In the Atlas UI, open **Atlas Search → your `$ATLAS_SEARCH_INDEX` → Edit Index
+   Definition**, or use `mongosh`/the Admin API with the JSON above.
+2. Add the `user_id` and `tenant_id` filter entries, keeping `numDimensions` and
+   `similarity` at whatever your deployment already uses.
+3. Save and wait for the index status to return to **Active**. Atlas rebuilds the
+   index in place; no re-embedding is required.
+4. Backfill `tenant_id` on chunks embedded before this release. They carry no
+   such field, and Atlas vector-search pre-filters match on declared scalar
+   values rather than on absent fields, so an untagged chunk stays invisible
+   until it is stamped with the base tenant:
+
+   ```javascript
+   db.getCollection("<COLLECTION_NAME>").updateMany(
+     { tenant_id: { $exists: false } },
+     { $set: { tenant_id: "__BASE__" } }
+   )
+   ```
+
+   `__BASE__` is the tenant every caller without a `tenant` claim resolves to, so
+   this restores exactly the visibility those chunks had before. Run it once,
+   after the index reaches **Active**.
+
+Queries against `file_id` continue to work throughout — only the owner- and
+tenant-scoped paths wait on the rebuild.
 
 #### Create a `file_id` Index (recommended)
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ agent's knowledge-base files. Strict tokens must list that id in their
 at face value — which is the reason to flip `RAG_AUTH_ACCEPT_LEGACY` off once
 the migration lands.
 
+Retrieval is scoped by document owner. `/query` and `/query_multiple` put that
+scope into the vector-store predicate, so a file belonging to another owner
+matches nothing rather than being filtered out after ranking. Documents written
+before `user_id` was recorded in chunk metadata are no longer visible to any
+caller; re-embed them if you still need them.
+
 ### Search service endpoints
 
 Enabled by `RAG_SEARCH_API_ENABLED=true` (default `false`); the service refuses

--- a/README.md
+++ b/README.md
@@ -137,6 +137,105 @@ The following environment variables are required to run the application:
 
 Make sure to set these environment variables before running the application. You can set them in a `.env` file or as system environment variables.
 
+### Authentication
+
+Requests carry a bearer JWT. Two token generations are recognised.
+
+**Strict tokens** are signed with `RAG_JWT_SECRET` — a key dedicated to this
+service — and carry `iss`, `aud`, `sub`, `exp`, a tenant claim, and scopes.
+`RAG_JWT_SECRET` must never be the application's `JWT_SECRET`: sharing the key
+makes every token minted for rag_api simultaneously a full API session token
+for the calling app, and vice versa. Startup refuses to proceed if the two
+match.
+
+**Legacy tokens** are the `{"id": userId}` shape older LibreChat releases mint.
+They are accepted while `RAG_AUTH_ACCEPT_LEGACY` is true. On the `/v1` service
+endpoints the flag relaxes only the *claim shape* — a token signed with the
+application `JWT_SECRET` is never accepted there, in any mode.
+
+- `RAG_JWT_SECRET`: (Optional) dedicated signing secret for this service. At
+  least 32 characters for HMAC algorithms. Required when `RAG_SEARCH_API_ENABLED=true`.
+- `RAG_JWT_PUBLIC_KEY`: (Optional) verification key when `RAG_JWT_ALGORITHM` is asymmetric.
+- `RAG_JWT_ALGORITHM`: (Optional) default `HS256`. `HS*`, `RS*`, `ES*` and `EdDSA` are supported.
+- `RAG_JWT_ISSUER`: (Optional) required `iss`, default `librechat`.
+- `RAG_JWT_AUDIENCE`: (Optional) required `aud`, default `rag_api`.
+- `RAG_JWT_LEEWAY_SECONDS`: (Optional) clock skew allowance, default `0`.
+- `RAG_AUTH_ACCEPT_LEGACY`: (Optional) default `true`. Set to `false` once every
+  caller mints the full claim set.
+
+Scopes: `rag:embed` grants `POST /v1/embeddings`, `rag:rerank` grants
+`POST /v1/rerank`. The tenant claim (`tenant`, or `tenant_id`) is required for
+strict tokens; the reserved value `__SYSTEM__` is always refused.
+
+Callers may pass an `entity_id` to `/query` and `/query_multiple` to reach an
+agent's knowledge-base files. Strict tokens must list that id in their
+`entities` claim. Legacy tokens cannot prove entity access, so the id is taken
+at face value — which is the reason to flip `RAG_AUTH_ACCEPT_LEGACY` off once
+the migration lands.
+
+### Search service endpoints
+
+Enabled by `RAG_SEARCH_API_ENABLED=true` (default `false`); the service refuses
+to start if enabled without a valid signing configuration.
+
+```text
+POST /v1/embeddings
+{ "space": "chat-v1", "input_type": "query" | "document",
+  "inputs": [{ "id": "...", "text": "..." }] }
+-> { "space", "model", "dimensions", "normalized",
+     "items": [{ "id", "content_hash", "embedding" }], "usage" }
+
+POST /v1/rerank
+{ "profile": "fast-v1", "query": "...",
+  "candidates": [{ "id", "text", "base_score" }], "top_n": 25 }
+-> { "profile", "model", "results": [{ "id", "index", "score" }] }
+```
+
+Limits: 64 inputs and 256,000 aggregate characters per embeddings call; 50
+candidates and `top_n <= 25` per rerank call. Caller ids are preserved and tie
+ordering is deterministic (ties break on the candidate's position in the
+request). `content_hash` is the SHA-256 of the NFKC-normalized,
+whitespace-collapsed text that was embedded. Vectors leave the service
+L2-normalized.
+
+The `chat-v1` space is substitution-locked: if its backend is unavailable, or
+returns a different dimensionality, the call fails with 503 rather than falling
+back to another model or space.
+
+- `RAG_SEARCH_API_ENABLED`: (Optional) default `false`.
+- `RAG_EMBEDDING_SPACE`: (Optional) space name, default `chat-v1`.
+- `RAG_CHAT_EMBEDDING_MODEL`: (Optional) default `qwen3-embedding-8b`.
+- `RAG_CHAT_EMBEDDING_DIMENSIONS`: (Optional) default `1024`.
+- `RAG_CHAT_EMBEDDING_BASEURL` / `RAG_CHAT_EMBEDDING_API_KEY`: (Optional)
+  OpenAI-compatible endpoint for the space, defaulting to `RAG_OPENAI_BASEURL`
+  and `RAG_OPENAI_API_KEY`.
+
+`/v1/rerank` implements the `fast-v1` profile as embed-blend: the query is
+embedded once through the retrieval cache, candidate vectors are read from the
+pgvector store wherever they already exist, and only vectorless candidates are
+embedded. The final score is reciprocal-rank fusion of cosine similarity with
+the caller's `base_score` — never pure embedding order, which regresses
+identifier and exact-match queries. Candidate ids resolve against the stored
+row's `uuid` or the chunk `digest` in its metadata, always restricted to owners
+the token permits.
+
+- `RAG_RERANK_RRF_K`: (Optional) fusion constant, default `60`.
+- `RAG_RERANK_SIMILARITY_WEIGHT` / `RAG_RERANK_BASE_WEIGHT`: (Optional) arm weights, default `1.0`.
+- `RAG_QUERY_EMBEDDING_CACHE_SIZE`: (Optional) shared query-vector cache size, default `128`.
+
+Rate limits apply per tenant and per subject, with separate embedding and
+rerank budgets. Counters are process-local, so a multi-pod deployment enforces
+`limit x pods`.
+
+- `RAG_RATE_LIMIT_ENABLED`: (Optional) default `true`.
+- `RAG_RATE_LIMIT_WINDOW_SECONDS`: (Optional) default `60`.
+- `RAG_RATE_LIMIT_EMBED_TENANT` / `RAG_RATE_LIMIT_EMBED_SUBJECT`: (Optional) default `600` / `120`.
+- `RAG_RATE_LIMIT_RERANK_TENANT` / `RAG_RATE_LIMIT_RERANK_SUBJECT`: (Optional) default `900` / `180`.
+
+Note for `atlas-mongo` deployments: `/query` and `/query_multiple` now put the
+owner predicate in the vector-search `filter`, so `user_id` must be declared as
+a filter field on the Atlas vector index.
+
 ### Embedding Batch Processing
 
 For large files, you can enable batched embedding processing to reduce memory consumption. This is particularly useful in memory-constrained environments like Kubernetes pods with memory limits.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,417 @@
+"""JWT verification for rag_api.
+
+Two token generations are recognised:
+
+* **Strict** tokens are signed with ``RAG_JWT_SECRET`` — a dedicated key that
+  must never be the LibreChat application ``JWT_SECRET`` — and carry issuer,
+  audience, subject, tenant and scopes.
+* **Legacy** tokens are the ``{"id": userId}`` shape LibreChat mints today.
+  They are accepted only while ``RAG_AUTH_ACCEPT_LEGACY`` is true.
+
+Key separation is what closes the bidirectional token-confusion channel: a
+LibreChat session token (signed with ``JWT_SECRET``) is never accepted on the
+``/v1`` service endpoints, in any mode. ``RAG_AUTH_ACCEPT_LEGACY`` relaxes the
+*claim shape*, never the *signing key*, for those endpoints.
+"""
+
+import os
+import jwt
+from jwt import PyJWTError
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence
+
+from fastapi import HTTPException, Request, status
+
+from app.config import logger
+
+SCOPE_EMBED = "rag:embed"
+SCOPE_RERANK = "rag:rerank"
+
+BASE_TENANT_ID = "__BASE__"
+SYSTEM_TENANT_ID = "__SYSTEM__"
+
+SERVICE_PATH_PREFIX = "/v1/"
+PUBLIC_PATHS = frozenset({"/docs", "/openapi.json", "/health"})
+
+_HMAC_ALGORITHMS = frozenset({"HS256", "HS384", "HS512"})
+_ASYMMETRIC_ALGORITHMS = frozenset(
+    {"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "EdDSA"}
+)
+_SUPPORTED_ALGORITHMS = _HMAC_ALGORITHMS | _ASYMMETRIC_ALGORITHMS
+
+_MIN_HMAC_SECRET_LENGTH = 32
+_LEGACY_ALGORITHMS = ["HS256"]
+
+
+class AuthError(Exception):
+    """Raised when a bearer token cannot be accepted."""
+
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _env_flag(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in ("true", "1", "yes", "on", "y")
+
+
+def _split_scopes(claims: Dict[str, Any]) -> FrozenSet[str]:
+    raw = claims.get("scopes", claims.get("scope"))
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str):
+        return frozenset(part for part in raw.split() if part)
+    if isinstance(raw, (list, tuple, set)):
+        return frozenset(str(part) for part in raw if str(part))
+    return frozenset()
+
+
+def _string_set(value: Any) -> FrozenSet[str]:
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        return frozenset({value}) if value else frozenset()
+    if isinstance(value, (list, tuple, set)):
+        return frozenset(str(item) for item in value if str(item))
+    return frozenset()
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The authenticated caller, as resolved from a verified bearer token."""
+
+    subject: str
+    tenant: str
+    scopes: FrozenSet[str] = field(default_factory=frozenset)
+    entities: FrozenSet[str] = field(default_factory=frozenset)
+    legacy: bool = False
+
+    def has_scope(self, scope: str) -> bool:
+        """Legacy tokens predate scopes and are grandfathered into all of them.
+
+        This is precisely what ``RAG_AUTH_ACCEPT_LEGACY=false`` turns off.
+        """
+        if self.legacy:
+            return True
+        return scope in self.scopes
+
+    def permits_entity(self, entity_id: str) -> bool:
+        """Whether the caller may act on documents owned by ``entity_id``.
+
+        A legacy token carries no entity list, so the caller's claim is taken at
+        face value — the same trust the current implementation extends. Strict
+        tokens must name the entity explicitly.
+        """
+        if entity_id == self.subject:
+            return True
+        if self.legacy:
+            return True
+        return entity_id in self.entities
+
+
+@dataclass(frozen=True)
+class AuthSettings:
+    rag_secret: Optional[str]
+    rag_public_key: Optional[str]
+    legacy_secret: Optional[str]
+    algorithm: str
+    issuer: str
+    audience: str
+    accept_legacy: bool
+    leeway: int
+    search_api_enabled: bool
+
+    @classmethod
+    def from_env(cls) -> "AuthSettings":
+        return cls(
+            rag_secret=(os.getenv("RAG_JWT_SECRET") or None),
+            rag_public_key=(os.getenv("RAG_JWT_PUBLIC_KEY") or None),
+            legacy_secret=(os.getenv("JWT_SECRET") or None),
+            algorithm=os.getenv("RAG_JWT_ALGORITHM", "HS256").strip().upper(),
+            issuer=os.getenv("RAG_JWT_ISSUER", "librechat").strip(),
+            audience=os.getenv("RAG_JWT_AUDIENCE", "rag_api").strip(),
+            accept_legacy=_env_flag("RAG_AUTH_ACCEPT_LEGACY", "true"),
+            leeway=int(os.getenv("RAG_JWT_LEEWAY_SECONDS", "0")),
+            search_api_enabled=_env_flag("RAG_SEARCH_API_ENABLED", "false"),
+        )
+
+    @property
+    def verification_key(self) -> Optional[str]:
+        if self.algorithm in _HMAC_ALGORITHMS:
+            return self.rag_secret
+        return self.rag_public_key
+
+    @property
+    def has_any_key(self) -> bool:
+        return bool(self.verification_key or self.legacy_secret)
+
+    def validate(self) -> None:
+        """Fail closed on unusable signing configuration.
+
+        Raised at import time by ``main`` so a misconfigured deployment never
+        reaches a state where it silently serves unauthenticated traffic.
+        """
+        if self.algorithm not in _SUPPORTED_ALGORITHMS:
+            raise RuntimeError(
+                f"RAG_JWT_ALGORITHM '{self.algorithm}' is not supported "
+                f"(expected one of {sorted(_SUPPORTED_ALGORITHMS)})"
+            )
+
+        if (
+            self.rag_secret
+            and self.legacy_secret
+            and self.rag_secret == self.legacy_secret
+        ):
+            raise RuntimeError(
+                "RAG_JWT_SECRET must differ from JWT_SECRET: sharing the key makes "
+                "every rag_api token a full LibreChat session token and vice versa"
+            )
+
+        if not self.accept_legacy and not self.verification_key:
+            raise RuntimeError(
+                "RAG_AUTH_ACCEPT_LEGACY=false requires a verification key "
+                "(RAG_JWT_SECRET, or RAG_JWT_PUBLIC_KEY for asymmetric algorithms)"
+            )
+
+        if not self.search_api_enabled:
+            return
+
+        if not self.verification_key:
+            raise RuntimeError(
+                "RAG_SEARCH_API_ENABLED=true requires "
+                + (
+                    "RAG_JWT_SECRET"
+                    if self.algorithm in _HMAC_ALGORITHMS
+                    else "RAG_JWT_PUBLIC_KEY"
+                )
+            )
+
+        if (
+            self.algorithm in _HMAC_ALGORITHMS
+            and len(self.rag_secret) < _MIN_HMAC_SECRET_LENGTH
+        ):
+            raise RuntimeError(
+                f"RAG_JWT_SECRET must be at least {_MIN_HMAC_SECRET_LENGTH} characters "
+                f"for {self.algorithm}"
+            )
+
+        if not self.issuer:
+            raise RuntimeError(
+                "RAG_JWT_ISSUER must be set when the search API is enabled"
+            )
+
+        if not self.audience:
+            raise RuntimeError(
+                "RAG_JWT_AUDIENCE must be set when the search API is enabled"
+            )
+
+
+_settings: Optional[AuthSettings] = None
+
+
+def get_settings() -> AuthSettings:
+    global _settings
+    if _settings is None:
+        _settings = AuthSettings.from_env()
+    return _settings
+
+
+def reset_settings() -> None:
+    """Drop the cached settings so the next read re-reads the environment."""
+    global _settings
+    _settings = None
+
+
+def validate_startup_config() -> AuthSettings:
+    settings = get_settings()
+    settings.validate()
+    if settings.search_api_enabled:
+        logger.info(
+            "Search API enabled | issuer=%s audience=%s algorithm=%s accept_legacy=%s",
+            settings.issuer,
+            settings.audience,
+            settings.algorithm,
+            settings.accept_legacy,
+        )
+    return settings
+
+
+def _principal_from_strict(claims: Dict[str, Any]) -> Principal:
+    subject = str(claims.get("sub") or "")
+    if not subject:
+        raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token is missing a subject")
+
+    tenant = claims.get("tenant") or claims.get("tenant_id")
+    if not tenant:
+        raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token is missing a tenant claim")
+    tenant = str(tenant)
+
+    scopes = _split_scopes(claims)
+    if not scopes:
+        raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token carries no scopes")
+
+    return Principal(
+        subject=subject,
+        tenant=tenant,
+        scopes=scopes,
+        entities=_string_set(claims.get("entities")),
+        legacy=False,
+    )
+
+
+def _principal_from_legacy(claims: Dict[str, Any]) -> Principal:
+    subject = str(claims.get("id") or claims.get("sub") or "")
+    if not subject:
+        raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token is missing a subject")
+    tenant = str(claims.get("tenant") or claims.get("tenant_id") or BASE_TENANT_ID)
+    return Principal(
+        subject=subject,
+        tenant=tenant,
+        scopes=_split_scopes(claims),
+        entities=_string_set(claims.get("entities")),
+        legacy=True,
+    )
+
+
+def _decode(
+    token: str,
+    key: str,
+    algorithms: Sequence[str],
+    settings: AuthSettings,
+    strict: bool,
+) -> Dict[str, Any]:
+    if strict:
+        return jwt.decode(
+            token,
+            key,
+            algorithms=list(algorithms),
+            audience=settings.audience,
+            issuer=settings.issuer,
+            leeway=settings.leeway,
+            options={"require": ["exp", "iss", "aud", "sub"], "verify_aud": True},
+        )
+    return jwt.decode(
+        token,
+        key,
+        algorithms=list(algorithms),
+        leeway=settings.leeway,
+        options={"verify_aud": False},
+    )
+
+
+def _legacy_claims_are_consistent(
+    claims: Dict[str, Any], settings: AuthSettings
+) -> bool:
+    """Legacy acceptance covers *absent* claims, never *wrong* ones."""
+    issuer = claims.get("iss")
+    if issuer is not None and str(issuer) != settings.issuer:
+        return False
+    audience = claims.get("aud")
+    if audience is None:
+        return True
+    audiences = audience if isinstance(audience, (list, tuple)) else [audience]
+    return settings.audience in [str(item) for item in audiences]
+
+
+def verify_token(
+    token: str,
+    settings: AuthSettings,
+    *,
+    allow_legacy_secret: bool,
+) -> Principal:
+    """Resolve a bearer token to a :class:`Principal` or raise :class:`AuthError`.
+
+    ``allow_legacy_secret`` is false for the ``/v1`` service endpoints: those
+    never accept a token signed with the LibreChat application secret, so a
+    captured session token cannot reach them.
+    """
+    verification_key = settings.verification_key
+
+    if verification_key:
+        try:
+            return _principal_from_strict(
+                _decode(token, verification_key, [settings.algorithm], settings, True)
+            )
+        except jwt.ExpiredSignatureError:
+            raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token has expired")
+        except (
+            jwt.InvalidSignatureError,
+            jwt.DecodeError,
+            jwt.InvalidAlgorithmError,
+        ):
+            pass
+        except (
+            jwt.InvalidAudienceError,
+            jwt.InvalidIssuerError,
+            jwt.MissingRequiredClaimError,
+            AuthError,
+        ) as exc:
+            # Signature verified but the claim set is not the strict one. That is
+            # exactly the transition case, and nothing else.
+            if not settings.accept_legacy:
+                detail = exc.detail if isinstance(exc, AuthError) else str(exc)
+                raise AuthError(
+                    status.HTTP_401_UNAUTHORIZED, f"Invalid token: {detail}"
+                )
+        except PyJWTError as exc:
+            raise AuthError(status.HTTP_401_UNAUTHORIZED, f"Invalid token: {exc}")
+
+    if not settings.accept_legacy:
+        raise AuthError(status.HTTP_401_UNAUTHORIZED, "Invalid token")
+
+    candidate_keys: List[tuple] = []
+    if verification_key:
+        candidate_keys.append((verification_key, [settings.algorithm]))
+    if allow_legacy_secret and settings.legacy_secret:
+        candidate_keys.append((settings.legacy_secret, _LEGACY_ALGORITHMS))
+
+    for key, algorithms in candidate_keys:
+        try:
+            claims = _decode(token, key, algorithms, settings, False)
+        except jwt.ExpiredSignatureError:
+            raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token has expired")
+        except PyJWTError:
+            continue
+        if not _legacy_claims_are_consistent(claims, settings):
+            continue
+        return _principal_from_legacy(claims)
+
+    raise AuthError(status.HTTP_401_UNAUTHORIZED, "Invalid token")
+
+
+def get_principal(request: Request) -> Principal:
+    """FastAPI dependency: the principal the middleware already verified."""
+    principal = getattr(request.state, "principal", None)
+    if principal is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    return principal
+
+
+def require_scope(scope: str):
+    """Dependency factory guarding a service endpoint with a single scope."""
+
+    async def dependency(request: Request) -> Principal:
+        settings = get_settings()
+        if not settings.search_api_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Search API is not enabled on this deployment",
+            )
+        principal = get_principal(request)
+        if principal.tenant == SYSTEM_TENANT_ID:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="System tenant may not call the search API",
+            )
+        if not principal.has_scope(scope):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Token is missing the '{scope}' scope",
+            )
+        return principal
+
+    return dependency

--- a/app/auth.py
+++ b/app/auth.py
@@ -234,6 +234,12 @@ def validate_startup_config() -> AuthSettings:
             settings.algorithm,
             settings.accept_legacy,
         )
+    if settings.accept_legacy:
+        logger.warning(
+            "RAG_AUTH_ACCEPT_LEGACY=true: legacy tokens carry no entity list, so a "
+            "caller-supplied entity_id is taken at face value. Set it false once "
+            "every caller mints the full claim set."
+        )
     return settings
 
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -42,6 +42,12 @@ _SUPPORTED_ALGORITHMS = _HMAC_ALGORITHMS | _ASYMMETRIC_ALGORITHMS
 _MIN_HMAC_SECRET_LENGTH = 32
 _LEGACY_ALGORITHMS = ["HS256"]
 
+# The subject claim of the pre-scopes ``{"id": userId}`` token shape, and the
+# claims a token uses to state its own authorization. A token carrying either of
+# the latter is never grandfathered into full privileges.
+_LEGACY_SUBJECT_CLAIM = "id"
+_AUTHORIZATION_CLAIMS = ("scopes", "scope", "entities")
+
 
 class AuthError(Exception):
     """Raised when a bearer token cannot be accepted."""
@@ -174,10 +180,9 @@ class AuthSettings:
                 "(RAG_JWT_SECRET, or RAG_JWT_PUBLIC_KEY for asymmetric algorithms)"
             )
 
-        if not self.search_api_enabled:
-            return
-
         if not self.verification_key:
+            if not self.search_api_enabled:
+                return
             raise RuntimeError(
                 "RAG_SEARCH_API_ENABLED=true requires "
                 + (
@@ -187,6 +192,12 @@ class AuthSettings:
                 )
             )
 
+        # Everything below validates a key that *is* configured, so it runs
+        # whether or not the search router is mounted. The middleware accepts
+        # RAG-signed strict tokens on /query, the upload routes and every other
+        # non-/v1 path regardless of RAG_SEARCH_API_ENABLED, so gating these
+        # checks on that flag would let a deployment protect its document APIs
+        # with a trivially weak secret and still start cleanly.
         if (
             self.algorithm in _HMAC_ALGORITHMS
             and len(self.rag_secret) < _MIN_HMAC_SECRET_LENGTH
@@ -198,12 +209,12 @@ class AuthSettings:
 
         if not self.issuer:
             raise RuntimeError(
-                "RAG_JWT_ISSUER must be set when the search API is enabled"
+                "RAG_JWT_ISSUER must not be empty when a RAG signing key is configured"
             )
 
         if not self.audience:
             raise RuntimeError(
-                "RAG_JWT_AUDIENCE must be set when the search API is enabled"
+                "RAG_JWT_AUDIENCE must not be empty when a RAG signing key is configured"
             )
 
 
@@ -266,17 +277,43 @@ def _principal_from_strict(claims: Dict[str, Any]) -> Principal:
     )
 
 
+def _declares_authorization(claims: Dict[str, Any]) -> bool:
+    """Whether the token states its own scopes or entity list."""
+    return any(claim in claims for claim in _AUTHORIZATION_CLAIMS)
+
+
 def _principal_from_legacy(claims: Dict[str, Any]) -> Principal:
+    """Resolve a transition-era token, without widening what it asked for.
+
+    The legacy grandfather in :meth:`Principal.has_scope` and
+    :meth:`Principal.permits_entity` exists for the ``{"id": userId}`` shape,
+    which predates scopes and entity lists entirely. It is withheld from every
+    other token, because handing it to a token that *states* its authorization
+    would mean a strict token gains privileges by being malformed: drop ``exp``,
+    the tenant, or the scopes and a ``rag:embed``-only token would come back
+    holding every scope and arbitrary entity access.
+
+    So legacy acceptance covers claims a token omits, never claims it makes.
+    """
     subject = str(claims.get("id") or claims.get("sub") or "")
     if not subject:
         raise AuthError(status.HTTP_401_UNAUTHORIZED, "Token is missing a subject")
-    tenant = str(claims.get("tenant") or claims.get("tenant_id") or BASE_TENANT_ID)
+
+    declares_authorization = _declares_authorization(claims)
+    if declares_authorization:
+        logger.warning(
+            "Token failed strict validation but states its own authorization; "
+            "honouring its scopes and entities rather than grandfathering it | "
+            "subject=%s",
+            subject,
+        )
+
     return Principal(
         subject=subject,
-        tenant=tenant,
+        tenant=str(claims.get("tenant") or claims.get("tenant_id") or BASE_TENANT_ID),
         scopes=_split_scopes(claims),
         entities=_string_set(claims.get("entities")),
-        legacy=True,
+        legacy=_LEGACY_SUBJECT_CLAIM in claims and not declares_authorization,
     )
 
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -26,6 +26,7 @@ from app.config import logger
 
 SCOPE_EMBED = "rag:embed"
 SCOPE_RERANK = "rag:rerank"
+SCOPE_DOCUMENTS = "rag:documents"
 
 BASE_TENANT_ID = "__BASE__"
 SYSTEM_TENANT_ID = "__SYSTEM__"
@@ -434,6 +435,15 @@ def get_principal(request: Request) -> Principal:
     return principal
 
 
+def _refuse_without_scope(principal: Principal, scope: str) -> None:
+    if principal.has_scope(scope):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Token is missing the '{scope}' scope",
+    )
+
+
 def require_scope(scope: str):
     """Dependency factory guarding a service endpoint with a single scope."""
 
@@ -450,11 +460,30 @@ def require_scope(scope: str):
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="System tenant may not call the search API",
             )
-        if not principal.has_scope(scope):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Token is missing the '{scope}' scope",
-            )
+        _refuse_without_scope(principal, scope)
         return principal
 
     return dependency
+
+
+async def require_document_scope(request: Request) -> Optional[Principal]:
+    """Dependency guarding the file-addressed document routes.
+
+    The document plane and the ``/v1`` inference plane are separate
+    capabilities, so they carry separate scopes. ``rag:documents`` reads and
+    deletes stored chunks; it buys no inference. ``rag:embed`` and
+    ``rag:rerank`` spend inference budget; neither one substitutes for this.
+    A credential minted to delete a file therefore cannot be replayed against
+    an embedding provider, and vice versa.
+
+    This is deliberately not :func:`require_scope`: that one gates the ``/v1``
+    router and 503s when the search API is off, while these routes serve every
+    deployment. A deployment with no signing key configured at all has no
+    principal to check — the middleware already warns that such requests are
+    unauthenticated — so scope enforcement starts where tokens do.
+    """
+    principal: Optional[Principal] = getattr(request.state, "principal", None)
+    if principal is None:
+        return None
+    _refuse_without_scope(principal, SCOPE_DOCUMENTS)
+    return principal

--- a/app/config.py
+++ b/app/config.py
@@ -54,9 +54,37 @@ VECTOR_DB_TYPE = VectorDBType(
 POSTGRES_USE_UNIX_SOCKET = (
     get_env_variable("POSTGRES_USE_UNIX_SOCKET", "False").lower() == "true"
 )
-POSTGRES_DB = get_env_variable("POSTGRES_DB", "mydatabase")
-POSTGRES_USER = get_env_variable("POSTGRES_USER", "myuser")
-POSTGRES_PASSWORD = get_env_variable("POSTGRES_PASSWORD", "mypassword")
+
+
+def require_env_variable(var_name: str, allow_empty: bool = False) -> str:
+    """Read a required credential, refusing to invent one.
+
+    A working fallback default is the defect, not the convenience: a sample
+    user/password pair baked into the code is exactly how a database ends up
+    reachable with credentials that are public in a compose file.
+    """
+    value = os.getenv(var_name)
+    if value is None or (value == "" and not allow_empty):
+        raise ValueError(
+            f"Environment variable '{var_name}' is required and has no default. "
+            "Set it in the environment or in your .env file."
+        )
+    return value
+
+
+# Credentials are required only for the backend that actually uses them.
+if VECTOR_DB_TYPE == VectorDBType.PGVECTOR:
+    POSTGRES_DB = require_env_variable("POSTGRES_DB")
+    POSTGRES_USER = require_env_variable("POSTGRES_USER")
+    # Unix-socket peer authentication legitimately carries no password.
+    POSTGRES_PASSWORD = require_env_variable(
+        "POSTGRES_PASSWORD", allow_empty=POSTGRES_USE_UNIX_SOCKET
+    )
+else:
+    POSTGRES_DB = get_env_variable("POSTGRES_DB", "")
+    POSTGRES_USER = get_env_variable("POSTGRES_USER", "")
+    POSTGRES_PASSWORD = get_env_variable("POSTGRES_PASSWORD", "")
+
 DB_HOST = get_env_variable("DB_HOST", "db")
 DB_PORT = get_env_variable("DB_PORT", "5432")
 PGVECTOR_CREATE_EXTENSION = get_env_variable(

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,6 +1,16 @@
 # app/constants.py
 from enum import Enum
 
+# Service endpoint limits — fixed by the search-stack contract, not tunable per
+# deployment: callers batch against them and the projector sizes its work units
+# from them.
+MAX_EMBEDDING_INPUTS = 64
+MAX_EMBEDDING_CHARS = 256_000
+MAX_RERANK_CANDIDATES = 50
+MAX_RERANK_TOP_N = 25
+
+RERANK_PROFILE_FAST_V1 = "fast-v1"
+
 
 class MESSAGES(str, Enum):
     DEFAULT = lambda msg="": f"{msg if msg else ''}"

--- a/app/constants.py
+++ b/app/constants.py
@@ -8,6 +8,11 @@ MAX_EMBEDDING_INPUTS = 64
 MAX_EMBEDDING_CHARS = 256_000
 MAX_RERANK_CANDIDATES = 50
 MAX_RERANK_TOP_N = 25
+# A rerank query is a single embedding input sent to the provider on its own, so
+# the aggregate candidate budget never bounds it. Without a limit of its own an
+# authenticated caller can hand the gateway an arbitrarily large query and get
+# the provider's rejection back as a 503.
+MAX_QUERY_CHARS = 8_000
 
 RERANK_PROFILE_FAST_V1 = "fast-v1"
 

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,57 +1,89 @@
 # app/middleware.py
-import os
-import jwt
-from jwt import PyJWTError
 from fastapi import Request
-from datetime import datetime, timezone
 from fastapi.responses import JSONResponse
+
 from app.config import logger
+from app.auth import (
+    AuthError,
+    PUBLIC_PATHS,
+    SERVICE_PATH_PREFIX,
+    get_settings,
+    verify_token,
+)
+
+_UNCONFIGURED_WARNING = (
+    "Neither RAG_JWT_SECRET nor JWT_SECRET is set — requests are not authenticated"
+)
+
+_warned_unconfigured = False
+
+
+def _warn_unconfigured_once() -> None:
+    global _warned_unconfigured
+    if not _warned_unconfigured:
+        _warned_unconfigured = True
+        logger.warning(_UNCONFIGURED_WARNING)
 
 
 async def security_middleware(request: Request, call_next):
     async def next_middleware_call():
         return await call_next(request)
 
-    if request.url.path in {"/docs", "/openapi.json", "/health"}:
+    path = request.url.path
+    if path in PUBLIC_PATHS:
         return await next_middleware_call()
 
-    jwt_secret = os.getenv("JWT_SECRET")
-    if not jwt_secret:
-        logger.warn("JWT_SECRET not found in environment variables")
+    settings = get_settings()
+    is_service_path = path.startswith(SERVICE_PATH_PREFIX)
+
+    if is_service_path and not settings.search_api_enabled:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "Search API is not enabled on this deployment"},
+        )
+
+    if not settings.has_any_key:
+        _warn_unconfigured_once()
         return await next_middleware_call()
 
     authorization = request.headers.get("Authorization")
     if not authorization or not authorization.startswith("Bearer "):
         logger.info(
-            f"Unauthorized request with missing or invalid Authorization header to: {request.url.path}"
+            "Unauthorized request with missing or invalid Authorization header to: %s",
+            path,
         )
         return JSONResponse(
             status_code=401,
             content={"detail": "Missing or invalid Authorization header"},
         )
 
-    token = authorization.split(" ")[1]
+    token = authorization.split(" ", 1)[1]
     try:
-        payload = jwt.decode(token, jwt_secret, algorithms=["HS256"])
-        exp_timestamp = payload.get("exp")
-        if exp_timestamp and datetime.now(tz=timezone.utc) > datetime.fromtimestamp(
-            exp_timestamp, tz=timezone.utc
-        ):
-            logger.info(
-                f"Unauthorized request with expired token to: {request.url.path}"
-            )
-            return JSONResponse(
-                status_code=401, content={"detail": "Token has expired"}
-            )
-
-        request.state.user = payload
-        logger.debug(f"{request.url.path} - {payload}")
-    except PyJWTError as e:
+        # The service endpoints never accept a token signed with the LibreChat
+        # application secret, regardless of the legacy transition flag.
+        principal = verify_token(
+            token, settings, allow_legacy_secret=not is_service_path
+        )
+    except AuthError as exc:
         logger.info(
-            f"Unauthorized request with invalid token to: {request.url.path}, reason: {str(e)}"
+            "Unauthorized request to: %s, reason: %s",
+            path,
+            exc.detail,
         )
-        return JSONResponse(
-            status_code=401, content={"detail": f"Invalid token: {str(e)}"}
-        )
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    request.state.principal = principal
+    request.state.user = {
+        "id": principal.subject,
+        "sub": principal.subject,
+        "tenant": principal.tenant,
+    }
+    logger.debug(
+        "%s - subject=%s tenant=%s legacy=%s",
+        path,
+        principal.subject,
+        principal.tenant,
+        principal.legacy,
+    )
 
     return await next_middleware_call()

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ from typing import List, Literal, Optional
 from app.constants import (
     MAX_EMBEDDING_CHARS,
     MAX_EMBEDDING_INPUTS,
+    MAX_QUERY_CHARS,
     MAX_RERANK_CANDIDATES,
     MAX_RERANK_TOP_N,
 )
@@ -115,7 +116,10 @@ class RerankCandidate(BaseModel):
 
 class RerankRequest(BaseModel):
     profile: str = Field(min_length=1)
-    query: str = Field(min_length=1)
+    # Bounded here rather than in the route: the query is embedded on its own, so
+    # the aggregate candidate budget below never covers it, and an unbounded one
+    # reaches the provider and comes back as a 503 instead of a 422.
+    query: str = Field(min_length=1, max_length=MAX_QUERY_CHARS)
     candidates: List[RerankCandidate] = Field(
         min_length=1, max_length=MAX_RERANK_CANDIDATES
     )

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,15 @@
 # app/models.py
 import hashlib
 from enum import Enum
-from pydantic import BaseModel
-from typing import Optional, List
+from pydantic import BaseModel, Field, field_validator
+from typing import List, Literal, Optional
+
+from app.constants import (
+    MAX_EMBEDDING_CHARS,
+    MAX_EMBEDDING_INPUTS,
+    MAX_RERANK_CANDIDATES,
+    MAX_RERANK_TOP_N,
+)
 
 
 class DocumentResponse(BaseModel):
@@ -42,3 +49,98 @@ class QueryMultipleBody(BaseModel):
     query: str
     file_ids: List[str]
     k: int = 4
+    entity_id: Optional[str] = None
+
+
+def _reject_duplicates(values: List[str], label: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{label} must be unique")
+
+
+class EmbeddingInput(BaseModel):
+    id: str = Field(min_length=1)
+    text: str = Field(min_length=1)
+
+
+class EmbeddingsRequest(BaseModel):
+    space: str = Field(min_length=1)
+    input_type: Literal["query", "document"]
+    inputs: List[EmbeddingInput] = Field(min_length=1, max_length=MAX_EMBEDDING_INPUTS)
+
+    @field_validator("inputs")
+    @classmethod
+    def _validate_inputs(cls, inputs: List[EmbeddingInput]) -> List[EmbeddingInput]:
+        _reject_duplicates([item.id for item in inputs], "input ids")
+        total_characters = sum(len(item.text) for item in inputs)
+        if total_characters > MAX_EMBEDDING_CHARS:
+            raise ValueError(
+                f"aggregate input length {total_characters} exceeds "
+                f"{MAX_EMBEDDING_CHARS} characters"
+            )
+        return inputs
+
+
+class EmbeddingItem(BaseModel):
+    id: str
+    content_hash: str
+    embedding: List[float]
+
+
+class EmbeddingsUsage(BaseModel):
+    input_count: int
+    total_characters: int
+
+
+class EmbeddingsResponse(BaseModel):
+    space: str
+    model: str
+    dimensions: int
+    normalized: bool
+    items: List[EmbeddingItem]
+    usage: EmbeddingsUsage
+
+
+class RerankCandidate(BaseModel):
+    id: str = Field(min_length=1)
+    text: Optional[str] = None
+    base_score: Optional[float] = None
+
+
+class RerankRequest(BaseModel):
+    profile: str = Field(min_length=1)
+    query: str = Field(min_length=1)
+    candidates: List[RerankCandidate] = Field(
+        min_length=1, max_length=MAX_RERANK_CANDIDATES
+    )
+    top_n: Optional[int] = Field(default=None, ge=1, le=MAX_RERANK_TOP_N)
+
+    @field_validator("candidates")
+    @classmethod
+    def _validate_candidates(
+        cls, candidates: List[RerankCandidate]
+    ) -> List[RerankCandidate]:
+        _reject_duplicates([candidate.id for candidate in candidates], "candidate ids")
+        total_characters = sum(len(candidate.text or "") for candidate in candidates)
+        if total_characters > MAX_EMBEDDING_CHARS:
+            raise ValueError(
+                f"aggregate candidate length {total_characters} exceeds "
+                f"{MAX_EMBEDDING_CHARS} characters"
+            )
+        return candidates
+
+    def resolved_top_n(self) -> int:
+        if self.top_n is None:
+            return min(len(self.candidates), MAX_RERANK_TOP_N)
+        return min(self.top_n, len(self.candidates))
+
+
+class RerankResult(BaseModel):
+    id: str
+    index: int
+    score: float
+
+
+class RerankResponse(BaseModel):
+    profile: str
+    model: str
+    results: List[RerankResult]

--- a/app/models.py
+++ b/app/models.py
@@ -70,6 +70,13 @@ class EmbeddingsRequest(BaseModel):
     @field_validator("inputs")
     @classmethod
     def _validate_inputs(cls, inputs: List[EmbeddingInput]) -> List[EmbeddingInput]:
+        """Reject the request on what the caller sent.
+
+        This is the cheap arm of the size limit. It cannot be the only one:
+        NFKC normalization runs in the route and expands compatibility
+        characters, so the route re-checks the aggregate length of the
+        normalized text before any of it reaches the backend.
+        """
         _reject_duplicates([item.id for item in inputs], "input ids")
         total_characters = sum(len(item.text) for item in inputs)
         if total_characters > MAX_EMBEDDING_CHARS:

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -88,6 +88,14 @@ from app.models import (
     DocumentResponse,
     QueryMultipleBody,
 )
+from app.auth import BASE_TENANT_ID
+from app.scope import (
+    PUBLIC_OWNER,
+    file_clause,
+    files_clause,
+    resolve_scope,
+    writer_tenant,
+)
 from app.services import embedding as embedding_service
 from app.services.vector_store.async_pg_vector import AsyncPgVector
 from app.utils.document_loader import (
@@ -183,42 +191,9 @@ def _order_documents_by_chunk_index(documents: List[Document]) -> List[Document]
     return ordered_documents
 
 
-PUBLIC_OWNER = "public"
-
-
-def resolve_owner_scope(request: Request, entity_id: Optional[str] = None) -> List[str]:
-    """Owners whose chunks the caller is allowed to see.
-
-    The result goes into the vector-store predicate *before* ranking. Nothing
-    downstream re-derives authorization from what the search returned — the old
-    "inspect ``documents[0]``" check authorized an entire result set from a
-    single hit and could not see the other hits at all.
-    """
-    principal = getattr(request.state, "principal", None)
-    if principal is None:
-        # No signing key configured anywhere: preserve the unauthenticated
-        # deployment's single-owner behaviour rather than opening the store.
-        return [entity_id] if entity_id else [PUBLIC_OWNER]
-
-    owners = {principal.subject}
-    if entity_id:
-        if not principal.permits_entity(entity_id):
-            logger.warning(
-                "Denied entity access | subject=%s entity=%s",
-                principal.subject,
-                entity_id,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Not authorized for the requested entity",
-            )
-        owners.add(entity_id)
-    return sorted(owners)
-
-
-def scoped_filter(file_clause: dict, owners: List[str]) -> dict:
-    """Combine the file predicate with the owner predicate for the store query."""
-    return {"$and": [file_clause, {"user_id": {"$in": owners}}]}
+INTERNAL_ERROR_DETAIL = (
+    "The request could not be completed. See the service logs for details."
+)
 
 
 def calculate_num_batches(total: int, batch_size: int) -> int:
@@ -231,7 +206,7 @@ def calculate_num_batches(total: int, batch_size: int) -> int:
 def get_user_id(request: Request, entity_id: str = None) -> str:
     """Extract user ID from request or entity_id."""
     if not hasattr(request.state, "user"):
-        return entity_id if entity_id else "public"
+        return entity_id if entity_id else PUBLIC_OWNER
     else:
         return entity_id if entity_id else request.state.user.get("id")
 
@@ -305,6 +280,17 @@ def build_ingestion_context(
     if include_memory:
         parts.append(get_process_memory_details())
     return " | ".join(parts)
+
+
+def resolve_writer(request: Request, entity_id: Optional[str] = None) -> tuple:
+    """``(owner, tenant)`` to stamp on the chunks this request writes.
+
+    Runs the same entity authorization as the read path: writing into another
+    entity's namespace would let a caller poison a knowledge base it cannot
+    read.
+    """
+    resolve_scope(request, entity_id)
+    return get_user_id(request, entity_id), writer_tenant(request)
 
 
 async def save_upload_file_async(file: UploadFile, temp_file_path: str) -> None:
@@ -450,7 +436,7 @@ async def get_all_ids(request: Request):
             str(e),
             traceback.format_exc(),
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.get("/health")
@@ -509,7 +495,7 @@ async def get_documents_by_ids(request: Request, ids: list[str] = Query(...)):
             str(e),
             traceback.format_exc(),
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.delete("/documents")
@@ -547,7 +533,7 @@ async def delete_documents(request: Request, document_ids: List[str] = Body(...)
             str(e),
             traceback.format_exc(),
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 # Shared with POST /v1/rerank so a rerank following a retrieval on the same
@@ -560,8 +546,8 @@ async def query_embeddings_by_file_id(
     body: QueryRequestBody,
     request: Request,
 ):
-    owners = resolve_owner_scope(request, body.entity_id)
-    query_filter = scoped_filter({"file_id": {"$eq": body.file_id}}, owners)
+    scope = resolve_scope(request, body.entity_id)
+    query_filter = scope.predicate(file_clause(body.file_id))
 
     try:
         embedding = get_cached_query_embedding(body.query)
@@ -595,7 +581,7 @@ async def query_embeddings_by_file_id(
             str(e),
             traceback.format_exc(),
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 async def _process_documents_async_pipeline(
@@ -961,10 +947,14 @@ def _prepare_documents_sync(
     file_id: str,
     user_id: str,
     clean_content: bool,
+    tenant_id: str = BASE_TENANT_ID,
 ) -> List[Document]:
     """
     Synchronous document preparation - runs in executor to avoid blocking event loop.
     Handles text splitting, cleaning, and metadata preparation.
+
+    ``tenant_id`` is recorded on every chunk so the retrieval predicate can scope
+    by tenant in the store rather than trusting a later filter.
     """
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP
@@ -983,6 +973,7 @@ def _prepare_documents_sync(
             metadata={
                 "file_id": file_id,
                 "user_id": user_id,
+                "tenant_id": tenant_id,
                 "digest": generate_digest(doc.page_content),
                 **(doc.metadata or {}),
             },
@@ -1001,6 +992,7 @@ async def store_data_in_vector_db(
     filename: Optional[str] = None,
     content_type: Optional[str] = None,
     temp_file_path: Optional[str] = None,
+    tenant_id: str = BASE_TENANT_ID,
 ) -> bool:
     start_time = time.perf_counter()
     # Run document preparation in executor to avoid blocking the event loop
@@ -1012,6 +1004,7 @@ async def store_data_in_vector_db(
         file_id,
         user_id,
         clean_content,
+        tenant_id,
     )
 
     logger.info(
@@ -1099,7 +1092,7 @@ async def store_data_in_vector_db(
 async def embed_local_file(
     document: StoreDocument, request: Request, entity_id: str = None
 ):
-    user_id = get_user_id(request, entity_id)
+    user_id, tenant_id = resolve_writer(request, entity_id)
     file_path = validate_file_path(RAG_UPLOAD_DIR, document.filepath)
 
     # Check if the file exists and if it is within the allowed upload directory
@@ -1147,6 +1140,7 @@ async def embed_local_file(
             filename=document.filename,
             content_type=document.file_content_type,
             temp_file_path=file_path,
+            tenant_id=tenant_id,
         )
 
         if result:
@@ -1207,7 +1201,7 @@ async def embed_file(
     response_message = "File processed successfully."
     known_type = None
 
-    user_id = get_user_id(request, entity_id)
+    user_id, tenant_id = resolve_writer(request, entity_id)
     validated_file_path = _make_unique_temp_path(user_id, file.filename)
 
     if validated_file_path is None:
@@ -1261,6 +1255,7 @@ async def embed_file(
             filename=file.filename,
             content_type=file.content_type,
             temp_file_path=validated_file_path,
+            tenant_id=tenant_id,
         )
 
         if not result:
@@ -1374,7 +1369,7 @@ async def embed_file_upload(
     uploaded_file: UploadFile = File(...),
     entity_id: str = Form(None),
 ):
-    user_id = get_user_id(request, entity_id)
+    user_id, tenant_id = resolve_writer(request, entity_id)
 
     validated_temp_file_path = _make_unique_temp_path(user_id, uploaded_file.filename)
 
@@ -1421,6 +1416,7 @@ async def embed_file_upload(
             filename=uploaded_file.filename,
             content_type=uploaded_file.content_type,
             temp_file_path=validated_temp_file_path,
+            tenant_id=tenant_id,
         )
 
         if not result:
@@ -1465,8 +1461,8 @@ async def embed_file_upload(
 
 @router.post("/query_multiple")
 async def query_embeddings_by_file_ids(request: Request, body: QueryMultipleBody):
-    owners = resolve_owner_scope(request, body.entity_id)
-    query_filter = scoped_filter({"file_id": {"$in": body.file_ids}}, owners)
+    scope = resolve_scope(request, body.entity_id)
+    query_filter = scope.predicate(files_clause(body.file_ids))
 
     try:
         # Get the embedding of the query text
@@ -1510,7 +1506,7 @@ async def query_embeddings_by_file_ids(request: Request, body: QueryMultipleBody
             str(e),
             traceback.format_exc(),
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.post("/text")

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -415,12 +415,17 @@ async def cleanup_temp_file_async(file_path: str) -> None:
 
 
 @router.get("/ids")
-async def get_all_ids(request: Request):
+async def get_all_ids(request: Request, entity_id: Optional[str] = Query(None)):
+    scope = resolve_scope(request, entity_id)
     try:
         if isinstance(vector_store, AsyncPgVector):
-            ids = await vector_store.get_all_ids(executor=request.app.state.thread_pool)
+            ids = await vector_store.get_all_ids(
+                list(scope.owners),
+                scope.tenant_values(),
+                executor=request.app.state.thread_pool,
+            )
         else:
-            ids = vector_store.get_all_ids()
+            ids = vector_store.get_all_ids(list(scope.owners), scope.tenant_values())
 
         return list(set(ids))
     except HTTPException as http_exc:
@@ -457,18 +462,32 @@ async def health_check():
 
 
 @router.get("/documents", response_model=list[DocumentResponse])
-async def get_documents_by_ids(request: Request, ids: list[str] = Query(...)):
+async def get_documents_by_ids(
+    request: Request,
+    ids: list[str] = Query(...),
+    entity_id: Optional[str] = Query(None),
+):
+    """Chunks of the named files, restricted to the caller's scope.
+
+    A file id is caller-supplied and proves nothing, so the owner and tenant
+    predicate goes into the store query alongside it. A file outside the scope
+    is "not found" rather than "found but refused": distinguishing the two would
+    turn this route into an existence oracle over the whole deployment.
+    """
+    scope = resolve_scope(request, entity_id)
+    owners = list(scope.owners)
+    tenants = scope.tenant_values()
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners, tenants, executor=request.app.state.thread_pool
             )
             documents = await vector_store.get_documents_by_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners, tenants, executor=request.app.state.thread_pool
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(ids)
-            documents = vector_store.get_documents_by_ids(ids)
+            existing_ids = vector_store.get_filtered_ids(ids, owners, tenants)
+            documents = vector_store.get_documents_by_ids(ids, owners, tenants)
 
         # Ensure all requested ids exist
         if not all(id in existing_ids for id in ids):
@@ -499,18 +518,34 @@ async def get_documents_by_ids(request: Request, ids: list[str] = Query(...)):
 
 
 @router.delete("/documents")
-async def delete_documents(request: Request, document_ids: List[str] = Body(...)):
+async def delete_documents(
+    request: Request,
+    document_ids: List[str] = Body(...),
+    entity_id: Optional[str] = Query(None),
+):
+    """Delete the named files' chunks, restricted to the caller's scope.
+
+    The scope is part of the DELETE predicate, not a check performed beside it:
+    a file id is chosen by whoever uploaded, so two owners can hold rows under
+    the same id and only the caller's may be removed.
+    """
+    scope = resolve_scope(request, entity_id)
+    owners = list(scope.owners)
+    tenants = scope.tenant_values()
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                document_ids, executor=request.app.state.thread_pool
+                document_ids, owners, tenants, executor=request.app.state.thread_pool
             )
-            await vector_store.delete(
-                ids=document_ids, executor=request.app.state.thread_pool
+            await vector_store.delete_scoped(
+                document_ids,
+                owners,
+                tenants,
+                executor=request.app.state.thread_pool,
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(document_ids)
-            vector_store.delete(ids=document_ids)
+            existing_ids = vector_store.get_filtered_ids(document_ids, owners, tenants)
+            vector_store.delete_scoped(document_ids, owners, tenants)
 
         if not all(id in existing_ids for id in document_ids):
             raise HTTPException(status_code=404, detail="One or more IDs not found")
@@ -924,8 +959,16 @@ async def _process_documents_batched_sync(
             ):  # any batch succeeded (i.e., any chunks for this file were inserted)
                 logger.warning("Rolling back file %s due to batch failure", file_id)
                 try:
+                    # Scoped to the writer: `file_id` is caller-supplied, so an
+                    # unscoped rollback would delete another owner's chunks that
+                    # happen to sit under the same id.
+                    owner = documents[0].metadata.get("user_id")
+                    tenant = documents[0].metadata.get("tenant_id")
                     await loop.run_in_executor(
-                        executor, lambda: vector_store.delete(ids=[file_id])
+                        executor,
+                        lambda: vector_store.delete_scoped(
+                            [file_id], [owner], [tenant]
+                        ),
                     )
                     logger.info("Rollback completed for file %s", file_id)
                 except Exception as rollback_error:
@@ -1319,19 +1362,29 @@ async def embed_file(
 
 
 @router.get("/documents/{id}/context")
-async def load_document_context(request: Request, id: str):
+async def load_document_context(
+    request: Request, id: str, entity_id: Optional[str] = Query(None)
+):
+    """Full text of one file, restricted to the caller's scope.
+
+    This route returns raw document content, so the owner and tenant predicate
+    is part of the store query exactly as it is for ``/query``.
+    """
     ids = [id]
+    scope = resolve_scope(request, entity_id)
+    owners = list(scope.owners)
+    tenants = scope.tenant_values()
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners, tenants, executor=request.app.state.thread_pool
             )
             documents = await vector_store.get_documents_by_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners, tenants, executor=request.app.state.thread_pool
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(ids)
-            documents = vector_store.get_documents_by_ids(ids)
+            existing_ids = vector_store.get_filtered_ids(ids, owners, tenants)
+            documents = vector_store.get_documents_by_ids(ids, owners, tenants)
 
         # Ensure the requested id exists
         if not all(id in existing_ids for id in ids):

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -14,6 +14,7 @@ from typing import List, Iterable, Optional, Union, TYPE_CHECKING
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import (
     APIRouter,
+    Depends,
     Request,
     UploadFile,
     HTTPException,
@@ -88,7 +89,7 @@ from app.models import (
     DocumentResponse,
     QueryMultipleBody,
 )
-from app.auth import BASE_TENANT_ID
+from app.auth import BASE_TENANT_ID, require_document_scope
 from app.scope import (
     PUBLIC_OWNER,
     file_clause,
@@ -108,6 +109,10 @@ from app.utils.health import is_health_ok
 from app.utils.text import fingerprint
 
 router = APIRouter()
+
+# The file-addressed routes: they read or delete stored chunks by id and need no
+# inference capability to do it, so they are guarded by the document scope alone.
+DOCUMENT_PLANE = [Depends(require_document_scope)]
 
 _INGESTION_ATTEMPT_ID_KEY = "_rag_ingestion_attempt_id"
 _INGESTION_ATTEMPT_STARTED_AT_NS_KEY = "_rag_ingestion_attempt_started_at_ns"
@@ -414,7 +419,7 @@ async def cleanup_temp_file_async(file_path: str) -> None:
         )
 
 
-@router.get("/ids")
+@router.get("/ids", dependencies=DOCUMENT_PLANE)
 async def get_all_ids(request: Request, entity_id: Optional[str] = Query(None)):
     scope = resolve_scope(request, entity_id)
     try:
@@ -461,7 +466,9 @@ async def health_check():
         return {"status": "DOWN", "error": str(e)}, 503
 
 
-@router.get("/documents", response_model=list[DocumentResponse])
+@router.get(
+    "/documents", response_model=list[DocumentResponse], dependencies=DOCUMENT_PLANE
+)
 async def get_documents_by_ids(
     request: Request,
     ids: list[str] = Query(...),
@@ -517,7 +524,7 @@ async def get_documents_by_ids(
         raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
-@router.delete("/documents")
+@router.delete("/documents", dependencies=DOCUMENT_PLANE)
 async def delete_documents(
     request: Request,
     document_ids: List[str] = Body(...),
@@ -1361,7 +1368,7 @@ async def embed_file(
     }
 
 
-@router.get("/documents/{id}/context")
+@router.get("/documents/{id}/context", dependencies=DOCUMENT_PLANE)
 async def load_document_context(
     request: Request, id: str, entity_id: Optional[str] = Query(None)
 ):

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -966,16 +966,20 @@ def _prepare_documents_sync(
         for doc in documents:
             doc.page_content = clean_text(doc.page_content)
 
-    # Preparing documents with page content and metadata for insertion.
+    # Loader metadata is untrusted: it comes from the uploaded file itself, and
+    # several loaders preserve document properties verbatim. It is merged first
+    # so the request's verified identity always wins — a crafted property named
+    # tenant_id, user_id, file_id or digest would otherwise overwrite the value
+    # taken from the token and stamp these chunks into another tenant.
     return [
         Document(
             page_content=doc.page_content,
             metadata={
+                **(doc.metadata or {}),
                 "file_id": file_id,
                 "user_id": user_id,
                 "tenant_id": tenant_id,
                 "digest": generate_digest(doc.page_content),
-                **(doc.metadata or {}),
             },
         )
         for doc in documents

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -25,7 +25,6 @@ from fastapi import (
 )
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from functools import lru_cache
 
 if TYPE_CHECKING:
     from app.services.vector_store.async_pg_vector import AsyncPgVector
@@ -89,6 +88,7 @@ from app.models import (
     DocumentResponse,
     QueryMultipleBody,
 )
+from app.services import embedding as embedding_service
 from app.services.vector_store.async_pg_vector import AsyncPgVector
 from app.utils.document_loader import (
     get_loader,
@@ -97,6 +97,7 @@ from app.utils.document_loader import (
     cleanup_temp_encoding_file,
 )
 from app.utils.health import is_health_ok
+from app.utils.text import fingerprint
 
 router = APIRouter()
 
@@ -180,6 +181,44 @@ def _order_documents_by_chunk_index(documents: List[Document]) -> List[Document]
     for attempt_key in sorted(attempt_groups):
         ordered_documents.extend(order_group(attempt_groups[attempt_key]))
     return ordered_documents
+
+
+PUBLIC_OWNER = "public"
+
+
+def resolve_owner_scope(request: Request, entity_id: Optional[str] = None) -> List[str]:
+    """Owners whose chunks the caller is allowed to see.
+
+    The result goes into the vector-store predicate *before* ranking. Nothing
+    downstream re-derives authorization from what the search returned — the old
+    "inspect ``documents[0]``" check authorized an entire result set from a
+    single hit and could not see the other hits at all.
+    """
+    principal = getattr(request.state, "principal", None)
+    if principal is None:
+        # No signing key configured anywhere: preserve the unauthenticated
+        # deployment's single-owner behaviour rather than opening the store.
+        return [entity_id] if entity_id else [PUBLIC_OWNER]
+
+    owners = {principal.subject}
+    if entity_id:
+        if not principal.permits_entity(entity_id):
+            logger.warning(
+                "Denied entity access | subject=%s entity=%s",
+                principal.subject,
+                entity_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized for the requested entity",
+            )
+        owners.add(entity_id)
+    return sorted(owners)
+
+
+def scoped_filter(file_clause: dict, owners: List[str]) -> dict:
+    """Combine the file predicate with the owner predicate for the store query."""
+    return {"$and": [file_clause, {"user_id": {"$in": owners}}]}
 
 
 def calculate_num_batches(total: int, batch_size: int) -> int:
@@ -511,10 +550,9 @@ async def delete_documents(request: Request, document_ids: List[str] = Body(...)
         raise HTTPException(status_code=500, detail=str(e))
 
 
-# Cache the embedding function with LRU cache
-@lru_cache(maxsize=128)
-def get_cached_query_embedding(query: str):
-    return vector_store.embedding_function.embed_query(query)
+# Shared with POST /v1/rerank so a rerank following a retrieval on the same
+# query string pays no query inference at all.
+get_cached_query_embedding = embedding_service.get_cached_query_embedding
 
 
 @router.post("/query")
@@ -522,14 +560,8 @@ async def query_embeddings_by_file_id(
     body: QueryRequestBody,
     request: Request,
 ):
-    if not hasattr(request.state, "user"):
-        user_authorized = body.entity_id if body.entity_id else "public"
-    else:
-        user_authorized = (
-            body.entity_id if body.entity_id else request.state.user.get("id")
-        )
-
-    authorized_documents = []
+    owners = resolve_owner_scope(request, body.entity_id)
+    query_filter = scoped_filter({"file_id": {"$eq": body.file_id}}, owners)
 
     try:
         embedding = get_cached_query_embedding(body.query)
@@ -538,46 +570,15 @@ async def query_embeddings_by_file_id(
             documents = await vector_store.asimilarity_search_with_score_by_vector(
                 embedding,
                 k=body.k,
-                filter={"file_id": {"$eq": body.file_id}},
+                filter=query_filter,
                 executor=request.app.state.thread_pool,
             )
         else:
             documents = vector_store.similarity_search_with_score_by_vector(
-                embedding, k=body.k, filter={"file_id": {"$eq": body.file_id}}
+                embedding, k=body.k, filter=query_filter
             )
 
-        documents = _apply_distance_threshold(documents)
-
-        if not documents:
-            return authorized_documents
-
-        document, score = documents[0]
-        doc_metadata = document.metadata
-        doc_user_id = doc_metadata.get("user_id")
-
-        if doc_user_id is None or doc_user_id == user_authorized:
-            authorized_documents = documents
-        else:
-            # If using entity_id and access denied, try again with user's actual ID
-            if body.entity_id and hasattr(request.state, "user"):
-                user_authorized = request.state.user.get("id")
-                if doc_user_id == user_authorized:
-                    authorized_documents = documents
-                else:
-                    if body.entity_id == doc_user_id:
-                        logger.warning(
-                            f"Entity ID {body.entity_id} matches document user_id but user {user_authorized} is not authorized"
-                        )
-                    else:
-                        logger.warning(
-                            f"Access denied for both entity ID {body.entity_id} and user {user_authorized} to document with user_id {doc_user_id}"
-                        )
-            else:
-                logger.warning(
-                    f"Unauthorized access attempt by user {user_authorized} to a document with user_id {doc_user_id}"
-                )
-
-        return authorized_documents
+        return _apply_distance_threshold(documents)
 
     except HTTPException as http_exc:
         logger.error(
@@ -590,7 +591,7 @@ async def query_embeddings_by_file_id(
         logger.error(
             "Error in query embeddings | File ID: %s | Query: %s | Error: %s | Traceback: %s",
             body.file_id,
-            body.query,
+            fingerprint(body.query),
             str(e),
             traceback.format_exc(),
         )
@@ -1464,21 +1465,25 @@ async def embed_file_upload(
 
 @router.post("/query_multiple")
 async def query_embeddings_by_file_ids(request: Request, body: QueryMultipleBody):
+    owners = resolve_owner_scope(request, body.entity_id)
+    query_filter = scoped_filter({"file_id": {"$in": body.file_ids}}, owners)
+
     try:
         # Get the embedding of the query text
         embedding = get_cached_query_embedding(body.query)
 
-        # Perform similarity search with the query embedding and filter by the file_ids in metadata
+        # Perform similarity search with the query embedding, filtered by the
+        # requested file ids *and* the owners the caller is authorized for.
         if isinstance(vector_store, AsyncPgVector):
             documents = await vector_store.asimilarity_search_with_score_by_vector(
                 embedding,
                 k=body.k,
-                filter={"file_id": {"$in": body.file_ids}},
+                filter=query_filter,
                 executor=request.app.state.thread_pool,
             )
         else:
             documents = vector_store.similarity_search_with_score_by_vector(
-                embedding, k=body.k, filter={"file_id": {"$in": body.file_ids}}
+                embedding, k=body.k, filter=query_filter
             )
 
         documents = _apply_distance_threshold(documents)
@@ -1501,7 +1506,7 @@ async def query_embeddings_by_file_ids(request: Request, body: QueryMultipleBody
         logger.error(
             "Error in query multiple embeddings | File IDs: %s | Query: %s | Error: %s | Traceback: %s",
             body.file_ids,
-            body.query,
+            fingerprint(body.query),
             str(e),
             traceback.format_exc(),
         )

--- a/app/routes/search_routes.py
+++ b/app/routes/search_routes.py
@@ -1,14 +1,15 @@
 # app/routes/search_routes.py
-"""Strict service endpoints for the LibreChat search stack.
+"""Strict service endpoints for embedding and reranking.
 
 ``POST /v1/embeddings`` serves the substitution-locked ``chat-v1`` space.
-``POST /v1/rerank`` serves the ``fast-v1`` profile as embed-blend v0.
+``POST /v1/rerank`` serves the ``fast-v1`` profile as embed-blend.
 
 Neither endpoint returns candidate text, and neither logs query or candidate
 text — only lengths and non-reversible fingerprints.
 """
 
 import asyncio
+import inspect
 import traceback
 from typing import Dict, List, Optional, Sequence
 
@@ -30,6 +31,8 @@ from app.models import (
     RerankResponse,
     RerankResult,
 )
+from app.scope import ScopeFilter, token_scope
+from app.services.vector_store.async_pg_vector import AsyncPgVector
 from app.services import embedding as embedding_service
 from app.services import ratelimit
 from app.services.rerank import (
@@ -132,22 +135,96 @@ async def create_embeddings(
     )
 
 
+async def _call_store(request: Request, method_name: str, *args):
+    """Invoke a store method, handing the async store this request's executor.
+
+    The async store caches ``loop._default_executor`` when none is supplied, and
+    that executor belongs to whichever event loop ran first — it is already shut
+    down by the next request.
+    """
+    method = getattr(vector_store, method_name, None)
+    if method is None:
+        return None
+    if isinstance(vector_store, AsyncPgVector):
+        result = method(*args, executor=_executor(request))
+    else:
+        result = method(*args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def _authorize_candidates(
+    request: Request, ids: Sequence[str], scope: ScopeFilter
+) -> None:
+    """Refuse candidates that exist in the store outside the caller's scope.
+
+    This runs *before* any text leaves the process. A caller who names another
+    owner's chunk and supplies its text must not have that text embedded: the
+    unauthorized content would leave the trust boundary even though the caller
+    never sees it in a response. Ids that match nothing in the store —
+    web-scrape candidates, synthetic ids — are unaffected.
+
+    The probe reads metadata only, never vectors or document text. If it cannot
+    run, the request fails closed: without it there is no way to tell a foreign
+    candidate from a fresh one.
+    """
+    if not hasattr(vector_store, "probe_candidate_ids"):
+        return
+    try:
+        probed = await _call_store(
+            request,
+            "probe_candidate_ids",
+            list(ids),
+            list(scope.owners),
+            scope.tenant_values(),
+        )
+        existing, authorized = probed
+    except Exception as exc:
+        logger.error(
+            "Candidate authorization probe failed | %s: %s", type(exc).__name__, exc
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Candidate authorization is unavailable",
+        )
+
+    foreign = sorted(existing - authorized)
+    if foreign:
+        logger.warning(
+            "Refused out-of-scope rerank candidates | tenant=%s owners=%s count=%d",
+            scope.tenant,
+            ",".join(scope.owners),
+            len(foreign),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Candidates outside the caller's scope: {foreign}",
+        )
+
+
 async def _stored_vectors(
-    request: Request, ids: Sequence[str], owners: Sequence[str]
+    request: Request, ids: Sequence[str], scope: ScopeFilter
 ) -> Dict[str, List[float]]:
-    """Candidate vectors already in the store, scoped to owners the token permits.
+    """Candidate vectors already in the store, scoped to the caller's tenant and owners.
 
     A store failure degrades to "no stored vectors" — the vectorless path still
-    produces a correct ranking, just at the cost of candidate inference.
+    produces a correct ranking, at the cost of candidate inference. That is safe
+    only because :func:`_authorize_candidates` has already run and fails closed.
     """
-    lookup = getattr(vector_store, "get_vectors_by_ids", None)
-    if lookup is None or not owners:
+    if not hasattr(vector_store, "get_vectors_by_ids") or not scope.owners:
         return {}
     try:
-        result = lookup(list(ids), list(owners))
-        if asyncio.iscoroutine(result):
-            return await result
-        return result
+        return (
+            await _call_store(
+                request,
+                "get_vectors_by_ids",
+                list(ids),
+                list(scope.owners),
+                scope.tenant_values(),
+            )
+            or {}
+        )
     except Exception as exc:
         logger.warning(
             "Stored candidate vector lookup failed, falling back to inference | %s: %s",
@@ -171,10 +248,12 @@ async def rerank(
 
     _enforce_budget(ratelimit.BUDGET_RERANK, principal)
 
-    owners = sorted({principal.subject} | set(principal.entities))
-    stored = await _stored_vectors(
-        request, [candidate.id for candidate in body.candidates], owners
-    )
+    # Authorize before egress: every candidate is scope-checked against the
+    # store before a single character of candidate text reaches the gateway.
+    scope = token_scope(request)
+    candidate_ids = [candidate.id for candidate in body.candidates]
+    await _authorize_candidates(request, candidate_ids, scope)
+    stored = await _stored_vectors(request, candidate_ids, scope)
 
     pending: List[int] = []
     pending_texts: List[str] = []

--- a/app/routes/search_routes.py
+++ b/app/routes/search_routes.py
@@ -5,12 +5,13 @@
 ``POST /v1/rerank`` serves the ``fast-v1`` profile as embed-blend.
 
 Neither endpoint returns candidate text, and neither logs query or candidate
-text — only lengths and non-reversible fingerprints.
+text — only lengths and non-reversible fingerprints. That extends to failures:
+an exception message is provider- or driver-controlled and routinely quotes the
+input that caused it, so only the exception's class chain is ever logged.
 """
 
 import asyncio
 import inspect
-import traceback
 from typing import Dict, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -45,6 +46,26 @@ from app.services.space import SpaceBackendError, get_space, known_spaces
 from app.utils.text import content_hash, fingerprint, normalize_text
 
 router = APIRouter(prefix="/v1")
+
+_MAX_CAUSE_DEPTH = 5
+
+
+def error_category(exc: BaseException) -> str:
+    """The exception's class chain — never its message, never a traceback.
+
+    An inference gateway that rejects an input commonly echoes that input back
+    in the error, and ``SpaceBackendError`` wraps the provider's message
+    verbatim; a database driver does the same with the statement parameters,
+    which here are caller-supplied candidate ids. Class names are the only part
+    of an exception this process authored, so they are the only part that gets
+    logged.
+    """
+    names: List[str] = []
+    current: Optional[BaseException] = exc
+    while current is not None and len(names) < _MAX_CAUSE_DEPTH:
+        names.append(type(current).__name__)
+        current = current.__cause__
+    return " <- ".join(names)
 
 
 def _executor(request: Request):
@@ -97,16 +118,32 @@ async def create_embeddings(
             detail=f"Inputs normalize to empty text: {empty}",
         )
 
+    # The model validator sizes the request as the caller sent it; NFKC is what
+    # the backend actually receives, and compatibility characters expand under
+    # it (one U+FB03 becomes three characters). The advertised limit is a
+    # provider limit, so it is re-checked against the text that will be sent —
+    # still before anything leaves the process.
+    normalized_characters = sum(len(text) for text in texts)
+    if normalized_characters > MAX_EMBEDDING_CHARS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"inputs normalize to {normalized_characters} characters, "
+                f"which exceeds the {MAX_EMBEDDING_CHARS} limit"
+            ),
+        )
+
     try:
-        vectors = await _run(request, space.embed_documents, texts)
+        vectors = await _run(request, space.embed, texts, body.input_type)
     except SpaceBackendError as exc:
         # chat-v1 is substitution-locked: a backend failure is a 503, never a
         # quiet switch to another model or dimensionality.
         logger.error(
-            "Embedding backend unavailable | space=%s inputs=%d | %s",
+            "Embedding backend unavailable | space=%s input_type=%s inputs=%d | %s",
             body.space,
+            body.input_type,
             len(texts),
-            exc,
+            error_category(exc),
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -190,9 +227,7 @@ async def _authorize_candidates(
         )
         existing, authorized = probed
     except Exception as exc:
-        logger.error(
-            "Candidate authorization probe failed | %s: %s", type(exc).__name__, exc
-        )
+        logger.error("Candidate authorization probe failed | %s", error_category(exc))
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Candidate authorization is unavailable",
@@ -236,9 +271,8 @@ async def _stored_vectors(
         )
     except Exception as exc:
         logger.warning(
-            "Stored candidate vector lookup failed, falling back to inference | %s: %s",
-            type(exc).__name__,
-            exc,
+            "Stored candidate vector lookup failed, falling back to inference | %s",
+            error_category(exc),
         )
         return {}
 
@@ -306,12 +340,10 @@ async def rerank(
         )
     except Exception as exc:
         logger.error(
-            "Rerank embedding backend unavailable | candidates=%d pending=%d | %s: %s\n%s",
+            "Rerank embedding backend unavailable | candidates=%d pending=%d | %s",
             len(body.candidates),
             len(pending_texts),
-            type(exc).__name__,
-            exc,
-            traceback.format_exc(),
+            error_category(exc),
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/app/routes/search_routes.py
+++ b/app/routes/search_routes.py
@@ -118,18 +118,18 @@ async def create_embeddings(
             detail=f"Inputs normalize to empty text: {empty}",
         )
 
-    # The model validator sizes the request as the caller sent it; NFKC is what
-    # the backend actually receives, and compatibility characters expand under
-    # it (one U+FB03 becomes three characters). The advertised limit is a
-    # provider limit, so it is re-checked against the text that will be sent —
-    # still before anything leaves the process.
-    normalized_characters = sum(len(text) for text in texts)
-    if normalized_characters > MAX_EMBEDDING_CHARS:
+    # The model validator sizes the request as the caller sent it. The backend
+    # receives something else: NFKC expands compatibility characters (one U+FB03
+    # becomes three), and the space prepends its task prefix to every input. The
+    # advertised limit is a provider limit, so it is re-checked against the exact
+    # payload that will be sent — still before anything leaves the process.
+    payload_characters = space.payload_characters(texts, body.input_type)
+    if payload_characters > MAX_EMBEDDING_CHARS:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=(
-                f"inputs normalize to {normalized_characters} characters, "
-                f"which exceeds the {MAX_EMBEDDING_CHARS} limit"
+                f"inputs total {payload_characters} characters once normalized "
+                f"and prefixed, which exceeds the {MAX_EMBEDDING_CHARS} limit"
             ),
         )
 

--- a/app/routes/search_routes.py
+++ b/app/routes/search_routes.py
@@ -170,7 +170,16 @@ async def _authorize_candidates(
     candidate from a fresh one.
     """
     if not hasattr(vector_store, "probe_candidate_ids"):
-        return
+        # No fallback: a store that cannot be probed cannot be reranked against,
+        # because there is no way to tell a foreign candidate from a fresh one.
+        logger.error(
+            "Vector store %s cannot authorize rerank candidates",
+            type(vector_store).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Candidate authorization is unavailable",
+        )
     try:
         probed = await _call_store(
             request,

--- a/app/routes/search_routes.py
+++ b/app/routes/search_routes.py
@@ -1,0 +1,268 @@
+# app/routes/search_routes.py
+"""Strict service endpoints for the LibreChat search stack.
+
+``POST /v1/embeddings`` serves the substitution-locked ``chat-v1`` space.
+``POST /v1/rerank`` serves the ``fast-v1`` profile as embed-blend v0.
+
+Neither endpoint returns candidate text, and neither logs query or candidate
+text — only lengths and non-reversible fingerprints.
+"""
+
+import asyncio
+import traceback
+from typing import Dict, List, Optional, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.auth import SCOPE_EMBED, SCOPE_RERANK, Principal, require_scope
+from app.config import logger, vector_store
+from app.constants import (
+    MAX_EMBEDDING_CHARS,
+    MAX_EMBEDDING_INPUTS,
+    RERANK_PROFILE_FAST_V1,
+)
+from app.models import (
+    EmbeddingItem,
+    EmbeddingsRequest,
+    EmbeddingsResponse,
+    EmbeddingsUsage,
+    RerankRequest,
+    RerankResponse,
+    RerankResult,
+)
+from app.services import embedding as embedding_service
+from app.services import ratelimit
+from app.services.rerank import (
+    BlendConfig,
+    blend_scores,
+    cosine_similarity,
+    order_by_score,
+)
+from app.services.space import SpaceBackendError, get_space, known_spaces
+from app.utils.text import content_hash, fingerprint, normalize_text
+
+router = APIRouter(prefix="/v1")
+
+
+def _executor(request: Request):
+    return getattr(request.app.state, "thread_pool", None)
+
+
+async def _run(request: Request, func, *args):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor(request), lambda: func(*args))
+
+
+def _enforce_budget(budget_name: str, principal: Principal) -> None:
+    decision = ratelimit.check(budget_name, principal.tenant, principal.subject)
+    if decision.allowed:
+        return
+    logger.warning(
+        "Rate limit exceeded | budget=%s scope=%s tenant=%s subject=%s",
+        budget_name,
+        decision.scope,
+        principal.tenant,
+        principal.subject,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=f"{budget_name} rate limit exceeded for this {decision.scope}",
+        headers={"Retry-After": str(decision.retry_after)},
+    )
+
+
+@router.post("/embeddings", response_model=EmbeddingsResponse)
+async def create_embeddings(
+    body: EmbeddingsRequest,
+    request: Request,
+    principal: Principal = Depends(require_scope(SCOPE_EMBED)),
+) -> EmbeddingsResponse:
+    space = get_space(body.space)
+    if space is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown embedding space '{body.space}' (known: {known_spaces()})",
+        )
+
+    _enforce_budget(ratelimit.BUDGET_EMBED, principal)
+
+    texts = [normalize_text(item.text) for item in body.inputs]
+    empty = [body.inputs[index].id for index, text in enumerate(texts) if not text]
+    if empty:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Inputs normalize to empty text: {empty}",
+        )
+
+    try:
+        vectors = await _run(request, space.embed_documents, texts)
+    except SpaceBackendError as exc:
+        # chat-v1 is substitution-locked: a backend failure is a 503, never a
+        # quiet switch to another model or dimensionality.
+        logger.error(
+            "Embedding backend unavailable | space=%s inputs=%d | %s",
+            body.space,
+            len(texts),
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Embedding space '{body.space}' is unavailable",
+        )
+
+    items = [
+        EmbeddingItem(
+            id=body.inputs[index].id,
+            content_hash=content_hash(texts[index]),
+            embedding=vectors[index],
+        )
+        for index in range(len(texts))
+    ]
+
+    return EmbeddingsResponse(
+        space=space.spec.name,
+        model=space.spec.model,
+        dimensions=space.spec.dimensions,
+        normalized=space.spec.normalized,
+        items=items,
+        usage=EmbeddingsUsage(
+            input_count=len(items),
+            total_characters=sum(len(text) for text in texts),
+        ),
+    )
+
+
+async def _stored_vectors(
+    request: Request, ids: Sequence[str], owners: Sequence[str]
+) -> Dict[str, List[float]]:
+    """Candidate vectors already in the store, scoped to owners the token permits.
+
+    A store failure degrades to "no stored vectors" — the vectorless path still
+    produces a correct ranking, just at the cost of candidate inference.
+    """
+    lookup = getattr(vector_store, "get_vectors_by_ids", None)
+    if lookup is None or not owners:
+        return {}
+    try:
+        result = lookup(list(ids), list(owners))
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+    except Exception as exc:
+        logger.warning(
+            "Stored candidate vector lookup failed, falling back to inference | %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return {}
+
+
+@router.post("/rerank", response_model=RerankResponse)
+async def rerank(
+    body: RerankRequest,
+    request: Request,
+    principal: Principal = Depends(require_scope(SCOPE_RERANK)),
+) -> RerankResponse:
+    if body.profile != RERANK_PROFILE_FAST_V1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown rerank profile '{body.profile}'",
+        )
+
+    _enforce_budget(ratelimit.BUDGET_RERANK, principal)
+
+    owners = sorted({principal.subject} | set(principal.entities))
+    stored = await _stored_vectors(
+        request, [candidate.id for candidate in body.candidates], owners
+    )
+
+    pending: List[int] = []
+    pending_texts: List[str] = []
+    for index, candidate in enumerate(body.candidates):
+        if candidate.id in stored or not candidate.text:
+            continue
+        text = normalize_text(candidate.text)
+        if not text:
+            continue
+        pending.append(index)
+        pending_texts.append(text)
+
+    if len(pending_texts) > MAX_EMBEDDING_INPUTS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"{len(pending_texts)} candidates require embedding, "
+                f"which exceeds the {MAX_EMBEDDING_INPUTS} input limit"
+            ),
+        )
+    pending_characters = sum(len(text) for text in pending_texts)
+    if pending_characters > MAX_EMBEDDING_CHARS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"candidates requiring embedding total {pending_characters} characters, "
+                f"which exceeds the {MAX_EMBEDDING_CHARS} limit"
+            ),
+        )
+
+    try:
+        # The raw query string is the retrieval cache key, so a rerank that
+        # follows /query on the same query pays no query inference.
+        query_vector = await _run(
+            request, embedding_service.get_cached_query_embedding, body.query
+        )
+        candidate_vectors = (
+            await _run(request, embedding_service.embed_texts, pending_texts)
+            if pending_texts
+            else []
+        )
+    except Exception as exc:
+        logger.error(
+            "Rerank embedding backend unavailable | candidates=%d pending=%d | %s: %s\n%s",
+            len(body.candidates),
+            len(pending_texts),
+            type(exc).__name__,
+            exc,
+            traceback.format_exc(),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Rerank profile '{body.profile}' backend is unavailable",
+        )
+
+    vectors: List[Optional[List[float]]] = [
+        stored.get(candidate.id) for candidate in body.candidates
+    ]
+    for position, index in enumerate(pending):
+        vectors[index] = candidate_vectors[position]
+
+    similarities = [
+        cosine_similarity(query_vector, vector) if vector else None
+        for vector in vectors
+    ]
+    base_scores = [candidate.base_score for candidate in body.candidates]
+    scores = blend_scores(similarities, base_scores, BlendConfig.from_env())
+    ranked = order_by_score(scores, body.resolved_top_n())
+
+    logger.info(
+        "Reranked | profile=%s query=%s candidates=%d stored_vectors=%d embedded=%d returned=%d",
+        body.profile,
+        fingerprint(body.query),
+        len(body.candidates),
+        len(body.candidates) - len(pending_texts),
+        len(pending_texts),
+        len(ranked),
+    )
+
+    return RerankResponse(
+        profile=body.profile,
+        model=embedding_service.STORE_EMBEDDING_MODEL,
+        results=[
+            RerankResult(
+                id=body.candidates[item.index].id,
+                index=item.index,
+                score=item.score,
+            )
+            for item in ranked
+        ],
+    )

--- a/app/scope.py
+++ b/app/scope.py
@@ -1,0 +1,138 @@
+"""The one place a request's scope becomes a store predicate.
+
+Files and their chunks are user-scoped and carry raw content, so scope is
+enforced structurally rather than remembered by each caller. Every retrieval
+path — ``/query``, ``/query_multiple`` and the ``fast-v1`` stored-vector
+lookup — builds its predicate from :class:`ScopeFilter`. Drift between
+hand-written scope clauses is the realistic failure mode; one builder makes it
+impossible rather than reviewable.
+
+The predicate is always ``(tenant, owner/entity, file)`` and always goes into
+the store query *before* ranking. Nothing downstream re-derives authorization
+from what the store returned.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from fastapi import HTTPException, Request, status
+
+from app.auth import BASE_TENANT_ID, SYSTEM_TENANT_ID, Principal
+from app.config import logger
+
+PUBLIC_OWNER = "public"
+
+TENANT_METADATA_KEY = "tenant_id"
+OWNER_METADATA_KEY = "user_id"
+
+
+@dataclass(frozen=True)
+class ScopeFilter:
+    """The tenant and owners a request may read, as store-query clauses."""
+
+    tenant: str
+    owners: Tuple[str, ...]
+
+    def tenant_values(self) -> List[Optional[str]]:
+        """Tenant values that satisfy this scope.
+
+        Chunks written before tenants were recorded carry no ``tenant_id`` at
+        all. They normalize to the base tenant — the same absent/null → base
+        rule the projector applies — so the base tenant matches them and a real
+        tenant never absorbs untagged content. ``None`` in an ``$in`` list means
+        "or the key is absent", matching MongoDB's own ``$in: [null]``
+        semantics; the pgvector filter builder implements the same rule.
+        """
+        if self.tenant == BASE_TENANT_ID:
+            return [BASE_TENANT_ID, None]
+        return [self.tenant]
+
+    def scope_clauses(self) -> List[Dict[str, Any]]:
+        return [
+            {OWNER_METADATA_KEY: {"$in": list(self.owners)}},
+            {TENANT_METADATA_KEY: {"$in": self.tenant_values()}},
+        ]
+
+    def predicate(self, *clauses: Dict[str, Any]) -> Dict[str, Any]:
+        """Combine caller clauses (e.g. file id) with the scope clauses."""
+        return {"$and": [*clauses, *self.scope_clauses()]}
+
+    def owns(self, tenant: Optional[str], owner: Optional[str]) -> bool:
+        """Whether a stored row's recorded tenant/owner falls inside this scope."""
+        return owner in self.owners and tenant in self.tenant_values()
+
+
+def file_clause(file_id: str) -> Dict[str, Any]:
+    return {"file_id": {"$eq": file_id}}
+
+
+def files_clause(file_ids: Sequence[str]) -> Dict[str, Any]:
+    return {"file_id": {"$in": list(file_ids)}}
+
+
+def resolve_scope(request: Request, entity_id: Optional[str] = None) -> ScopeFilter:
+    """Resolve the caller's scope, or refuse the request.
+
+    Scope comes from the verified token — never from the query, the body, or the
+    returned rows. A caller-supplied ``entity_id`` only widens the owner set
+    when the token proves the caller may act for that entity.
+    """
+    principal: Optional[Principal] = getattr(request.state, "principal", None)
+
+    if principal is None:
+        # No signing key configured anywhere: preserve the unauthenticated
+        # deployment's single-owner behaviour rather than opening the store.
+        owner = entity_id or PUBLIC_OWNER
+        return ScopeFilter(tenant=BASE_TENANT_ID, owners=(owner,))
+
+    if principal.tenant == SYSTEM_TENANT_ID:
+        # __SYSTEM__ is a query-time wildcard upstream; porting it here would
+        # hand every background context cross-tenant reach.
+        logger.warning("Refused system-tenant request | subject=%s", principal.subject)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System tenant may not read documents",
+        )
+
+    owners = {principal.subject}
+    if entity_id:
+        if not principal.permits_entity(entity_id):
+            logger.warning(
+                "Denied entity access | subject=%s entity=%s",
+                principal.subject,
+                entity_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized for the requested entity",
+            )
+        owners.add(entity_id)
+
+    return ScopeFilter(tenant=principal.tenant, owners=tuple(sorted(owners)))
+
+
+def token_scope(request: Request) -> ScopeFilter:
+    """Scope for endpoints that take no ``entity_id``: the token decides alone."""
+    principal: Optional[Principal] = getattr(request.state, "principal", None)
+    if principal is None:
+        return ScopeFilter(tenant=BASE_TENANT_ID, owners=(PUBLIC_OWNER,))
+    scope = resolve_scope(request)
+    if principal.entities:
+        return ScopeFilter(
+            tenant=scope.tenant,
+            owners=tuple(sorted(set(scope.owners) | set(principal.entities))),
+        )
+    return scope
+
+
+def writer_tenant(request: Request) -> str:
+    """Tenant to stamp on chunks written by this request."""
+    principal: Optional[Principal] = getattr(request.state, "principal", None)
+    if principal is None or not principal.tenant:
+        return BASE_TENANT_ID
+    if principal.tenant == SYSTEM_TENANT_ID:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System tenant may not write documents",
+        )
+    return principal.tenant

--- a/app/services/embedding.py
+++ b/app/services/embedding.py
@@ -1,0 +1,25 @@
+"""Query and candidate embedding against the vector store's own space.
+
+Retrieval and ``fast-v1`` rerank share this cache on purpose: on the file-search
+path the rerank query vector is the retrieval query vector, so the rerank costs
+no inference at all beyond what retrieval already paid.
+"""
+
+import os
+from functools import lru_cache
+from typing import List
+
+from app.config import EMBEDDINGS_MODEL, vector_store
+
+QUERY_EMBEDDING_CACHE_SIZE = int(os.getenv("RAG_QUERY_EMBEDDING_CACHE_SIZE", "128"))
+
+STORE_EMBEDDING_MODEL = EMBEDDINGS_MODEL
+
+
+@lru_cache(maxsize=QUERY_EMBEDDING_CACHE_SIZE)
+def get_cached_query_embedding(query: str) -> List[float]:
+    return vector_store.embedding_function.embed_query(query)
+
+
+def embed_texts(texts: List[str]) -> List[List[float]]:
+    return vector_store.embedding_function.embed_documents(texts)

--- a/app/services/ratelimit.py
+++ b/app/services/ratelimit.py
@@ -1,0 +1,159 @@
+"""Per-tenant and per-subject request budgets for the service endpoints.
+
+Embedding and rerank hold separate budgets: a rerank storm must not starve the
+interactive query-embedding path, and the backfill (which runs under its own
+service subject) must not consume live traffic's allowance.
+
+The counters are process-local. A multi-pod deployment therefore enforces
+``limit x pods``; a shared store is the follow-up hardening, and the budgets are
+sized as a safety valve rather than a billing control.
+"""
+
+import os
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Dict, Optional, Tuple
+
+BUDGET_EMBED = "embed"
+BUDGET_RERANK = "rerank"
+
+_MAX_TRACKED_KEYS = 20_000
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+def _flag_env(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in ("true", "1", "yes", "on", "y")
+
+
+@dataclass(frozen=True)
+class Budget:
+    tenant_limit: int
+    subject_limit: int
+    window_seconds: int
+
+
+@dataclass(frozen=True)
+class RateLimitSettings:
+    enabled: bool
+    window_seconds: int
+    budgets: Dict[str, Budget]
+
+    @classmethod
+    def from_env(cls) -> "RateLimitSettings":
+        window = _int_env("RAG_RATE_LIMIT_WINDOW_SECONDS", 60)
+        return cls(
+            enabled=_flag_env("RAG_RATE_LIMIT_ENABLED", "true"),
+            window_seconds=window,
+            budgets={
+                BUDGET_EMBED: Budget(
+                    tenant_limit=_int_env("RAG_RATE_LIMIT_EMBED_TENANT", 600),
+                    subject_limit=_int_env("RAG_RATE_LIMIT_EMBED_SUBJECT", 120),
+                    window_seconds=window,
+                ),
+                BUDGET_RERANK: Budget(
+                    tenant_limit=_int_env("RAG_RATE_LIMIT_RERANK_TENANT", 900),
+                    subject_limit=_int_env("RAG_RATE_LIMIT_RERANK_SUBJECT", 180),
+                    window_seconds=window,
+                ),
+            },
+        )
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    allowed: bool
+    scope: Optional[str] = None
+    retry_after: int = 0
+
+
+class FixedWindowLimiter:
+    """Fixed-window counters keyed by (budget, scope, identity)."""
+
+    def __init__(self):
+        self._counters: Dict[Tuple[str, str, str], Tuple[float, int]] = {}
+        self._lock = Lock()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+
+    def _hit(self, key, limit: int, window: int, now: float) -> Optional[int]:
+        window_start = now - (now % window)
+        started, count = self._counters.get(key, (window_start, 0))
+        if started < window_start:
+            started, count = window_start, 0
+        if count >= limit:
+            return max(1, int(started + window - now))
+        self._counters[key] = (started, count + 1)
+        return None
+
+    def _prune(self, now: float, window: int) -> None:
+        if len(self._counters) <= _MAX_TRACKED_KEYS:
+            return
+        cutoff = now - (now % window)
+        for key in [
+            key for key, (started, _) in self._counters.items() if started < cutoff
+        ]:
+            del self._counters[key]
+
+    def check(
+        self,
+        budget_name: str,
+        budget: Budget,
+        tenant: str,
+        subject: str,
+        now: Optional[float] = None,
+    ) -> RateLimitDecision:
+        now = time.time() if now is None else now
+        with self._lock:
+            self._prune(now, budget.window_seconds)
+            retry_after = self._hit(
+                (budget_name, "tenant", tenant),
+                budget.tenant_limit,
+                budget.window_seconds,
+                now,
+            )
+            if retry_after is not None:
+                return RateLimitDecision(False, "tenant", retry_after)
+            retry_after = self._hit(
+                (budget_name, "subject", subject),
+                budget.subject_limit,
+                budget.window_seconds,
+                now,
+            )
+            if retry_after is not None:
+                return RateLimitDecision(False, "subject", retry_after)
+        return RateLimitDecision(True)
+
+
+_limiter = FixedWindowLimiter()
+_settings: Optional[RateLimitSettings] = None
+
+
+def get_settings() -> RateLimitSettings:
+    global _settings
+    if _settings is None:
+        _settings = RateLimitSettings.from_env()
+    return _settings
+
+
+def reset() -> None:
+    """Drop cached settings and counters — used between tests."""
+    global _settings
+    _settings = None
+    _limiter.reset()
+
+
+def check(budget_name: str, tenant: str, subject: str) -> RateLimitDecision:
+    settings = get_settings()
+    if not settings.enabled:
+        return RateLimitDecision(True)
+    budget = settings.budgets[budget_name]
+    return _limiter.check(budget_name, budget, tenant, subject)

--- a/app/services/ratelimit.py
+++ b/app/services/ratelimit.py
@@ -84,15 +84,27 @@ class FixedWindowLimiter:
         with self._lock:
             self._counters.clear()
 
-    def _hit(self, key, limit: int, window: int, now: float) -> Optional[int]:
-        window_start = now - (now % window)
+    @staticmethod
+    def _window_start(now: float, window: int) -> float:
+        return now - (now % window)
+
+    def _current(self, key, window: int, now: float) -> Tuple[float, int]:
+        window_start = self._window_start(now, window)
         started, count = self._counters.get(key, (window_start, 0))
         if started < window_start:
-            started, count = window_start, 0
-        if count >= limit:
-            return max(1, int(started + window - now))
+            return window_start, 0
+        return started, count
+
+    def _retry_after(self, key, limit: int, window: int, now: float) -> Optional[int]:
+        """Seconds until ``key`` frees a slot, or ``None`` while it still has one."""
+        started, count = self._current(key, window, now)
+        if count < limit:
+            return None
+        return max(1, int(started + window - now))
+
+    def _commit(self, key, window: int, now: float) -> None:
+        started, count = self._current(key, window, now)
         self._counters[key] = (started, count + 1)
-        return None
 
     def _prune(self, now: float, window: int) -> None:
         if len(self._counters) <= _MAX_TRACKED_KEYS:
@@ -112,24 +124,27 @@ class FixedWindowLimiter:
         now: Optional[float] = None,
     ) -> RateLimitDecision:
         now = time.time() if now is None else now
+        window = budget.window_seconds
+        tenant_key = (budget_name, "tenant", tenant)
+        subject_key = (budget_name, "subject", subject)
         with self._lock:
-            self._prune(now, budget.window_seconds)
-            retry_after = self._hit(
-                (budget_name, "tenant", tenant),
-                budget.tenant_limit,
-                budget.window_seconds,
-                now,
+            self._prune(now, window)
+            # Both arms are inspected before either counter moves. Charging the
+            # tenant for a request the subject arm then rejects would let one
+            # subject spend the whole tenant budget on refusals and deny service
+            # to every other subject in that tenant.
+            retry_after = self._retry_after(
+                tenant_key, budget.tenant_limit, window, now
             )
             if retry_after is not None:
                 return RateLimitDecision(False, "tenant", retry_after)
-            retry_after = self._hit(
-                (budget_name, "subject", subject),
-                budget.subject_limit,
-                budget.window_seconds,
-                now,
+            retry_after = self._retry_after(
+                subject_key, budget.subject_limit, window, now
             )
             if retry_after is not None:
                 return RateLimitDecision(False, "subject", retry_after)
+            self._commit(tenant_key, window, now)
+            self._commit(subject_key, window, now)
         return RateLimitDecision(True)
 
 

--- a/app/services/rerank.py
+++ b/app/services/rerank.py
@@ -1,0 +1,125 @@
+"""``fast-v1`` reranking — embed-blend v0.
+
+Scoring is reciprocal-rank fusion of two arms: cosine similarity between the
+query vector and each candidate vector, and the caller's own ``base_score``
+(the retrieval score that produced the candidate). Pure bi-encoder order is
+deliberately *not* used — it regresses identifier and exact-match queries, and
+the blend recovers that loss.
+
+Candidate vectors come from storage wherever they exist; inference is spent
+only on candidates that arrive vectorless.
+"""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return float(raw)
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+@dataclass(frozen=True)
+class BlendConfig:
+    k: int
+    similarity_weight: float
+    base_weight: float
+
+    @classmethod
+    def from_env(cls) -> "BlendConfig":
+        return cls(
+            k=_int_env("RAG_RERANK_RRF_K", 60),
+            similarity_weight=_float_env("RAG_RERANK_SIMILARITY_WEIGHT", 1.0),
+            base_weight=_float_env("RAG_RERANK_BASE_WEIGHT", 1.0),
+        )
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    index: int
+    score: float
+
+
+def cosine_similarity(left: Sequence[float], right: Sequence[float]) -> Optional[float]:
+    """Cosine similarity, or ``None`` when either side is degenerate."""
+    if not left or not right or len(left) != len(right):
+        return None
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for a, b in zip(left, right):
+        dot += a * b
+        left_norm += a * a
+        right_norm += b * b
+    if left_norm == 0.0 or right_norm == 0.0:
+        return None
+    return dot / (math.sqrt(left_norm) * math.sqrt(right_norm))
+
+
+def rank_positions(values: Sequence[Optional[float]]) -> List[int]:
+    """1-based ranks, highest value first.
+
+    ``None`` entries rank after every scored entry, and ties break on the
+    candidate's position in the request — so identical inputs always produce
+    identical ranks.
+    """
+    order = sorted(
+        range(len(values)),
+        key=lambda index: (
+            values[index] is None,
+            -(values[index] if values[index] is not None else 0.0),
+            index,
+        ),
+    )
+    ranks = [0] * len(values)
+    for position, index in enumerate(order, start=1):
+        ranks[index] = position
+    return ranks
+
+
+def blend_scores(
+    similarities: Sequence[Optional[float]],
+    base_scores: Sequence[Optional[float]],
+    config: BlendConfig,
+) -> List[float]:
+    """RRF-blend the similarity arm with the caller's retrieval arm.
+
+    An arm with no usable values at all is dropped rather than contributing a
+    constant, so a fully vectorless call degrades to the caller's own order
+    instead of shuffling it.
+    """
+    count = len(similarities)
+    use_similarity = any(value is not None for value in similarities)
+    use_base = any(value is not None for value in base_scores)
+
+    similarity_ranks = rank_positions(similarities) if use_similarity else None
+    base_ranks = rank_positions(base_scores) if use_base else None
+
+    scores = []
+    for index in range(count):
+        score = 0.0
+        if similarity_ranks is not None:
+            score += config.similarity_weight / (config.k + similarity_ranks[index])
+        if base_ranks is not None:
+            score += config.base_weight / (config.k + base_ranks[index])
+        scores.append(score)
+    return scores
+
+
+def order_by_score(scores: Sequence[float], top_n: int) -> List[RankedCandidate]:
+    """Highest score first, ties broken by request position, truncated to ``top_n``."""
+    order = sorted(range(len(scores)), key=lambda index: (-scores[index], index))
+    return [
+        RankedCandidate(index=index, score=scores[index]) for index in order[:top_n]
+    ]

--- a/app/services/space.py
+++ b/app/services/space.py
@@ -1,9 +1,13 @@
 """Embedding spaces served by ``POST /v1/embeddings``.
 
-A space is a locked tuple of (model, dimensions, normalization). ``chat-v1`` is
-substitution-locked: if its backend is unavailable, or returns vectors of the
-wrong width, the request fails with 503. It never silently falls back to
-another model, another dimensionality, or the file-search space.
+A space is a locked tuple of (model, dimensions, normalization, task prefixes).
+``chat-v1`` is substitution-locked: if its backend is unavailable, or returns
+vectors of the wrong width, the request fails with 503. It never silently falls
+back to another model, another dimensionality, or the file-search space.
+
+The task prefixes belong to that tuple because they change the vectors a model
+produces: editing one is a space change, not a tuning knob, and stored vectors
+have to be rebuilt to match.
 """
 
 import math
@@ -19,6 +23,10 @@ from app.config import (
 )
 
 
+INPUT_TYPE_QUERY = "query"
+INPUT_TYPE_DOCUMENT = "document"
+
+
 class SpaceBackendError(Exception):
     """The backend serving a space failed or answered off-contract."""
 
@@ -30,6 +38,19 @@ class SpaceSpec:
     dimensions: int
     normalized: bool = True
     dtype: str = "float32"
+    query_prefix: str = ""
+    document_prefix: str = ""
+
+    def prefix_for(self, input_type: str) -> str:
+        """The task prefix this space's model expects for ``input_type``.
+
+        Asymmetric embedding models — qwen3-embedding among them — encode a
+        query and a passage differently, usually through an instruction prefix.
+        Both prefixes default to empty, which is the symmetric case.
+        """
+        if input_type == INPUT_TYPE_QUERY:
+            return self.query_prefix
+        return self.document_prefix
 
 
 def l2_normalize(vector: List[float]) -> List[float]:
@@ -76,10 +97,35 @@ class EmbeddingSpace:
             )
         return finalized
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def _encoder(self, input_type: str) -> Callable[[List[str]], List[List[float]]]:
+        """The batch encoder this space uses for ``input_type``.
+
+        A backend that exposes a distinct batch query encoder gets to serve
+        queries with it; otherwise the task prefix is what carries the
+        distinction, and one batched call still serves the whole request.
+        """
         client = self._client_or_raise()
+        if input_type == INPUT_TYPE_QUERY:
+            query_encoder = getattr(client, "embed_queries", None)
+            if callable(query_encoder):
+                return query_encoder
+        return client.embed_documents
+
+    def embed(
+        self, texts: List[str], input_type: str = INPUT_TYPE_DOCUMENT
+    ) -> List[List[float]]:
+        """Embed ``texts`` the way this space encodes ``input_type``.
+
+        Routing a query through the passage path returns a passage vector, which
+        an asymmetric model scores against stored passages incorrectly. The
+        caller's declared input type therefore selects the encoder and the task
+        prefix rather than being recorded and ignored.
+        """
+        encoder = self._encoder(input_type)
+        prefix = self.spec.prefix_for(input_type)
+        prepared = [prefix + text for text in texts] if prefix else list(texts)
         try:
-            vectors = client.embed_documents(texts)
+            vectors = encoder(prepared)
         except SpaceBackendError:
             raise
         except Exception as exc:
@@ -88,8 +134,11 @@ class EmbeddingSpace:
             ) from exc
         return self._finalize(vectors, len(texts))
 
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return self.embed(texts, INPUT_TYPE_DOCUMENT)
+
     def embed_query(self, text: str) -> List[float]:
-        return self.embed_documents([text])[0]
+        return self.embed([text], INPUT_TYPE_QUERY)[0]
 
 
 def _int_env(name: str, default: int) -> int:
@@ -122,6 +171,8 @@ CHAT_SPACE_SPEC = SpaceSpec(
     dimensions=_int_env("RAG_CHAT_EMBEDDING_DIMENSIONS", 1024),
     normalized=True,
     dtype="float32",
+    query_prefix=os.getenv("RAG_CHAT_EMBEDDING_QUERY_PREFIX", ""),
+    document_prefix=os.getenv("RAG_CHAT_EMBEDDING_DOCUMENT_PREFIX", ""),
 )
 
 _spaces: Dict[str, EmbeddingSpace] = {

--- a/app/services/space.py
+++ b/app/services/space.py
@@ -1,0 +1,145 @@
+"""Embedding spaces served by ``POST /v1/embeddings``.
+
+A space is a locked tuple of (model, dimensions, normalization). ``chat-v1`` is
+substitution-locked: if its backend is unavailable, or returns vectors of the
+wrong width, the request fails with 503. It never silently falls back to
+another model, another dimensionality, or the file-search space.
+"""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+from app.config import (
+    RAG_OPENAI_API_KEY,
+    RAG_OPENAI_BASEURL,
+    RAG_OPENAI_PROXY,
+    logger,
+)
+
+
+class SpaceBackendError(Exception):
+    """The backend serving a space failed or answered off-contract."""
+
+
+@dataclass(frozen=True)
+class SpaceSpec:
+    name: str
+    model: str
+    dimensions: int
+    normalized: bool = True
+    dtype: str = "float32"
+
+
+def l2_normalize(vector: List[float]) -> List[float]:
+    norm = math.sqrt(sum(component * component for component in vector))
+    if norm == 0.0:
+        raise SpaceBackendError(
+            "Backend returned a zero vector, which cannot be normalized"
+        )
+    return [component / norm for component in vector]
+
+
+class EmbeddingSpace:
+    """Lazily-built client for one space, with contract enforcement on egress."""
+
+    def __init__(self, spec: SpaceSpec, client_factory: Callable[[], object]):
+        self.spec = spec
+        self._client_factory = client_factory
+        self._client: Optional[object] = None
+
+    def _client_or_raise(self):
+        if self._client is None:
+            try:
+                self._client = self._client_factory()
+            except Exception as exc:
+                raise SpaceBackendError(
+                    f"Failed to initialize backend for space '{self.spec.name}': {exc}"
+                ) from exc
+        return self._client
+
+    def _finalize(self, vectors: List[List[float]], expected: int) -> List[List[float]]:
+        if len(vectors) != expected:
+            raise SpaceBackendError(
+                f"Backend returned {len(vectors)} vectors for {expected} inputs"
+            )
+        finalized = []
+        for vector in vectors:
+            if len(vector) != self.spec.dimensions:
+                raise SpaceBackendError(
+                    f"Backend returned {len(vector)} dimensions, "
+                    f"space '{self.spec.name}' is locked to {self.spec.dimensions}"
+                )
+            finalized.append(
+                l2_normalize(vector) if self.spec.normalized else list(vector)
+            )
+        return finalized
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        client = self._client_or_raise()
+        try:
+            vectors = client.embed_documents(texts)
+        except SpaceBackendError:
+            raise
+        except Exception as exc:
+            raise SpaceBackendError(
+                f"Embedding backend for space '{self.spec.name}' failed: {exc}"
+            ) from exc
+        return self._finalize(vectors, len(texts))
+
+    def embed_query(self, text: str) -> List[float]:
+        return self.embed_documents([text])[0]
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+def _build_openai_client(spec: SpaceSpec):
+    from langchain_openai import OpenAIEmbeddings
+
+    return OpenAIEmbeddings(
+        model=spec.model,
+        api_key=os.getenv("RAG_CHAT_EMBEDDING_API_KEY") or RAG_OPENAI_API_KEY,
+        openai_api_base=os.getenv("RAG_CHAT_EMBEDDING_BASEURL") or RAG_OPENAI_BASEURL,
+        openai_proxy=RAG_OPENAI_PROXY,
+        dimensions=spec.dimensions,
+        # The gateway serves models tiktoken has never heard of; client-side
+        # context measurement would fail before the request is even sent.
+        check_embedding_ctx_length=False,
+    )
+
+
+CHAT_SPACE_NAME = os.getenv("RAG_EMBEDDING_SPACE", "chat-v1").strip() or "chat-v1"
+
+CHAT_SPACE_SPEC = SpaceSpec(
+    name=CHAT_SPACE_NAME,
+    model=os.getenv("RAG_CHAT_EMBEDDING_MODEL", "qwen3-embedding-8b").strip(),
+    dimensions=_int_env("RAG_CHAT_EMBEDDING_DIMENSIONS", 1024),
+    normalized=True,
+    dtype="float32",
+)
+
+_spaces: Dict[str, EmbeddingSpace] = {
+    CHAT_SPACE_SPEC.name: EmbeddingSpace(
+        CHAT_SPACE_SPEC, lambda: _build_openai_client(CHAT_SPACE_SPEC)
+    )
+}
+
+
+def get_space(name: str) -> Optional[EmbeddingSpace]:
+    return _spaces.get(name)
+
+
+def known_spaces() -> List[str]:
+    return sorted(_spaces)
+
+
+def register_space(space: EmbeddingSpace) -> None:
+    """Register or replace a space. Used by tests to inject a fake backend."""
+    logger.debug("Registering embedding space %s", space.spec.name)
+    _spaces[space.spec.name] = space

--- a/app/services/space.py
+++ b/app/services/space.py
@@ -134,6 +134,16 @@ class EmbeddingSpace:
             ) from exc
         return self._finalize(vectors, len(texts))
 
+    def payload_characters(self, texts: List[str], input_type: str) -> int:
+        """Characters :meth:`embed` would actually send for ``texts``.
+
+        The task prefix is prepended to every input, so the caller's text is not
+        the payload. The size limit is a provider limit and has to bind what
+        leaves the process, prefix included.
+        """
+        prefix_length = len(self.spec.prefix_for(input_type))
+        return sum(len(text) for text in texts) + prefix_length * len(texts)
+
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         return self.embed(texts, INPUT_TYPE_DOCUMENT)
 

--- a/app/services/space.py
+++ b/app/services/space.py
@@ -13,6 +13,7 @@ have to be rebuilt to match.
 import math
 import os
 from dataclasses import dataclass
+from numbers import Real
 from typing import Callable, Dict, List, Optional
 
 from app.config import (
@@ -53,6 +54,25 @@ class SpaceSpec:
         return self.document_prefix
 
 
+def _finite_component(component: object) -> float:
+    """One vector component, or the reason it is not one.
+
+    ``bool`` is excluded deliberately: it is a ``Real`` in Python, and a payload
+    of ``true``/``false`` is a malformed vector rather than a vector of ones and
+    zeroes. NaN and infinity are rejected here because they survive
+    normalization and poison every cosine score computed against them.
+    """
+    if isinstance(component, bool) or not isinstance(component, Real):
+        raise SpaceBackendError(
+            f"Backend returned a non-numeric vector component "
+            f"({type(component).__name__})"
+        )
+    value = float(component)
+    if not math.isfinite(value):
+        raise SpaceBackendError("Backend returned a non-finite vector component")
+    return value
+
+
 def l2_normalize(vector: List[float]) -> List[float]:
     norm = math.sqrt(sum(component * component for component in vector))
     if norm == 0.0:
@@ -80,22 +100,39 @@ class EmbeddingSpace:
                 ) from exc
         return self._client
 
-    def _finalize(self, vectors: List[List[float]], expected: int) -> List[List[float]]:
+    def _finalize(self, vectors: object, expected: int) -> List[List[float]]:
+        """Check the backend's answer against the space contract.
+
+        Everything here is a statement about a payload this process did not
+        author, so every rejection is a :class:`SpaceBackendError` — including
+        the shape violations that would otherwise surface as ``TypeError``. The
+        route translates that single class into the documented 503; anything
+        else escapes as an unhandled 500 and breaks the substitution lock.
+        """
+        if not isinstance(vectors, (list, tuple)):
+            raise SpaceBackendError(
+                f"Backend returned {type(vectors).__name__} where "
+                f"{expected} vectors were expected"
+            )
         if len(vectors) != expected:
             raise SpaceBackendError(
                 f"Backend returned {len(vectors)} vectors for {expected} inputs"
             )
-        finalized = []
-        for vector in vectors:
-            if len(vector) != self.spec.dimensions:
-                raise SpaceBackendError(
-                    f"Backend returned {len(vector)} dimensions, "
-                    f"space '{self.spec.name}' is locked to {self.spec.dimensions}"
-                )
-            finalized.append(
-                l2_normalize(vector) if self.spec.normalized else list(vector)
+        return [self._finalize_vector(vector) for vector in vectors]
+
+    def _finalize_vector(self, vector: object) -> List[float]:
+        if not isinstance(vector, (list, tuple)):
+            raise SpaceBackendError(
+                f"Backend returned a {type(vector).__name__} where a vector "
+                f"of {self.spec.dimensions} components was expected"
             )
-        return finalized
+        if len(vector) != self.spec.dimensions:
+            raise SpaceBackendError(
+                f"Backend returned {len(vector)} dimensions, "
+                f"space '{self.spec.name}' is locked to {self.spec.dimensions}"
+            )
+        components = [_finite_component(component) for component in vector]
+        return l2_normalize(components) if self.spec.normalized else components
 
     def _encoder(self, input_type: str) -> Callable[[List[str]], List[List[float]]]:
         """The batch encoder this space uses for ``input_type``.
@@ -126,13 +163,16 @@ class EmbeddingSpace:
         prepared = [prefix + text for text in texts] if prefix else list(texts)
         try:
             vectors = encoder(prepared)
+            return self._finalize(vectors, len(texts))
         except SpaceBackendError:
             raise
         except Exception as exc:
+            # Reading the response is as much "the backend" as the call itself:
+            # a malformed payload raises TypeError or ValueError from inside
+            # _finalize, and the route only knows how to sanitize one class.
             raise SpaceBackendError(
                 f"Embedding backend for space '{self.spec.name}' failed: {exc}"
             ) from exc
-        return self._finalize(vectors, len(texts))
 
     def payload_characters(self, texts: List[str], input_type: str) -> int:
         """Characters :meth:`embed` would actually send for ``texts``.

--- a/app/services/vector_store/async_pg_vector.py
+++ b/app/services/vector_store/async_pg_vector.py
@@ -44,19 +44,50 @@ class AsyncPgVector(ExtendedPgVector):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, wrapper)
 
-    async def get_all_ids(self, executor=None) -> list[str]:
+    async def get_all_ids(
+        self,
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+        executor=None,
+    ) -> list[str]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_all_ids)
+        return await self._run_in_executor(
+            executor, super().get_all_ids, owners, tenants
+        )
 
-    async def get_filtered_ids(self, ids: list[str], executor=None) -> list[str]:
+    async def get_filtered_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+        executor=None,
+    ) -> list[str]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_filtered_ids, ids)
+        return await self._run_in_executor(
+            executor, super().get_filtered_ids, ids, owners, tenants
+        )
 
     async def get_documents_by_ids(
-        self, ids: list[str], executor=None
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+        executor=None,
     ) -> list[Document]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_documents_by_ids, ids)
+        return await self._run_in_executor(
+            executor, super().get_documents_by_ids, ids, owners, tenants
+        )
+
+    async def delete_scoped(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+        executor=None,
+    ) -> None:
+        executor = executor or self._get_thread_pool()
+        await self._run_in_executor(executor, self._delete_scoped, ids, owners, tenants)
 
     async def get_vectors_by_ids(
         self,

--- a/app/services/vector_store/async_pg_vector.py
+++ b/app/services/vector_store/async_pg_vector.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, List, Tuple, Dict, Any, TypeVar
+from typing import Callable, Optional, List, Sequence, Set, Tuple, Dict, Any, TypeVar
 import asyncio
 from concurrent.futures import Executor
 from langchain_core.documents import Document
@@ -59,11 +59,27 @@ class AsyncPgVector(ExtendedPgVector):
         return await self._run_in_executor(executor, super().get_documents_by_ids, ids)
 
     async def get_vectors_by_ids(
-        self, ids: List[str], owners: List[str], executor=None
+        self,
+        ids: List[str],
+        owners: List[str],
+        tenants: Sequence[Optional[str]] = (None,),
+        executor=None,
     ) -> Dict[str, List[float]]:
         executor = executor or self._get_thread_pool()
         return await self._run_in_executor(
-            executor, super().get_vectors_by_ids, ids, owners
+            executor, super().get_vectors_by_ids, ids, owners, tenants
+        )
+
+    async def probe_candidate_ids(
+        self,
+        ids: List[str],
+        owners: List[str],
+        tenants: Sequence[Optional[str]] = (None,),
+        executor=None,
+    ) -> Tuple[Set[str], Set[str]]:
+        executor = executor or self._get_thread_pool()
+        return await self._run_in_executor(
+            executor, super().probe_candidate_ids, ids, owners, tenants
         )
 
     async def delete(

--- a/app/services/vector_store/async_pg_vector.py
+++ b/app/services/vector_store/async_pg_vector.py
@@ -58,6 +58,14 @@ class AsyncPgVector(ExtendedPgVector):
         executor = executor or self._get_thread_pool()
         return await self._run_in_executor(executor, super().get_documents_by_ids, ids)
 
+    async def get_vectors_by_ids(
+        self, ids: List[str], owners: List[str], executor=None
+    ) -> Dict[str, List[float]]:
+        executor = executor or self._get_thread_pool()
+        return await self._run_in_executor(
+            executor, super().get_vectors_by_ids, ids, owners
+        )
+
     async def delete(
         self,
         ids: Optional[list[str]] = None,

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -54,16 +54,69 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
             processed_documents.append((new_document, score))
         return processed_documents
 
-    def get_all_ids(self) -> list[str]:
-        # Return unique file_id fields in self._collection
-        return self._collection.distinct("file_id")
+    @staticmethod
+    def _file_scope_query(
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> dict:
+        """``(file id, owner, tenant)`` — the predicate the file routes read by.
 
-    def get_filtered_ids(self, ids: list[str]) -> list[str]:
-        # Return unique file_id fields filtered by the provided ids
-        return self._collection.distinct("file_id", {"file_id": {"$in": ids}})
+        ``None`` in ``tenants`` matches a missing ``tenant_id``, which is
+        MongoDB's own ``$in: [null]`` semantic and the rule chunks written before
+        tenants were recorded rely on.
+        """
+        return {
+            "$and": [
+                {"file_id": {"$in": list(ids)}},
+                {"user_id": {"$in": list(owners)}},
+                {"tenant_id": {"$in": list(tenants)}},
+            ]
+        }
 
-    def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
-        # Return documents filtered by file_id
+    def get_all_ids(
+        self, owners: Sequence[str], tenants: Sequence[Optional[str]]
+    ) -> list[str]:
+        """File ids this caller's scope holds — never the collection's whole set."""
+        allowed = list(dict.fromkeys(owners))
+        if not allowed or not tenants:
+            return []
+        return self._collection.distinct(
+            "file_id",
+            {
+                "$and": [
+                    {"user_id": {"$in": allowed}},
+                    {"tenant_id": {"$in": list(tenants)}},
+                ]
+            },
+        )
+
+    def get_filtered_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> list[str]:
+        """Which of ``ids`` exist inside ``owners`` and ``tenants``."""
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return []
+        return self._collection.distinct(
+            "file_id", self._file_scope_query(wanted, allowed, tenants)
+        )
+
+    def get_documents_by_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> list[Document]:
+        """Chunks of ``ids`` owned inside ``owners`` and ``tenants``."""
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return []
         return [
             Document(
                 page_content=doc["text"],
@@ -75,8 +128,23 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
                     "page": int(doc.get("page", 0)),
                 },
             )
-            for doc in self._collection.find({"file_id": {"$in": ids}})
+            for doc in self._collection.find(
+                self._file_scope_query(wanted, allowed, tenants)
+            )
         ]
+
+    def delete_scoped(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> None:
+        """Delete the chunks of ``ids`` that ``owners``/``tenants`` actually own."""
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return
+        self._collection.delete_many(self._file_scope_query(wanted, allowed, tenants))
 
     @staticmethod
     def _candidate_id_query(wanted: List[str]) -> dict:

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -54,6 +54,25 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
             processed_documents.append((new_document, score))
         return processed_documents
 
+    def ensure_indexes(self) -> None:
+        """Create the standard indexes the file and rerank lookups depend on.
+
+        The Atlas *vector-search* index accelerates ``$vectorSearch`` only; the
+        ordinary ``find`` calls below use regular indexes or they scan the whole
+        collection. ``createIndex`` is idempotent, so this is safe to run on
+        every start.
+        """
+        self._collection.create_index([("file_id", 1)], name="rag_file_id")
+        # The rerank authorization probe and the stored-vector lookup both match
+        # candidate ids against `digest`, and candidate ids handed back to
+        # callers are normally digests. The trailing scope fields let the
+        # stored-vector lookup answer from the index instead of fetching rows it
+        # will then discard.
+        self._collection.create_index(
+            [("digest", 1), ("user_id", 1), ("tenant_id", 1)],
+            name="rag_digest_scope",
+        )
+
     @staticmethod
     def _file_scope_query(
         ids: Sequence[str],

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -1,6 +1,6 @@
 import copy
 import hashlib
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Sequence, Set, Tuple
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_mongodb import MongoDBAtlasVectorSearch
@@ -78,26 +78,72 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
             for doc in self._collection.find({"file_id": {"$in": ids}})
         ]
 
+    @staticmethod
+    def _candidate_id_query(wanted: List[str]) -> dict:
+        return {"$or": [{"_id": {"$in": wanted}}, {"digest": {"$in": wanted}}]}
+
+    def probe_candidate_ids(
+        self,
+        ids: List[str],
+        owners: List[str],
+        tenants: Sequence[Optional[str]] = (None,),
+    ) -> Tuple[Set[str], Set[str]]:
+        """``(ids that exist at all, ids that exist within scope)`` — metadata only.
+
+        Mirrors the pgvector probe so authorize-before-egress behaves identically
+        on both backends.
+        """
+        wanted = list(dict.fromkeys(ids))
+        if not wanted:
+            return set(), set()
+
+        allowed = set(dict.fromkeys(owners))
+        tenant_values = set(tenants)
+        cursor = self._collection.find(
+            self._candidate_id_query(wanted),
+            {"_id": 1, "digest": 1, "user_id": 1, "tenant_id": 1},
+        ).sort("_id", 1)
+
+        requested = set(wanted)
+        existing: Set[str] = set()
+        authorized: Set[str] = set()
+        for doc in cursor:
+            in_scope = (
+                doc.get("user_id") in allowed and doc.get("tenant_id") in tenant_values
+            )
+            for key in (doc.get("_id"), doc.get("digest")):
+                if key not in requested:
+                    continue
+                existing.add(key)
+                if in_scope:
+                    authorized.add(key)
+        return existing, authorized
+
     def get_vectors_by_ids(
-        self, ids: List[str], owners: List[str]
+        self,
+        ids: List[str],
+        owners: List[str],
+        tenants: Sequence[Optional[str]] = (None,),
     ) -> dict[str, List[float]]:
-        """Stored chunk vectors for ``ids``, restricted to ``owners``.
+        """Stored chunk vectors for ``ids``, restricted to ``owners`` and ``tenants``.
 
         Mirrors the pgvector resolution: a candidate id matches the document
-        ``_id`` or its chunk ``digest``, and ownership is part of the query
-        predicate rather than a post-filter.
+        ``_id`` or its chunk ``digest``, and scope is part of the query predicate
+        rather than a post-filter. ``None`` in ``tenants`` matches missing
+        fields, which is MongoDB's own ``$in: [null]`` semantic.
         """
         wanted = list(dict.fromkeys(ids))
         allowed = list(dict.fromkeys(owners))
-        if not wanted or not allowed:
+        if not wanted or not allowed or not tenants:
             return {}
 
         embedding_key = getattr(self, "_embedding_key", "embedding")
         cursor = self._collection.find(
             {
                 "$and": [
-                    {"$or": [{"_id": {"$in": wanted}}, {"digest": {"$in": wanted}}]},
+                    self._candidate_id_query(wanted),
                     {"user_id": {"$in": allowed}},
+                    {"tenant_id": {"$in": list(tenants)}},
                 ]
             },
             {"_id": 1, "digest": 1, embedding_key: 1},

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -78,6 +78,43 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
             for doc in self._collection.find({"file_id": {"$in": ids}})
         ]
 
+    def get_vectors_by_ids(
+        self, ids: List[str], owners: List[str]
+    ) -> dict[str, List[float]]:
+        """Stored chunk vectors for ``ids``, restricted to ``owners``.
+
+        Mirrors the pgvector resolution: a candidate id matches the document
+        ``_id`` or its chunk ``digest``, and ownership is part of the query
+        predicate rather than a post-filter.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return {}
+
+        embedding_key = getattr(self, "_embedding_key", "embedding")
+        cursor = self._collection.find(
+            {
+                "$and": [
+                    {"$or": [{"_id": {"$in": wanted}}, {"digest": {"$in": wanted}}]},
+                    {"user_id": {"$in": allowed}},
+                ]
+            },
+            {"_id": 1, "digest": 1, embedding_key: 1},
+        ).sort("_id", 1)
+
+        requested = set(wanted)
+        vectors: dict[str, List[float]] = {}
+        for doc in cursor:
+            embedding = doc.get(embedding_key)
+            if not embedding:
+                continue
+            vector = [float(component) for component in embedding]
+            for key in (doc.get("_id"), doc.get("digest")):
+                if key in requested and key not in vectors:
+                    vectors[key] = vector
+        return vectors
+
     def delete(self, ids: Optional[list[str]] = None) -> None:
         # Delete documents by file_id
         if ids is not None:

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -1,7 +1,7 @@
 import os
 import time
 import logging
-from typing import Optional, Any, Dict, List, Sequence, Union
+from typing import Optional, Any, Dict, List, Sequence, Set, Tuple, Union
 import sqlalchemy
 from sqlalchemy import event
 from sqlalchemy import delete
@@ -170,6 +170,17 @@ class ExtendedPgVector(PGVector):
             return self.EmbeddingStore.cmetadata[field].astext == str(filter_value)
         elif operator == "$ne":
             return self.EmbeddingStore.cmetadata[field].astext != str(filter_value)
+        elif operator == "$in" and any(item is None for item in filter_value):
+            # MongoDB's `$in: [null]` matches documents where the field is null
+            # *or absent*. Scope predicates depend on that to treat chunks
+            # written before tenants were recorded as base-tenant content, so
+            # the same semantic is implemented here rather than dropping the
+            # null and silently narrowing the filter.
+            column = self.EmbeddingStore.cmetadata[field].astext
+            present = [str(item) for item in filter_value if item is not None]
+            if not present:
+                return column.is_(None)
+            return sqlalchemy.or_(column.in_(present), column.is_(None))
 
         return super()._handle_field_filter(field, value)
 
@@ -219,22 +230,91 @@ class ExtendedPgVector(PGVector):
             session.execute(stmt)
             session.commit()
 
+    def _candidate_id_clause(self, wanted: List[str]):
+        """Match a caller's candidate id against the two per-chunk handles.
+
+        ``custom_id`` is the file id and is shared by every chunk of a file, so
+        it identifies no single vector; the row ``uuid`` and the chunk
+        ``digest`` recorded in metadata are the handles a caller can hold.
+        """
+        return sqlalchemy.or_(
+            sqlalchemy.cast(self.EmbeddingStore.uuid, sqlalchemy.String).in_(wanted),
+            self.EmbeddingStore.cmetadata["digest"].astext.in_(wanted),
+        )
+
+    def _scope_clause(self, owners: List[str], tenants: Sequence[Optional[str]]):
+        owner_column = self.EmbeddingStore.cmetadata["user_id"].astext
+        tenant_column = self.EmbeddingStore.cmetadata["tenant_id"].astext
+        present = [str(tenant) for tenant in tenants if tenant is not None]
+        if any(tenant is None for tenant in tenants):
+            tenant_clause = (
+                sqlalchemy.or_(tenant_column.in_(present), tenant_column.is_(None))
+                if present
+                else tenant_column.is_(None)
+            )
+        else:
+            tenant_clause = tenant_column.in_(present)
+        return sqlalchemy.and_(owner_column.in_(owners), tenant_clause)
+
+    def probe_candidate_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> Tuple[Set[str], Set[str]]:
+        """``(ids that exist at all, ids that exist within scope)``.
+
+        Metadata only — no vectors, no document text. This is the
+        authorize-before-egress check: a candidate id that exists in the store
+        but resolves to nothing inside the caller's scope must be refused
+        *before* its caller-supplied text is sent to the inference gateway.
+        """
+        wanted = list(dict.fromkeys(ids))
+        if not wanted:
+            return set(), set()
+
+        allowed = list(dict.fromkeys(owners))
+        with Session(self._bind) as session:
+            rows = (
+                session.query(
+                    self.EmbeddingStore.uuid,
+                    self.EmbeddingStore.cmetadata["digest"].astext,
+                    self.EmbeddingStore.cmetadata["user_id"].astext,
+                    self.EmbeddingStore.cmetadata["tenant_id"].astext,
+                )
+                .filter(self._candidate_id_clause(wanted))
+                .order_by(self.EmbeddingStore.uuid)
+                .all()
+            )
+
+        requested = set(wanted)
+        tenant_values = set(tenants)
+        existing: Set[str] = set()
+        authorized: Set[str] = set()
+        for row_uuid, row_digest, row_owner, row_tenant in rows:
+            in_scope = row_owner in allowed and row_tenant in tenant_values
+            for key in (str(row_uuid), row_digest):
+                if key not in requested:
+                    continue
+                existing.add(key)
+                if in_scope:
+                    authorized.add(key)
+        return existing, authorized
+
     def get_vectors_by_ids(
-        self, ids: Sequence[str], owners: Sequence[str]
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]] = (None,),
     ) -> Dict[str, List[float]]:
-        """Stored chunk vectors for ``ids``, restricted to ``owners``.
+        """Stored chunk vectors for ``ids``, restricted to ``owners`` and ``tenants``.
 
-        A candidate id resolves against the row's ``uuid`` or the chunk
-        ``digest`` recorded in metadata — the two per-chunk handles a caller can
-        actually hold (``custom_id`` is the file id and is shared by every chunk
-        of a file, so it identifies no single vector).
-
-        Ownership is part of the SQL predicate: a foreign chunk is never
-        fetched, so it can never be scored or counted.
+        Scope is part of the SQL predicate: a foreign chunk is never fetched, so
+        it can never be scored, counted, or read into this process.
         """
         wanted = list(dict.fromkeys(ids))
         allowed = list(dict.fromkeys(owners))
-        if not wanted or not allowed:
+        if not wanted or not allowed or not tenants:
             return {}
 
         with Session(self._bind) as session:
@@ -244,15 +324,8 @@ class ExtendedPgVector(PGVector):
                     self.EmbeddingStore.cmetadata,
                     self.EmbeddingStore.embedding,
                 )
-                .filter(
-                    sqlalchemy.or_(
-                        sqlalchemy.cast(
-                            self.EmbeddingStore.uuid, sqlalchemy.String
-                        ).in_(wanted),
-                        self.EmbeddingStore.cmetadata["digest"].astext.in_(wanted),
-                    )
-                )
-                .filter(self.EmbeddingStore.cmetadata["user_id"].astext.in_(allowed))
+                .filter(self._candidate_id_clause(wanted))
+                .filter(self._scope_clause(allowed, tenants))
                 .order_by(self.EmbeddingStore.uuid)
                 .all()
             )

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -1,7 +1,8 @@
 import os
 import time
 import logging
-from typing import Optional, Any, Dict, List, Union
+from typing import Optional, Any, Dict, List, Sequence, Union
+import sqlalchemy
 from sqlalchemy import event
 from sqlalchemy import delete
 from sqlalchemy.orm import Session
@@ -217,6 +218,55 @@ class ExtendedPgVector(PGVector):
 
             session.execute(stmt)
             session.commit()
+
+    def get_vectors_by_ids(
+        self, ids: Sequence[str], owners: Sequence[str]
+    ) -> Dict[str, List[float]]:
+        """Stored chunk vectors for ``ids``, restricted to ``owners``.
+
+        A candidate id resolves against the row's ``uuid`` or the chunk
+        ``digest`` recorded in metadata — the two per-chunk handles a caller can
+        actually hold (``custom_id`` is the file id and is shared by every chunk
+        of a file, so it identifies no single vector).
+
+        Ownership is part of the SQL predicate: a foreign chunk is never
+        fetched, so it can never be scored or counted.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return {}
+
+        with Session(self._bind) as session:
+            rows = (
+                session.query(
+                    self.EmbeddingStore.uuid,
+                    self.EmbeddingStore.cmetadata,
+                    self.EmbeddingStore.embedding,
+                )
+                .filter(
+                    sqlalchemy.or_(
+                        sqlalchemy.cast(
+                            self.EmbeddingStore.uuid, sqlalchemy.String
+                        ).in_(wanted),
+                        self.EmbeddingStore.cmetadata["digest"].astext.in_(wanted),
+                    )
+                )
+                .filter(self.EmbeddingStore.cmetadata["user_id"].astext.in_(allowed))
+                .order_by(self.EmbeddingStore.uuid)
+                .all()
+            )
+
+        requested = set(wanted)
+        vectors: Dict[str, List[float]] = {}
+        for row_uuid, metadata, embedding in rows:
+            if embedding is None:
+                continue
+            vector = [float(component) for component in embedding]
+            for key in (str(row_uuid), (metadata or {}).get("digest")):
+                if key in requested and key not in vectors:
+                    vectors[key] = vector
+        return vectors
 
     def _delete_multiple(
         self, ids: Optional[list[str]] = None, collection_only: bool = False

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -242,6 +242,20 @@ class ExtendedPgVector(PGVector):
             self.EmbeddingStore.cmetadata["digest"].astext.in_(wanted),
         )
 
+    def _collection_clause(self, session: Session):
+        """Restrict a query to the collection this store serves, or ``None``.
+
+        ``langchain_pg_embedding`` is shared by every collection in the
+        database, so a candidate lookup that omits ``collection_id`` can see —
+        and reuse the vector of — a row this store does not serve. ``None`` means
+        the collection has not been created yet, which is indistinguishable from
+        it holding no rows.
+        """
+        collection = self.get_collection(session)
+        if collection is None:
+            return None
+        return self.EmbeddingStore.collection_id == collection.uuid
+
     def _scope_clause(self, owners: List[str], tenants: Sequence[Optional[str]]):
         owner_column = self.EmbeddingStore.cmetadata["user_id"].astext
         tenant_column = self.EmbeddingStore.cmetadata["tenant_id"].astext
@@ -268,6 +282,11 @@ class ExtendedPgVector(PGVector):
         authorize-before-egress check: a candidate id that exists in the store
         but resolves to nothing inside the caller's scope must be refused
         *before* its caller-supplied text is sent to the inference gateway.
+
+        "The store" means this store's collection. A row belonging to another
+        collection in the same database is not served here at all, so counting
+        it as existing would only manufacture a 403 for a candidate this
+        deployment never held.
         """
         wanted = list(dict.fromkeys(ids))
         if not wanted:
@@ -275,6 +294,9 @@ class ExtendedPgVector(PGVector):
 
         allowed = list(dict.fromkeys(owners))
         with Session(self._bind) as session:
+            collection_clause = self._collection_clause(session)
+            if collection_clause is None:
+                return set(), set()
             rows = (
                 session.query(
                     self.EmbeddingStore.uuid,
@@ -282,6 +304,7 @@ class ExtendedPgVector(PGVector):
                     self.EmbeddingStore.cmetadata["user_id"].astext,
                     self.EmbeddingStore.cmetadata["tenant_id"].astext,
                 )
+                .filter(collection_clause)
                 .filter(self._candidate_id_clause(wanted))
                 .order_by(self.EmbeddingStore.uuid)
                 .all()
@@ -310,7 +333,9 @@ class ExtendedPgVector(PGVector):
         """Stored chunk vectors for ``ids``, restricted to ``owners`` and ``tenants``.
 
         Scope is part of the SQL predicate: a foreign chunk is never fetched, so
-        it can never be scored, counted, or read into this process.
+        it can never be scored, counted, or read into this process. Collection
+        is part of it too, so a matching digest in a sibling collection cannot
+        have its vector reused here.
         """
         wanted = list(dict.fromkeys(ids))
         allowed = list(dict.fromkeys(owners))
@@ -318,12 +343,16 @@ class ExtendedPgVector(PGVector):
             return {}
 
         with Session(self._bind) as session:
+            collection_clause = self._collection_clause(session)
+            if collection_clause is None:
+                return {}
             rows = (
                 session.query(
                     self.EmbeddingStore.uuid,
                     self.EmbeddingStore.cmetadata,
                     self.EmbeddingStore.embedding,
                 )
+                .filter(collection_clause)
                 .filter(self._candidate_id_clause(wanted))
                 .filter(self._scope_clause(allowed, tenants))
                 .order_by(self.EmbeddingStore.uuid)

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -184,31 +184,110 @@ class ExtendedPgVector(PGVector):
 
         return super()._handle_field_filter(field, value)
 
-    def get_all_ids(self) -> list[str]:
+    def get_all_ids(
+        self, owners: Sequence[str], tenants: Sequence[Optional[str]]
+    ) -> list[str]:
+        """File ids this caller's scope holds — never the deployment's whole set."""
+        allowed = list(dict.fromkeys(owners))
+        if not allowed or not tenants:
+            return []
         with Session(self._bind) as session:
-            results = session.query(self.EmbeddingStore.custom_id).all()
-            return [result[0] for result in results if result[0] is not None]
-
-    def get_filtered_ids(self, ids: list[str]) -> list[str]:
-        with Session(self._bind) as session:
-            query = session.query(self.EmbeddingStore.custom_id).filter(
-                self.EmbeddingStore.custom_id.in_(ids)
-            )
-            results = query.all()
-            return [result[0] for result in results if result[0] is not None]
-
-    def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
-        with Session(self._bind) as session:
+            collection_clause = self._collection_clause(session)
+            if collection_clause is None:
+                return []
             results = (
-                session.query(self.EmbeddingStore)
-                .filter(self.EmbeddingStore.custom_id.in_(ids))
+                session.query(self.EmbeddingStore.custom_id)
+                .filter(collection_clause)
+                .filter(self._scope_clause(allowed, tenants))
+                .distinct()
                 .all()
             )
+            return [result[0] for result in results if result[0] is not None]
+
+    def get_filtered_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> list[str]:
+        """Which of ``ids`` exist inside ``owners`` and ``tenants``.
+
+        Scope is a required argument rather than an optional one: a
+        caller-supplied file id is not an authorization, and an existence answer
+        computed without the owner and tenant predicate is an oracle over every
+        file in the deployment.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return []
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed, tenants)
+            if file_clause is None:
+                return []
+            results = (
+                session.query(self.EmbeddingStore.custom_id)
+                .filter(file_clause)
+                .distinct()
+                .all()
+            )
+            return [result[0] for result in results if result[0] is not None]
+
+    def get_documents_by_ids(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> list[Document]:
+        """Chunks of ``ids`` owned inside ``owners`` and ``tenants``.
+
+        The scope goes into the SQL predicate, so a foreign chunk is never read
+        into this process rather than being filtered out after the fact.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return []
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed, tenants)
+            if file_clause is None:
+                return []
+            results = session.query(self.EmbeddingStore).filter(file_clause).all()
             return [
                 Document(page_content=result.document, metadata=result.cmetadata or {})
                 for result in results
-                if result.custom_id in ids
             ]
+
+    def delete_scoped(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> None:
+        """Delete the chunks of ``ids`` that ``owners``/``tenants`` actually own.
+
+        A file id is caller-supplied and not unique across owners — anyone may
+        upload under a chosen ``file_id`` — so the DELETE carries the scope in
+        its own predicate rather than trusting a separate existence check.
+        """
+        self._delete_scoped(ids, owners, tenants)
+
+    def _delete_scoped(
+        self,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ) -> None:
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed or not tenants:
+            return
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed, tenants)
+            if file_clause is None:
+                return
+            session.execute(delete(self.EmbeddingStore).where(file_clause))
+            session.commit()
 
     def _delete_by_metadata(self, metadata_filter: Dict[str, Any]) -> None:
         """Delete rows in this collection that exactly match metadata values."""
@@ -269,6 +348,27 @@ class ExtendedPgVector(PGVector):
         else:
             tenant_clause = tenant_column.in_(present)
         return sqlalchemy.and_(owner_column.in_(owners), tenant_clause)
+
+    def _file_scope_clause(
+        self,
+        session: Session,
+        ids: Sequence[str],
+        owners: Sequence[str],
+        tenants: Sequence[Optional[str]],
+    ):
+        """``(collection, file id, owner, tenant)`` for the file-addressed routes.
+
+        ``None`` means this store's collection does not exist yet, which is
+        indistinguishable from it holding no rows.
+        """
+        collection_clause = self._collection_clause(session)
+        if collection_clause is None:
+            return None
+        return sqlalchemy.and_(
+            collection_clause,
+            self.EmbeddingStore.custom_id.in_(list(ids)),
+            self._scope_clause(list(owners), tenants),
+        )
 
     def probe_candidate_ids(
         self,

--- a/app/utils/text.py
+++ b/app/utils/text.py
@@ -1,0 +1,32 @@
+"""Text normalization and non-reversible fingerprints.
+
+The search stack bans raw search text from rag_api logs, so every place that
+would otherwise log a query or a candidate body logs a fingerprint from here
+instead.
+"""
+
+import re
+import hashlib
+import unicodedata
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def normalize_text(value: str) -> str:
+    """NFKC-normalize, collapse whitespace runs, and trim.
+
+    Mirrors the projector-side normalization so a content hash computed here
+    matches the embedding-input hash the caller stores. The transform is
+    idempotent, so already-normalized input is passed through unchanged.
+    """
+    return _WHITESPACE.sub(" ", unicodedata.normalize("NFKC", value)).strip()
+
+
+def content_hash(value: str) -> str:
+    """SHA-256 hex digest of ``value`` (expected to be normalized already)."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def fingerprint(value: str) -> str:
+    """Short non-reversible handle safe to put in logs."""
+    return content_hash(value)[:12]

--- a/db-compose.yaml
+++ b/db-compose.yaml
@@ -4,9 +4,10 @@ services:
   db:
     image: ankane/pgvector:latest
     environment:
-      POSTGRES_DB: mydatabase
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypassword
+      # Required — no fallback default. Set these in .env (see .env.example).
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - pgdata2:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,10 @@ services:
   db:
     image: ankane/pgvector:latest
     environment:
-      POSTGRES_DB: mydatabase
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypassword
+      # Required — no fallback default. Set these in .env (see .env.example).
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - pgdata2:/var/lib/postgresql/data
     ports:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 import os
 import uvicorn
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
@@ -102,10 +103,22 @@ if debug_mode:
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    logger.debug("Validation error: %s", exc.errors())
+    # Custom field validators put the originating exception in `ctx`, which is
+    # not JSON serializable — encoding it as its message keeps a 422 a 422.
+    errors = jsonable_encoder(exc.errors(), custom_encoder={Exception: str})
+    # Only locations and error types are logged: the `input` values carry the
+    # caller's raw text, which never belongs in these logs.
+    logger.debug(
+        "Validation error: %s",
+        [
+            {"loc": error.get("loc"), "type": error.get("type")}
+            for error in errors
+            if isinstance(error, dict)
+        ],
+    )
     return JSONResponse(
         status_code=422,
-        content={"detail": exc.errors(), "message": "Request validation failed"},
+        content={"detail": errors, "message": "Request validation failed"},
     )
 
 

--- a/main.py
+++ b/main.py
@@ -52,6 +52,14 @@ async def lifespan(app: FastAPI):
         await PSQLDatabase.get_pool()  # Initialize the pool
         await ensure_vector_indexes()
 
+    if VECTOR_DB_TYPE == VectorDBType.ATLAS_MONGO:
+        try:
+            vector_store.ensure_indexes()
+        except Exception as exc:
+            # An index-restricted database user must not stop the service. The
+            # lookups still return the right answers, they just scan.
+            logger.warning("Failed to ensure Atlas standard indexes: %s", exc)
+
     yield
 
     # Cleanup logic

--- a/main.py
+++ b/main.py
@@ -22,10 +22,15 @@ from app.config import (
     logger,
     vector_store,
 )
+from app.auth import validate_startup_config
 from app.middleware import security_middleware
-from app.routes import document_routes, pgvector_routes
+from app.routes import document_routes, pgvector_routes, search_routes
 from app.services.database import PSQLDatabase, ensure_vector_indexes
 from app.services.vector_store.factory import close_vector_store_connections
+
+# Fail closed before the app exists: a deployment with broken signing
+# configuration must not reach a state where it serves requests.
+auth_settings = validate_startup_config()
 
 
 @asynccontextmanager
@@ -90,6 +95,7 @@ app.state.PDF_EXTRACT_IMAGES = PDF_EXTRACT_IMAGES
 
 # Include routers
 app.include_router(document_routes.router)
+app.include_router(search_routes.router)
 if debug_mode:
     app.include_router(router=pgvector_routes.router)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,10 @@ def dummy_post_init(self):
     pass
 
 
+# Integration tests that talk to a real container need the genuine bootstrap
+# back, so keep a handle on it before it is replaced.
+ORIGINAL_PGVECTOR_POST_INIT = PGVector.__post_init__
+
 AsyncPgVector.__post_init__ = dummy_post_init
 PGVector.__post_init__ = dummy_post_init
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,19 @@ import os
 
 import pytest
 
-from app.services.vector_store.async_pg_vector import AsyncPgVector
-
 # Set environment variables early so config picks up test settings.
 os.environ["TESTING"] = "1"
 # Set DB_HOST (and DSN) to dummy values to avoid real connection attempts.
 os.environ["DB_HOST"] = "localhost"  # or any dummy value
 os.environ["DSN"] = "dummy://"
+# The application ships no fallback credentials, so the harness supplies its
+# own throwaway values before app.config is imported. These reach a container
+# that holds test data only.
+os.environ.setdefault("POSTGRES_DB", "rag_api_test_db")
+os.environ.setdefault("POSTGRES_USER", "rag_api_test_user")
+os.environ.setdefault("POSTGRES_PASSWORD", "rag_api_test_password")
+
+from app.services.vector_store.async_pg_vector import AsyncPgVector
 
 # -- Patch the vector store classes to bypass DB connection --
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,18 +55,21 @@ def reset_request_scoped_settings():
 
 
 class DummyVectorStore:
-    def get_all_ids(self) -> list[str]:
+    def get_all_ids(self, owners, tenants) -> list[str]:
         return ["testid1", "testid2"]
 
-    def get_filtered_ids(self, ids) -> list[str]:
+    def get_filtered_ids(self, ids, owners, tenants) -> list[str]:
         dummy_ids = ["testid1", "testid2"]
         return [id for id in dummy_ids if id in ids]
 
-    async def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
+    async def get_documents_by_ids(self, ids, owners, tenants) -> list[Document]:
         return [
             Document(page_content="Test content", metadata={"file_id": id})
             for id in ids
         ]
+
+    def delete_scoped(self, ids, owners, tenants) -> None:
+        return None
 
     def similarity_search_with_score_by_vector(self, embedding, k: int, filter: dict):
         doc = Document(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # tests/conftest.py
 import os
 
+import pytest
+
 from app.services.vector_store.async_pg_vector import AsyncPgVector
 
 # Set environment variables early so config picks up test settings.
@@ -24,6 +26,22 @@ AsyncPgVector.__post_init__ = dummy_post_init
 PGVector.__post_init__ = dummy_post_init
 
 from langchain_core.documents import Document
+
+from app import auth
+from app.services import ratelimit
+
+
+@pytest.fixture(autouse=True)
+def reset_request_scoped_settings():
+    """Auth and rate-limit settings are read once and cached, as in production.
+
+    Tests mutate the environment, so the cache is dropped around every test.
+    """
+    auth.reset_settings()
+    ratelimit.reset()
+    yield
+    auth.reset_settings()
+    ratelimit.reset()
 
 
 class DummyVectorStore:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,75 @@
+"""Deterministic in-process stand-ins for the inference backends.
+
+Only the network boundary is faked. Space contract enforcement, blending,
+ranking, limits and authorization all run their real code paths.
+"""
+
+import hashlib
+from typing import Dict, List, Optional
+
+from app.services import space as space_module
+from app.services.space import EmbeddingSpace, SpaceSpec
+
+FAKE_DIMENSIONS = 8
+FAKE_MODEL = "fake-embedding-model"
+
+
+def deterministic_vector(text: str, dimensions: int = FAKE_DIMENSIONS) -> List[float]:
+    """A stable pseudo-random vector for ``text``. Never the zero vector."""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return [(digest[index % len(digest)] / 255.0) - 0.5 for index in range(dimensions)]
+
+
+class FakeEmbeddingClient:
+    """Records every batch it is asked to embed."""
+
+    def __init__(
+        self,
+        dimensions: int = FAKE_DIMENSIONS,
+        vectors: Optional[Dict[str, List[float]]] = None,
+        error: Optional[Exception] = None,
+    ):
+        self.dimensions = dimensions
+        self.vectors = vectors or {}
+        self.error = error
+        self.calls: List[List[str]] = []
+
+    @property
+    def embedded_texts(self) -> List[str]:
+        return [text for call in self.calls for text in call]
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        if self.error is not None:
+            raise self.error
+        self.calls.append(list(texts))
+        return [
+            self.vectors.get(text, deterministic_vector(text, self.dimensions))
+            for text in texts
+        ]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self.embed_documents([text])[0]
+
+
+def install_fake_space(
+    monkeypatch,
+    client: FakeEmbeddingClient,
+    name: Optional[str] = None,
+    model: str = FAKE_MODEL,
+    normalized: bool = True,
+    dimensions: Optional[int] = None,
+) -> EmbeddingSpace:
+    """Swap a space's backend for ``client`` for the duration of one test.
+
+    ``dimensions`` defaults to what the client produces; passing a different
+    value models a backend that drifted off its locked width.
+    """
+    spec = SpaceSpec(
+        name=name or space_module.CHAT_SPACE_SPEC.name,
+        model=model,
+        dimensions=client.dimensions if dimensions is None else dimensions,
+        normalized=normalized,
+    )
+    space = EmbeddingSpace(spec, lambda: client)
+    monkeypatch.setitem(space_module._spaces, spec.name, space)
+    return space

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,20 +4,45 @@ Equivalent to mongodb-memory-server in Node.js: spins up a real, ephemeral
 PostgreSQL instance with pgvector for production-parity testing.
 """
 
+import hashlib
+from typing import List
+
 import pytest
 import sqlalchemy
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from testcontainers.postgres import PostgresContainer
 
+from app.services.vector_store.async_pg_vector import AsyncPgVector
+from app.services.vector_store.factory import get_vector_store
+from tests.conftest import ORIGINAL_PGVECTOR_POST_INIT
+
 PGVECTOR_IMAGE = "pgvector/pgvector:pg16"
+
+# The shared table is created with `vector(3)`, so every store built against
+# this container embeds into three dimensions.
+TEST_DIMENSIONS = 3
 
 
 @pytest.fixture(scope="session")
 def pg_container():
-    """Start a pgvector PostgreSQL container once for the entire test session."""
-    with PostgresContainer(PGVECTOR_IMAGE, driver="psycopg2") as pg:
-        yield pg
+    """Start a pgvector PostgreSQL container once for the entire test session.
+
+    Skips — rather than errors — when no container runtime is reachable, so the
+    DB-dependent suites stay runnable on machines without Docker.
+    """
+    container = PostgresContainer(PGVECTOR_IMAGE, driver="psycopg2")
+    try:
+        container.start()
+    except Exception as exc:
+        pytest.skip(
+            f"PostgreSQL is unreachable ({type(exc).__name__}: {exc}); "
+            "skipping database-dependent tests"
+        )
+    try:
+        yield container
+    finally:
+        container.stop()
 
 
 @pytest.fixture(scope="session")
@@ -100,6 +125,50 @@ def collection_id(engine, _create_tables):
             {"name": "test_collection", "meta": "{}"},
         ).fetchone()
     return row[0]
+
+
+class DeterministicEmbeddings:
+    """Three-dimensional embeddings derived from the text, plus a call log.
+
+    Real inference is the only thing faked here; every store write, SQL
+    predicate and cosine computation below runs for real against PostgreSQL.
+    """
+
+    def __init__(self, vectors=None):
+        self.vectors = vectors or {}
+        self.queries: List[str] = []
+        self.documents: List[str] = []
+
+    def _vector(self, text_value: str) -> List[float]:
+        if text_value in self.vectors:
+            return list(self.vectors[text_value])
+        digest = hashlib.sha256(text_value.encode("utf-8")).digest()
+        return [(digest[index] / 255.0) + 0.01 for index in range(TEST_DIMENSIONS)]
+
+    def embed_query(self, text_value: str) -> List[float]:
+        self.queries.append(text_value)
+        return self._vector(text_value)
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        self.documents.extend(texts)
+        return [self._vector(text_value) for text_value in texts]
+
+
+@pytest.fixture()
+def pg_store(pg_url, engine, _create_tables, monkeypatch):
+    """A real AsyncPgVector bound to the container, with its own collection."""
+    monkeypatch.setattr(AsyncPgVector, "__post_init__", ORIGINAL_PGVECTOR_POST_INIT)
+    embeddings = DeterministicEmbeddings()
+    store = get_vector_store(
+        connection_string=pg_url,
+        embeddings=embeddings,
+        collection_name=f"integration-{id(embeddings)}",
+        mode="async",
+        create_extension=False,
+    )
+    store.embeddings_log = embeddings
+    yield store
+    store._bind.dispose()
 
 
 @pytest.fixture()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ PostgreSQL instance with pgvector for production-parity testing.
 """
 
 import hashlib
+import uuid
 from typing import List
 
 import pytest
@@ -162,7 +163,10 @@ def pg_store(pg_url, engine, _create_tables, monkeypatch):
     store = get_vector_store(
         connection_string=pg_url,
         embeddings=embeddings,
-        collection_name=f"integration-{id(embeddings)}",
+        # A fresh collection per test. id() is not usable here: CPython
+        # reuses addresses after collection, so two tests could land in the
+        # same collection and see each other's rows.
+        collection_name=f"integration-{uuid.uuid4().hex}",
         mode="async",
         create_extension=False,
     )

--- a/tests/integration/test_document_authorization_pg.py
+++ b/tests/integration/test_document_authorization_pg.py
@@ -1,0 +1,211 @@
+"""File-addressed reads and deletes against real PostgreSQL.
+
+``GET /documents``, ``GET /documents/{id}/context`` and ``DELETE /documents``
+address rows by a caller-supplied file id. These prove the owner and tenant
+predicate is in the SQL — not applied to the rows afterwards — including the
+case a fake store cannot show: two owners holding rows under the same file id,
+where an unscoped ``DELETE ... WHERE custom_id IN (...)`` destroys both.
+"""
+
+import uuid
+
+import pytest
+from langchain_core.documents import Document
+
+from app.services.vector_store.async_pg_vector import AsyncPgVector
+from tests.integration.conftest import DeterministicEmbeddings
+
+pytestmark = pytest.mark.integration
+
+BASE_TENANTS = ["__BASE__", None]
+
+# (file_id, user_id, tenant_id, chunk)
+CORPUS = [
+    ("file-owned", "user-1", "__BASE__", "owned chunk"),
+    ("file-foreign", "user-2", "__BASE__", "foreign chunk"),
+    ("file-agent", "agent-7", "__BASE__", "agent chunk"),
+    ("file-other-tenant", "user-1", "tenant-b", "other tenant chunk"),
+    ("file-collided", "user-1", "__BASE__", "mine"),
+    ("file-collided", "user-2", "__BASE__", "theirs"),
+    ("file-untagged", "user-1", None, "pre-tenant chunk"),
+]
+
+
+@pytest.fixture()
+def seeded(pg_store):
+    for file_id, user_id, tenant_id, chunk in CORPUS:
+        metadata = {"file_id": file_id, "user_id": user_id}
+        if tenant_id is not None:
+            metadata["tenant_id"] = tenant_id
+        pg_store.add_documents(
+            [Document(page_content=chunk, metadata=metadata)], ids=[file_id]
+        )
+    return pg_store
+
+
+@pytest.fixture()
+def sibling_collection(pg_url, engine, _create_tables, monkeypatch):
+    """A second collection sharing ``langchain_pg_embedding``."""
+    from app.services.vector_store.factory import get_vector_store
+    from tests.conftest import ORIGINAL_PGVECTOR_POST_INIT
+
+    monkeypatch.setattr(AsyncPgVector, "__post_init__", ORIGINAL_PGVECTOR_POST_INIT)
+    store = get_vector_store(
+        connection_string=pg_url,
+        embeddings=DeterministicEmbeddings(),
+        collection_name=f"sibling-{uuid.uuid4().hex}",
+        mode="async",
+        create_extension=False,
+    )
+    yield store
+    store._bind.dispose()
+
+
+def contents(documents):
+    return sorted(document.page_content for document in documents)
+
+
+class TestReadsAreScopedInSql:
+    async def test_a_foreign_file_resolves_to_nothing(self, seeded):
+        assert (
+            await seeded.get_filtered_ids(["file-foreign"], ["user-1"], BASE_TENANTS)
+            == []
+        )
+        assert (
+            await seeded.get_documents_by_ids(
+                ["file-foreign"], ["user-1"], BASE_TENANTS
+            )
+            == []
+        )
+
+    async def test_the_owners_own_file_still_resolves(self, seeded):
+        assert await seeded.get_filtered_ids(
+            ["file-owned"], ["user-1"], BASE_TENANTS
+        ) == ["file-owned"]
+        documents = await seeded.get_documents_by_ids(
+            ["file-owned"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["owned chunk"]
+
+    async def test_a_collided_file_id_yields_only_the_callers_chunks(self, seeded):
+        documents = await seeded.get_documents_by_ids(
+            ["file-collided"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["mine"]
+
+    async def test_another_tenant_does_not_see_the_same_owners_rows(self, seeded):
+        assert (
+            await seeded.get_documents_by_ids(
+                ["file-other-tenant"], ["user-1"], ["tenant-a"]
+            )
+            == []
+        )
+        documents = await seeded.get_documents_by_ids(
+            ["file-other-tenant"], ["user-1"], ["tenant-b"]
+        )
+        assert contents(documents) == ["other tenant chunk"]
+
+    async def test_the_base_tenant_matches_chunks_written_before_tenants(self, seeded):
+        documents = await seeded.get_documents_by_ids(
+            ["file-untagged"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["pre-tenant chunk"]
+
+    async def test_a_permitted_entity_widens_the_owner_set(self, seeded):
+        documents = await seeded.get_documents_by_ids(
+            ["file-agent"], ["agent-7", "user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["agent chunk"]
+
+    async def test_an_empty_owner_set_authorizes_nothing(self, seeded):
+        assert await seeded.get_documents_by_ids(["file-owned"], [], BASE_TENANTS) == []
+
+    async def test_listing_is_scoped_to_the_caller(self, seeded):
+        assert sorted(await seeded.get_all_ids(["user-1"], BASE_TENANTS)) == [
+            "file-collided",
+            "file-owned",
+            "file-untagged",
+        ]
+
+    async def test_a_sibling_collections_rows_are_invisible(
+        self, seeded, sibling_collection
+    ):
+        await sibling_collection.aadd_documents(
+            [
+                Document(
+                    page_content="sibling chunk",
+                    metadata={
+                        "file_id": "file-owned",
+                        "user_id": "user-1",
+                        "tenant_id": "__BASE__",
+                    },
+                )
+            ],
+            ids=["file-owned"],
+        )
+        documents = await seeded.get_documents_by_ids(
+            ["file-owned"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["owned chunk"]
+
+
+class TestDeletesAreScopedInSql:
+    async def test_a_foreign_file_is_not_deleted(self, seeded):
+        await seeded.delete_scoped(["file-foreign"], ["user-1"], BASE_TENANTS)
+        survivors = await seeded.get_documents_by_ids(
+            ["file-foreign"], ["user-2"], BASE_TENANTS
+        )
+        assert contents(survivors) == ["foreign chunk"]
+
+    async def test_the_owners_own_file_is_deleted(self, seeded):
+        await seeded.delete_scoped(["file-owned"], ["user-1"], BASE_TENANTS)
+        assert (
+            await seeded.get_documents_by_ids(["file-owned"], ["user-1"], BASE_TENANTS)
+            == []
+        )
+
+    async def test_a_collided_file_id_deletes_only_the_callers_rows(self, seeded):
+        """The case the separate existence check cannot cover.
+
+        Both owners hold rows under ``file-collided``; a DELETE that filters on
+        the file id alone removes the other owner's chunk as well.
+        """
+        await seeded.delete_scoped(["file-collided"], ["user-1"], BASE_TENANTS)
+        survivors = await seeded.get_documents_by_ids(
+            ["file-collided"], ["user-2"], BASE_TENANTS
+        )
+        assert contents(survivors) == ["theirs"]
+
+    async def test_another_tenant_cannot_delete_the_same_owners_rows(self, seeded):
+        await seeded.delete_scoped(["file-other-tenant"], ["user-1"], ["tenant-a"])
+        survivors = await seeded.get_documents_by_ids(
+            ["file-other-tenant"], ["user-1"], ["tenant-b"]
+        )
+        assert contents(survivors) == ["other tenant chunk"]
+
+    async def test_an_empty_owner_set_deletes_nothing(self, seeded):
+        await seeded.delete_scoped(["file-owned"], [], BASE_TENANTS)
+        documents = await seeded.get_documents_by_ids(
+            ["file-owned"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["owned chunk"]
+
+    async def test_a_sibling_collections_rows_survive(self, seeded, sibling_collection):
+        await sibling_collection.aadd_documents(
+            [
+                Document(
+                    page_content="sibling chunk",
+                    metadata={
+                        "file_id": "file-owned",
+                        "user_id": "user-1",
+                        "tenant_id": "__BASE__",
+                    },
+                )
+            ],
+            ids=["file-owned"],
+        )
+        await seeded.delete_scoped(["file-owned"], ["user-1"], BASE_TENANTS)
+        survivors = await sibling_collection.get_documents_by_ids(
+            ["file-owned"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(survivors) == ["sibling chunk"]

--- a/tests/integration/test_gateway_embeddings.py
+++ b/tests/integration/test_gateway_embeddings.py
@@ -16,8 +16,6 @@ import pytest
 
 from app.services.space import EmbeddingSpace, SpaceSpec, _build_openai_client
 
-pytestmark = pytest.mark.integration
-
 BASE_URL = os.getenv("RAG_GATEWAY_TEST_BASEURL")
 API_KEY = os.getenv("RAG_GATEWAY_TEST_API_KEY")
 

--- a/tests/integration/test_gateway_embeddings.py
+++ b/tests/integration/test_gateway_embeddings.py
@@ -1,0 +1,63 @@
+"""Optional live check of the chat-v1 space against the inference gateway.
+
+Skipped unless ``RAG_GATEWAY_TEST_BASEURL`` and ``RAG_GATEWAY_TEST_API_KEY``
+are set, because the gateway is reached over a tunnel that can disappear at any
+time. Everything else in the suite runs against fakes.
+
+    RAG_GATEWAY_TEST_BASEURL=http://localhost:18080/v1 \
+    RAG_GATEWAY_TEST_API_KEY=... \
+    pytest tests/integration/test_gateway_embeddings.py -m integration
+"""
+
+import math
+import os
+
+import pytest
+
+from app.services.space import EmbeddingSpace, SpaceSpec, _build_openai_client
+
+pytestmark = pytest.mark.integration
+
+BASE_URL = os.getenv("RAG_GATEWAY_TEST_BASEURL")
+API_KEY = os.getenv("RAG_GATEWAY_TEST_API_KEY")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (BASE_URL and API_KEY),
+        reason="RAG_GATEWAY_TEST_BASEURL / RAG_GATEWAY_TEST_API_KEY are not set",
+    ),
+]
+
+
+@pytest.fixture()
+def chat_space(monkeypatch):
+    monkeypatch.setenv("RAG_CHAT_EMBEDDING_BASEURL", BASE_URL)
+    monkeypatch.setenv("RAG_CHAT_EMBEDDING_API_KEY", API_KEY)
+    spec = SpaceSpec(
+        name="chat-v1",
+        model=os.getenv("RAG_GATEWAY_TEST_MODEL", "qwen3-embedding-8b"),
+        dimensions=1024,
+        normalized=True,
+    )
+    return EmbeddingSpace(spec, lambda: _build_openai_client(spec))
+
+
+def test_gateway_serves_the_locked_dimensionality(chat_space):
+    vectors = chat_space.embed_documents(["hello world", "a second input"])
+    assert len(vectors) == 2
+    assert all(len(vector) == 1024 for vector in vectors)
+
+
+def test_vectors_leave_the_service_l2_normalized(chat_space):
+    """The gateway returns unnormalized vectors; the space normalizes them."""
+    vector = chat_space.embed_query("normalize me")
+    assert math.isclose(
+        math.sqrt(sum(component**2 for component in vector)), 1.0, rel_tol=1e-6
+    )
+
+
+def test_the_same_text_embeds_to_the_same_vector(chat_space):
+    first = chat_space.embed_query("stability check")
+    second = chat_space.embed_query("stability check")
+    assert first == second

--- a/tests/integration/test_query_authorization_pg.py
+++ b/tests/integration/test_query_authorization_pg.py
@@ -1,0 +1,146 @@
+"""Cross-user isolation of /query and /query_multiple, executed by real PostgreSQL.
+
+The unit suite proves the owner predicate is built and honoured by a fake
+store. These tests prove PostgreSQL itself enforces it: the documents are
+written through the real pgvector write path, and the filter is translated to
+SQL and executed by the database.
+"""
+
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.documents import Document
+
+from app import auth
+from main import app
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, legacy_token, strict_token
+
+pytestmark = pytest.mark.integration
+
+client = TestClient(app)
+
+CORPUS = [
+    ("file-owned", "user-1", "owner chunk one"),
+    ("file-owned", "user-1", "owner chunk two"),
+    ("file-foreign", "user-2", "foreign chunk"),
+    ("file-shared", "user-1", "shared chunk owned by user one"),
+    ("file-shared", "user-2", "shared chunk owned by user two"),
+    ("file-agent", "agent-7", "agent knowledge chunk"),
+]
+
+
+def digest(text_value: str) -> str:
+    return hashlib.md5(text_value.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture()
+def seeded(pg_store, monkeypatch):
+    for file_id, user_id, chunk in CORPUS:
+        pg_store.add_documents(
+            [
+                Document(
+                    page_content=chunk,
+                    metadata={
+                        "file_id": file_id,
+                        "user_id": user_id,
+                        "digest": digest(chunk),
+                    },
+                )
+            ],
+            ids=[file_id],
+        )
+
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "true")
+    auth.reset_settings()
+
+    monkeypatch.setattr("app.routes.document_routes.vector_store", pg_store)
+    monkeypatch.setattr(
+        "app.routes.document_routes.get_cached_query_embedding",
+        pg_store.embedding_function.embed_query,
+    )
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+    return pg_store
+
+
+def query(file_id, subject="user-1", entity_id=None, token=None, k=20):
+    body = {"query": "chunk", "file_id": file_id, "k": k}
+    if entity_id:
+        body["entity_id"] = entity_id
+    return client.post(
+        "/query", json=body, headers=bearer(token or strict_token(subject=subject))
+    )
+
+
+def owners_of(response):
+    return {hit[0]["metadata"]["user_id"] for hit in response.json()}
+
+
+def test_foreign_file_returns_nothing(seeded):
+    response = query("file-foreign", subject="user-1")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_shared_file_returns_only_the_callers_chunks(seeded):
+    response = query("file-shared", subject="user-1")
+    assert response.status_code == 200
+    assert owners_of(response) == {"user-1"}
+
+
+def test_each_user_sees_only_their_own_side_of_a_shared_file(seeded):
+    assert owners_of(query("file-shared", subject="user-1")) == {"user-1"}
+    assert owners_of(query("file-shared", subject="user-2")) == {"user-2"}
+
+
+def test_entity_impersonation_is_refused(seeded):
+    response = query("file-foreign", subject="user-1", entity_id="user-2")
+    assert response.status_code == 403
+
+
+def test_permitted_entity_reaches_only_that_entitys_chunks(seeded):
+    token = strict_token(subject="user-1", entities=["agent-7"])
+    response = query("file-agent", token=token, entity_id="agent-7")
+    assert response.status_code == 200
+    assert owners_of(response) == {"agent-7"}
+
+
+def test_unpermitted_entity_cannot_reach_agent_chunks(seeded):
+    response = query("file-agent", subject="user-1")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_legacy_token_is_scoped_to_its_subject(seeded):
+    response = query("file-shared", token=legacy_token(user_id="user-1"))
+    assert response.status_code == 200
+    assert owners_of(response) == {"user-1"}
+
+
+def test_query_multiple_filters_foreign_files_in_sql(seeded):
+    response = client.post(
+        "/query_multiple",
+        json={
+            "query": "chunk",
+            "file_ids": ["file-owned", "file-foreign", "file-shared", "file-agent"],
+            "k": 20,
+        },
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 200
+    assert owners_of(response) == {"user-1"}
+    files = {hit[0]["metadata"]["file_id"] for hit in response.json()}
+    assert files == {"file-owned", "file-shared"}
+
+
+def test_query_multiple_over_only_foreign_files_returns_nothing(seeded):
+    response = client.post(
+        "/query_multiple",
+        json={"query": "chunk", "file_ids": ["file-foreign", "file-agent"], "k": 20},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 404

--- a/tests/integration/test_query_authorization_pg.py
+++ b/tests/integration/test_query_authorization_pg.py
@@ -21,13 +21,17 @@ pytestmark = pytest.mark.integration
 
 client = TestClient(app)
 
+# (file_id, user_id, chunk, tenant_id) — a None tenant models a chunk written
+# before tenants were recorded on write.
 CORPUS = [
-    ("file-owned", "user-1", "owner chunk one"),
-    ("file-owned", "user-1", "owner chunk two"),
-    ("file-foreign", "user-2", "foreign chunk"),
-    ("file-shared", "user-1", "shared chunk owned by user one"),
-    ("file-shared", "user-2", "shared chunk owned by user two"),
-    ("file-agent", "agent-7", "agent knowledge chunk"),
+    ("file-owned", "user-1", "owner chunk one", None),
+    ("file-owned", "user-1", "owner chunk two", None),
+    ("file-foreign", "user-2", "foreign chunk", None),
+    ("file-shared", "user-1", "shared chunk owned by user one", None),
+    ("file-shared", "user-2", "shared chunk owned by user two", None),
+    ("file-agent", "agent-7", "agent knowledge chunk", None),
+    ("file-tenanted", "user-1", "chunk in tenant a", "tenant-a"),
+    ("file-tenanted", "user-1", "chunk in tenant b", "tenant-b"),
 ]
 
 
@@ -37,19 +41,16 @@ def digest(text_value: str) -> str:
 
 @pytest.fixture()
 def seeded(pg_store, monkeypatch):
-    for file_id, user_id, chunk in CORPUS:
+    for file_id, user_id, chunk, tenant_id in CORPUS:
+        metadata = {
+            "file_id": file_id,
+            "user_id": user_id,
+            "digest": digest(chunk),
+        }
+        if tenant_id is not None:
+            metadata["tenant_id"] = tenant_id
         pg_store.add_documents(
-            [
-                Document(
-                    page_content=chunk,
-                    metadata={
-                        "file_id": file_id,
-                        "user_id": user_id,
-                        "digest": digest(chunk),
-                    },
-                )
-            ],
-            ids=[file_id],
+            [Document(page_content=chunk, metadata=metadata)], ids=[file_id]
         )
 
     monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
@@ -67,13 +68,21 @@ def seeded(pg_store, monkeypatch):
     return pg_store
 
 
-def query(file_id, subject="user-1", entity_id=None, token=None, k=20):
+def query(file_id, subject="user-1", entity_id=None, token=None, k=20, tenant=None):
     body = {"query": "chunk", "file_id": file_id, "k": k}
     if entity_id:
         body["entity_id"] = entity_id
-    return client.post(
-        "/query", json=body, headers=bearer(token or strict_token(subject=subject))
-    )
+    if token is None:
+        token = (
+            strict_token(subject=subject, tenant=tenant)
+            if tenant
+            else strict_token(subject=subject)
+        )
+    return client.post("/query", json=body, headers=bearer(token))
+
+
+def contents_of(response):
+    return {hit[0]["page_content"] for hit in response.json()}
 
 
 def owners_of(response):
@@ -144,3 +153,92 @@ def test_query_multiple_over_only_foreign_files_returns_nothing(seeded):
         headers=bearer(strict_token(subject="user-1")),
     )
     assert response.status_code == 404
+
+
+class TestTenantScopeInPostgres:
+    """Tenant is enforced by the SQL predicate, not by a later filter."""
+
+    def test_a_tenant_sees_only_its_own_side_of_a_shared_file(self, seeded):
+        response = query("file-tenanted", tenant="tenant-a")
+        assert response.status_code == 200
+        assert contents_of(response) == {"chunk in tenant a"}
+
+    def test_the_other_tenant_sees_only_its_own_side(self, seeded):
+        response = query("file-tenanted", tenant="tenant-b")
+        assert response.status_code == 200
+        assert contents_of(response) == {"chunk in tenant b"}
+
+    def test_the_base_tenant_sees_neither(self, seeded):
+        response = query("file-tenanted", tenant="__BASE__")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_the_base_tenant_still_reads_chunks_written_before_tenants_existed(
+        self, seeded
+    ):
+        response = query("file-owned", tenant="__BASE__")
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+
+    def test_a_real_tenant_never_absorbs_untagged_chunks(self, seeded):
+        response = query("file-owned", tenant="tenant-a")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_the_system_tenant_is_refused(self, seeded):
+        response = query("file-owned", tenant="__SYSTEM__")
+        assert response.status_code == 403
+
+    def test_query_multiple_is_tenant_scoped_in_sql(self, seeded):
+        response = client.post(
+            "/query_multiple",
+            json={
+                "query": "chunk",
+                "file_ids": ["file-owned", "file-tenanted"],
+                "k": 20,
+            },
+            headers=bearer(strict_token(subject="user-1", tenant="tenant-a")),
+        )
+        assert response.status_code == 200
+        assert contents_of(response) == {"chunk in tenant a"}
+
+
+class TestWritePathRecordsScope:
+    """Chunks are stamped with the writer's tenant so reads can scope on it."""
+
+    def test_uploaded_chunks_record_the_callers_tenant(self, seeded, tmp_path, engine):
+        from sqlalchemy import text
+
+        upload = tmp_path / "note.txt"
+        upload.write_text("a freshly uploaded chunk of text")
+        with upload.open("rb") as handle:
+            response = client.post(
+                "/embed",
+                data={"file_id": "file-uploaded"},
+                files={"file": ("note.txt", handle, "text/plain")},
+                headers=bearer(strict_token(subject="user-9", tenant="tenant-z")),
+            )
+        assert response.status_code == 200, response.text
+
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT cmetadata->>'user_id', cmetadata->>'tenant_id' "
+                    "FROM langchain_pg_embedding WHERE custom_id = :file_id"
+                ),
+                {"file_id": "file-uploaded"},
+            ).fetchall()
+        assert rows
+        assert all(row[0] == "user-9" and row[1] == "tenant-z" for row in rows)
+
+    def test_writing_into_an_unpermitted_entity_is_refused(self, seeded, tmp_path):
+        upload = tmp_path / "poison.txt"
+        upload.write_text("content aimed at another entity")
+        with upload.open("rb") as handle:
+            response = client.post(
+                "/embed",
+                data={"file_id": "file-poison", "entity_id": "agent-7"},
+                files={"file": ("poison.txt", handle, "text/plain")},
+                headers=bearer(strict_token(subject="user-9")),
+            )
+        assert response.status_code == 403

--- a/tests/integration/test_rerank_pg.py
+++ b/tests/integration/test_rerank_pg.py
@@ -6,6 +6,7 @@ costs no candidate inference.
 """
 
 import hashlib
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import List
 
@@ -14,7 +15,9 @@ from fastapi.testclient import TestClient
 from langchain_core.documents import Document
 
 from app import auth
+from app.services.vector_store.async_pg_vector import AsyncPgVector
 from main import app
+from tests.integration.conftest import DeterministicEmbeddings
 from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
 
 pytestmark = pytest.mark.integration
@@ -51,6 +54,26 @@ def digest(text_value: str) -> str:
     return hashlib.md5(text_value.encode("utf-8")).hexdigest()
 
 
+def row_uuid_for(engine, store, chunk: str) -> str:
+    """The row id of ``chunk`` *in this store's collection*.
+
+    Digests collide by design — identical content hashes identically — and the
+    embedding table is shared by every collection in the database, so the
+    collection has to be part of the lookup.
+    """
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        return conn.execute(
+            text(
+                "SELECT e.uuid FROM langchain_pg_embedding e "
+                "JOIN langchain_pg_collection c ON c.uuid = e.collection_id "
+                "WHERE c.name = :collection AND e.cmetadata->>'digest' = :digest"
+            ),
+            {"collection": store.collection_name, "digest": digest(chunk)},
+        ).scalar()
+
+
 class RecordingEmbedder:
     """Stands in for the inference call so candidate embeds are countable."""
 
@@ -82,6 +105,156 @@ def seeded(pg_store):
             [Document(page_content=chunk, metadata=metadata)], ids=[file_id]
         )
     return pg_store
+
+
+@pytest.fixture()
+def sibling_collection(pg_url, engine, _create_tables, monkeypatch):
+    """A second PGVector collection in the same database and the same table.
+
+    ``langchain_pg_embedding`` is shared by every collection, so this is what a
+    deployment hosting more than one store actually looks like.
+    """
+    from app.services.vector_store.factory import get_vector_store
+    from tests.conftest import ORIGINAL_PGVECTOR_POST_INIT
+
+    monkeypatch.setattr(AsyncPgVector, "__post_init__", ORIGINAL_PGVECTOR_POST_INIT)
+    embeddings = DeterministicEmbeddings(VECTORS)
+    store = get_vector_store(
+        connection_string=pg_url,
+        embeddings=embeddings,
+        collection_name=f"sibling-{uuid.uuid4().hex}",
+        mode="async",
+        create_extension=False,
+    )
+    yield store
+    store._bind.dispose()
+
+
+class TestCollectionIsolation:
+    """One database, two collections: neither may answer for the other.
+
+    The candidate queries used to match on id alone, so a row belonging to a
+    sibling collection could be reported as existing — manufacturing a 403 for a
+    candidate this store never held — or have its vector handed back and scored.
+    """
+
+    async def test_a_sibling_collections_row_is_not_reported_as_existing(
+        self, seeded, sibling_collection
+    ):
+        shared_digest = digest("alpha chunk")
+        await sibling_collection.aadd_documents(
+            [
+                Document(
+                    page_content="alpha chunk",
+                    metadata={
+                        "file_id": "file-x",
+                        "user_id": "stranger",
+                        "digest": shared_digest,
+                    },
+                )
+            ],
+            ids=["file-x"],
+        )
+
+        existing, authorized = await sibling_collection.probe_candidate_ids(
+            [digest("foreign chunk")], ["user-1"], BASE_TENANTS
+        )
+        # foreign chunk lives only in the seeded collection.
+        assert existing == set()
+        assert authorized == set()
+
+    async def test_a_sibling_collections_vector_is_never_reused(
+        self, seeded, sibling_collection
+    ):
+        foreign = digest("foreign chunk")
+        assert (
+            await sibling_collection.get_vectors_by_ids(
+                [foreign], ["user-2"], BASE_TENANTS
+            )
+            == {}
+        )
+        # The same id, owner and tenant resolve fine in the collection that owns it.
+        assert list(
+            await seeded.get_vectors_by_ids([foreign], ["user-2"], BASE_TENANTS)
+        ) == [foreign]
+
+    async def test_each_collection_sees_only_its_own_copy(
+        self, seeded, sibling_collection
+    ):
+        shared_digest = digest("alpha chunk")
+        await sibling_collection.aadd_documents(
+            [
+                Document(
+                    page_content="alpha chunk",
+                    metadata={
+                        "file_id": "file-x",
+                        "user_id": "stranger",
+                        "digest": shared_digest,
+                    },
+                )
+            ],
+            ids=["file-x"],
+        )
+
+        seeded_existing, seeded_authorized = await seeded.probe_candidate_ids(
+            [shared_digest], ["user-1"], BASE_TENANTS
+        )
+        assert seeded_existing == {shared_digest}
+        assert seeded_authorized == {shared_digest}
+
+        sibling_existing, sibling_authorized = (
+            await sibling_collection.probe_candidate_ids(
+                [shared_digest], ["user-1"], BASE_TENANTS
+            )
+        )
+        # The sibling holds a copy owned by someone else — existing, unauthorized.
+        assert sibling_existing == {shared_digest}
+        assert sibling_authorized == set()
+
+    async def test_a_sibling_collections_row_uuid_resolves_to_nothing(
+        self, seeded, sibling_collection, engine
+    ):
+        """The row id is globally unique, so only the collection filter stops it."""
+        await sibling_collection.aadd_documents(
+            [
+                Document(
+                    page_content="alpha chunk",
+                    metadata={
+                        "file_id": "file-x",
+                        "user_id": "user-1",
+                        "digest": digest("alpha chunk"),
+                    },
+                )
+            ],
+            ids=["file-x"],
+        )
+        sibling_uuid = str(row_uuid_for(engine, sibling_collection, "alpha chunk"))
+
+        assert (
+            await seeded.get_vectors_by_ids([sibling_uuid], ["user-1"], BASE_TENANTS)
+            == {}
+        )
+        existing, authorized = await seeded.probe_candidate_ids(
+            [sibling_uuid], ["user-1"], BASE_TENANTS
+        )
+        assert existing == set()
+        assert authorized == set()
+
+    async def test_a_collection_that_holds_nothing_authorizes_nothing(
+        self, seeded, sibling_collection
+    ):
+        candidates = [digest(chunk) for _, _, chunk, _ in CORPUS]
+        existing, authorized = await sibling_collection.probe_candidate_ids(
+            candidates, ["user-1"], BASE_TENANTS
+        )
+        assert existing == set()
+        assert authorized == set()
+        assert (
+            await sibling_collection.get_vectors_by_ids(
+                candidates, ["user-1"], BASE_TENANTS
+            )
+            == {}
+        )
 
 
 @pytest.fixture()
@@ -120,16 +293,7 @@ class TestStoredVectorLookup:
         assert len(vectors[digest("alpha chunk")]) == 3
 
     async def test_row_uuid_resolves_to_the_stored_vector(self, seeded, engine):
-        from sqlalchemy import text
-
-        with engine.connect() as conn:
-            row_uuid = conn.execute(
-                text(
-                    "SELECT uuid FROM langchain_pg_embedding "
-                    "WHERE cmetadata->>'digest' = :digest"
-                ),
-                {"digest": digest("alpha chunk")},
-            ).scalar()
+        row_uuid = row_uuid_for(engine, seeded, "alpha chunk")
         vectors = await seeded.get_vectors_by_ids(
             [str(row_uuid)], ["user-1"], BASE_TENANTS
         )

--- a/tests/integration/test_rerank_pg.py
+++ b/tests/integration/test_rerank_pg.py
@@ -29,14 +29,22 @@ VECTORS = {
     "beta chunk": [0.9, 0.4358898943540674, 0.0],
     "gamma chunk": [0.8, 0.6, 0.0],
     "foreign chunk": [0.0, 1.0, 0.0],
+    "tenant chunk": [0.7, 0.7141428428542851, 0.0],
 }
 
+# (file_id, user_id, chunk, tenant_id) — a None tenant models a chunk written
+# before tenants were recorded.
 CORPUS = [
-    ("file-a", "user-1", "alpha chunk"),
-    ("file-a", "user-1", "beta chunk"),
-    ("file-b", "agent-7", "gamma chunk"),
-    ("file-c", "user-2", "foreign chunk"),
+    ("file-a", "user-1", "alpha chunk", None),
+    ("file-a", "user-1", "beta chunk", None),
+    ("file-b", "agent-7", "gamma chunk", None),
+    ("file-c", "user-2", "foreign chunk", None),
+    ("file-d", "user-1", "tenant chunk", "tenant-a"),
 ]
+
+
+# The base tenant also matches chunks written before tenants were recorded.
+BASE_TENANTS = ["__BASE__", None]
 
 
 def digest(text_value: str) -> str:
@@ -62,19 +70,16 @@ class RecordingEmbedder:
 @pytest.fixture()
 def seeded(pg_store):
     pg_store.embedding_function.vectors = VECTORS
-    for file_id, user_id, chunk in CORPUS:
+    for file_id, user_id, chunk, tenant_id in CORPUS:
+        metadata = {
+            "file_id": file_id,
+            "user_id": user_id,
+            "digest": digest(chunk),
+        }
+        if tenant_id is not None:
+            metadata["tenant_id"] = tenant_id
         pg_store.add_documents(
-            [
-                Document(
-                    page_content=chunk,
-                    metadata={
-                        "file_id": file_id,
-                        "user_id": user_id,
-                        "digest": digest(chunk),
-                    },
-                )
-            ],
-            ids=[file_id],
+            [Document(page_content=chunk, metadata=metadata)], ids=[file_id]
         )
     return pg_store
 
@@ -108,7 +113,9 @@ def rerank(candidates, token=None):
 
 class TestStoredVectorLookup:
     async def test_digest_resolves_to_the_stored_vector(self, seeded):
-        vectors = await seeded.get_vectors_by_ids([digest("alpha chunk")], ["user-1"])
+        vectors = await seeded.get_vectors_by_ids(
+            [digest("alpha chunk")], ["user-1"], BASE_TENANTS
+        )
         assert list(vectors) == [digest("alpha chunk")]
         assert len(vectors[digest("alpha chunk")]) == 3
 
@@ -123,25 +130,38 @@ class TestStoredVectorLookup:
                 ),
                 {"digest": digest("alpha chunk")},
             ).scalar()
-        vectors = await seeded.get_vectors_by_ids([str(row_uuid)], ["user-1"])
+        vectors = await seeded.get_vectors_by_ids(
+            [str(row_uuid)], ["user-1"], BASE_TENANTS
+        )
         assert list(vectors) == [str(row_uuid)]
 
     async def test_foreign_owners_vector_is_never_returned(self, seeded):
         foreign = digest("foreign chunk")
-        assert await seeded.get_vectors_by_ids([foreign], ["user-1"]) == {}
-        assert list(await seeded.get_vectors_by_ids([foreign], ["user-2"])) == [foreign]
+        assert (
+            await seeded.get_vectors_by_ids([foreign], ["user-1"], BASE_TENANTS) == {}
+        )
+        assert list(
+            await seeded.get_vectors_by_ids([foreign], ["user-2"], BASE_TENANTS)
+        ) == [foreign]
 
     async def test_unknown_ids_resolve_to_nothing(self, seeded):
-        assert await seeded.get_vectors_by_ids(["not-a-real-id"], ["user-1"]) == {}
+        assert (
+            await seeded.get_vectors_by_ids(["not-a-real-id"], ["user-1"], BASE_TENANTS)
+            == {}
+        )
 
     async def test_empty_owner_scope_resolves_to_nothing(self, seeded):
-        assert await seeded.get_vectors_by_ids([digest("alpha chunk")], []) == {}
+        assert (
+            await seeded.get_vectors_by_ids([digest("alpha chunk")], [], BASE_TENANTS)
+            == {}
+        )
 
     async def test_a_non_uuid_candidate_id_does_not_break_the_query(self, seeded):
         """The uuid arm casts the column, never the caller's string."""
         result = await seeded.get_vectors_by_ids(
             ["'; DROP TABLE langchain_pg_embedding; --", digest("alpha chunk")],
             ["user-1"],
+            BASE_TENANTS,
         )
         assert list(result) == [digest("alpha chunk")]
 
@@ -165,14 +185,36 @@ class TestRerankOverStoredVectors:
         assert rerank(candidates).status_code == 200
         assert rerank_client.documents == ["gamma chunk"]
 
-    def test_a_foreign_candidate_id_never_reads_the_foreign_vector(self, rerank_client):
-        """The id resolves to a stored row, but not for this subject."""
+    def test_a_foreign_candidate_id_is_refused_before_any_egress(self, rerank_client):
+        """The id resolves to a stored row, but not for this subject.
+
+        Falling through to inference on the caller-supplied text would ship
+        content the caller cannot read out to the gateway, so the request is
+        refused instead of quietly proceeding.
+        """
         candidates = [
             {"id": digest("foreign chunk"), "text": "gamma chunk", "base_score": 1.0}
         ]
-        assert rerank(candidates).status_code == 200
-        # Falls through to inference on the caller-supplied text instead.
-        assert rerank_client.documents == ["gamma chunk"]
+        response = rerank(candidates)
+        assert response.status_code == 403
+        assert rerank_client.documents == []
+        assert rerank_client.queries == []
+
+    def test_a_cross_tenant_candidate_is_refused_before_any_egress(self, rerank_client):
+        candidates = [
+            {"id": digest("tenant chunk"), "text": "gamma chunk", "base_score": 1.0}
+        ]
+        response = rerank(candidates)
+        assert response.status_code == 403
+        assert rerank_client.documents == []
+
+    def test_the_owning_tenant_reaches_its_own_chunk(self, rerank_client):
+        token = strict_token(subject="user-1", tenant="tenant-a")
+        candidates = [
+            {"id": digest("tenant chunk"), "text": "gamma chunk", "base_score": 1.0}
+        ]
+        assert rerank(candidates, token=token).status_code == 200
+        assert rerank_client.documents == []
 
     def test_permitted_entity_vectors_are_reachable(self, rerank_client):
         token = strict_token(subject="user-1", entities=["agent-7"])
@@ -186,8 +228,9 @@ class TestRerankOverStoredVectors:
         candidates = [
             {"id": digest("gamma chunk"), "text": "gamma chunk", "base_score": 1.0}
         ]
-        assert rerank(candidates).status_code == 200
-        assert rerank_client.documents == ["gamma chunk"]
+        response = rerank(candidates)
+        assert response.status_code == 403
+        assert rerank_client.documents == []
 
     def test_blend_over_stored_vectors_is_not_pure_embedding_order(self, rerank_client):
         token = strict_token(subject="user-1", entities=["agent-7"])

--- a/tests/integration/test_rerank_pg.py
+++ b/tests/integration/test_rerank_pg.py
@@ -1,0 +1,211 @@
+"""fast-v1 embed-blend against real stored vectors in PostgreSQL.
+
+Proves the two properties that only a real database can show: the stored-vector
+lookup is owner-scoped in SQL, and a candidate whose vector is already stored
+costs no candidate inference.
+"""
+
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.documents import Document
+
+from app import auth
+from main import app
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
+
+pytestmark = pytest.mark.integration
+
+client = TestClient(app)
+
+QUERY = "how do I rotate the signing key"
+
+VECTORS = {
+    QUERY: [1.0, 0.0, 0.0],
+    "alpha chunk": [1.0, 0.0, 0.0],
+    "beta chunk": [0.9, 0.4358898943540674, 0.0],
+    "gamma chunk": [0.8, 0.6, 0.0],
+    "foreign chunk": [0.0, 1.0, 0.0],
+}
+
+CORPUS = [
+    ("file-a", "user-1", "alpha chunk"),
+    ("file-a", "user-1", "beta chunk"),
+    ("file-b", "agent-7", "gamma chunk"),
+    ("file-c", "user-2", "foreign chunk"),
+]
+
+
+def digest(text_value: str) -> str:
+    return hashlib.md5(text_value.encode("utf-8")).hexdigest()
+
+
+class RecordingEmbedder:
+    """Stands in for the inference call so candidate embeds are countable."""
+
+    def __init__(self):
+        self.queries: List[str] = []
+        self.documents: List[str] = []
+
+    def embed_query(self, text_value: str) -> List[float]:
+        self.queries.append(text_value)
+        return list(VECTORS.get(text_value, [0.1, 0.1, 0.1]))
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        self.documents.extend(texts)
+        return [list(VECTORS.get(text_value, [0.1, 0.1, 0.1])) for text_value in texts]
+
+
+@pytest.fixture()
+def seeded(pg_store):
+    pg_store.embedding_function.vectors = VECTORS
+    for file_id, user_id, chunk in CORPUS:
+        pg_store.add_documents(
+            [
+                Document(
+                    page_content=chunk,
+                    metadata={
+                        "file_id": file_id,
+                        "user_id": user_id,
+                        "digest": digest(chunk),
+                    },
+                )
+            ],
+            ids=[file_id],
+        )
+    return pg_store
+
+
+@pytest.fixture()
+def rerank_client(seeded, monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    auth.reset_settings()
+
+    embedder = RecordingEmbedder()
+    monkeypatch.setattr("app.routes.search_routes.vector_store", seeded)
+    monkeypatch.setattr(
+        "app.services.embedding.get_cached_query_embedding", embedder.embed_query
+    )
+    monkeypatch.setattr("app.services.embedding.embed_texts", embedder.embed_documents)
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+    return embedder
+
+
+def rerank(candidates, token=None):
+    return client.post(
+        "/v1/rerank",
+        json={"profile": "fast-v1", "query": QUERY, "candidates": candidates},
+        headers=bearer(token or strict_token(subject="user-1")),
+    )
+
+
+class TestStoredVectorLookup:
+    async def test_digest_resolves_to_the_stored_vector(self, seeded):
+        vectors = await seeded.get_vectors_by_ids([digest("alpha chunk")], ["user-1"])
+        assert list(vectors) == [digest("alpha chunk")]
+        assert len(vectors[digest("alpha chunk")]) == 3
+
+    async def test_row_uuid_resolves_to_the_stored_vector(self, seeded, engine):
+        from sqlalchemy import text
+
+        with engine.connect() as conn:
+            row_uuid = conn.execute(
+                text(
+                    "SELECT uuid FROM langchain_pg_embedding "
+                    "WHERE cmetadata->>'digest' = :digest"
+                ),
+                {"digest": digest("alpha chunk")},
+            ).scalar()
+        vectors = await seeded.get_vectors_by_ids([str(row_uuid)], ["user-1"])
+        assert list(vectors) == [str(row_uuid)]
+
+    async def test_foreign_owners_vector_is_never_returned(self, seeded):
+        foreign = digest("foreign chunk")
+        assert await seeded.get_vectors_by_ids([foreign], ["user-1"]) == {}
+        assert list(await seeded.get_vectors_by_ids([foreign], ["user-2"])) == [foreign]
+
+    async def test_unknown_ids_resolve_to_nothing(self, seeded):
+        assert await seeded.get_vectors_by_ids(["not-a-real-id"], ["user-1"]) == {}
+
+    async def test_empty_owner_scope_resolves_to_nothing(self, seeded):
+        assert await seeded.get_vectors_by_ids([digest("alpha chunk")], []) == {}
+
+    async def test_a_non_uuid_candidate_id_does_not_break_the_query(self, seeded):
+        """The uuid arm casts the column, never the caller's string."""
+        result = await seeded.get_vectors_by_ids(
+            ["'; DROP TABLE langchain_pg_embedding; --", digest("alpha chunk")],
+            ["user-1"],
+        )
+        assert list(result) == [digest("alpha chunk")]
+
+
+class TestRerankOverStoredVectors:
+    def test_stored_candidates_cost_no_candidate_inference(self, rerank_client):
+        candidates = [
+            {"id": digest("alpha chunk"), "text": "alpha chunk", "base_score": 1.0},
+            {"id": digest("beta chunk"), "text": "beta chunk", "base_score": 5.0},
+        ]
+        response = rerank(candidates)
+        assert response.status_code == 200
+        assert rerank_client.queries == [QUERY]
+        assert rerank_client.documents == []
+
+    def test_only_vectorless_candidates_are_embedded(self, rerank_client):
+        candidates = [
+            {"id": digest("alpha chunk"), "text": "alpha chunk", "base_score": 1.0},
+            {"id": "web-scrape-1", "text": "gamma chunk", "base_score": 5.0},
+        ]
+        assert rerank(candidates).status_code == 200
+        assert rerank_client.documents == ["gamma chunk"]
+
+    def test_a_foreign_candidate_id_never_reads_the_foreign_vector(self, rerank_client):
+        """The id resolves to a stored row, but not for this subject."""
+        candidates = [
+            {"id": digest("foreign chunk"), "text": "gamma chunk", "base_score": 1.0}
+        ]
+        assert rerank(candidates).status_code == 200
+        # Falls through to inference on the caller-supplied text instead.
+        assert rerank_client.documents == ["gamma chunk"]
+
+    def test_permitted_entity_vectors_are_reachable(self, rerank_client):
+        token = strict_token(subject="user-1", entities=["agent-7"])
+        candidates = [
+            {"id": digest("gamma chunk"), "text": "gamma chunk", "base_score": 1.0}
+        ]
+        assert rerank(candidates, token=token).status_code == 200
+        assert rerank_client.documents == []
+
+    def test_entity_vectors_are_unreachable_without_the_claim(self, rerank_client):
+        candidates = [
+            {"id": digest("gamma chunk"), "text": "gamma chunk", "base_score": 1.0}
+        ]
+        assert rerank(candidates).status_code == 200
+        assert rerank_client.documents == ["gamma chunk"]
+
+    def test_blend_over_stored_vectors_is_not_pure_embedding_order(self, rerank_client):
+        token = strict_token(subject="user-1", entities=["agent-7"])
+        candidates = [
+            {"id": digest("alpha chunk"), "text": "alpha chunk", "base_score": 1.0},
+            {"id": digest("beta chunk"), "text": "beta chunk", "base_score": 5.0},
+            {"id": digest("gamma chunk"), "text": "gamma chunk", "base_score": 10.0},
+        ]
+        response = rerank(candidates, token=token)
+        assert response.status_code == 200
+        assert rerank_client.documents == []
+        order = [result["index"] for result in response.json()["results"]]
+        # Cosine order is 0, 1, 2; the base scores lift gamma above beta.
+        assert order == [0, 2, 1]
+
+    def test_results_are_stable_across_repeated_calls(self, rerank_client):
+        candidates = [
+            {"id": digest("alpha chunk"), "text": "alpha chunk", "base_score": 1.0},
+            {"id": digest("beta chunk"), "text": "beta chunk", "base_score": 5.0},
+        ]
+        assert rerank(candidates).json() == rerank(candidates).json()

--- a/tests/services/test_async_pg_vector.py
+++ b/tests/services/test_async_pg_vector.py
@@ -25,8 +25,8 @@ async def test_get_all_ids_dispatches_to_super(store):
     with patch.object(
         ExtendedPgVector, "get_all_ids", return_value=["id1", "id2"]
     ) as mock:
-        result = await store.get_all_ids()
-    mock.assert_called_once_with()
+        result = await store.get_all_ids(["user-1"], ["__BASE__"])
+    mock.assert_called_once_with(["user-1"], ["__BASE__"])
     assert result == ["id1", "id2"]
 
 
@@ -35,8 +35,8 @@ async def test_get_filtered_ids_passes_ids(store):
     with patch.object(
         ExtendedPgVector, "get_filtered_ids", return_value=["id1"]
     ) as mock:
-        result = await store.get_filtered_ids(["id1", "id2"])
-    mock.assert_called_once_with(["id1", "id2"])
+        result = await store.get_filtered_ids(["id1", "id2"], ["user-1"], ["__BASE__"])
+    mock.assert_called_once_with(["id1", "id2"], ["user-1"], ["__BASE__"])
     assert result == ["id1"]
 
 
@@ -46,8 +46,8 @@ async def test_get_documents_by_ids_passes_ids(store):
     with patch.object(
         ExtendedPgVector, "get_documents_by_ids", return_value=docs
     ) as mock:
-        result = await store.get_documents_by_ids(["id1"])
-    mock.assert_called_once_with(["id1"])
+        result = await store.get_documents_by_ids(["id1"], ["user-1"], ["__BASE__"])
+    mock.assert_called_once_with(["id1"], ["user-1"], ["__BASE__"])
     assert result == docs
 
 
@@ -56,6 +56,13 @@ async def test_delete_passes_args(store):
     with patch.object(ExtendedPgVector, "_delete_multiple") as mock:
         await store.delete(ids=["id1"], collection_only=True)
     mock.assert_called_once_with(["id1"], True)
+
+
+@pytest.mark.asyncio
+async def test_delete_scoped_passes_scope(store):
+    with patch.object(ExtendedPgVector, "_delete_scoped") as mock:
+        await store.delete_scoped(["id1"], ["user-1"], ["__BASE__"])
+    mock.assert_called_once_with(["id1"], ["user-1"], ["__BASE__"])
 
 
 @pytest.mark.asyncio
@@ -95,9 +102,9 @@ async def test_aadd_documents_passes_args(store):
 async def test_run_in_executor_converts_stop_iteration(store):
     """StopIteration can't be set on an asyncio.Future — verify it becomes RuntimeError."""
 
-    def raises_stop():
+    def raises_stop(*args):
         raise StopIteration("exhausted")
 
     with patch.object(ExtendedPgVector, "get_all_ids", side_effect=raises_stop):
         with pytest.raises(RuntimeError):
-            await store.get_all_ids()
+            await store.get_all_ids(["user-1"], ["__BASE__"])

--- a/tests/services/test_atlas_mongo_vector.py
+++ b/tests/services/test_atlas_mongo_vector.py
@@ -1,10 +1,13 @@
-"""AtlasMongoVector: the file lookups the document routes read and delete by.
+"""AtlasMongoVector: the scoped file lookups and the indexes they depend on.
 
-These lookups address rows by a caller-supplied file id, so the owner and tenant
-predicate has to be part of the query. The collection below evaluates the
-predicate it is handed, so a method that stops emitting one fails here.
+The Atlas vector-search index accelerates ``$vectorSearch`` only. Every lookup
+here is an ordinary ``find``, so the standard indexes are part of the deployment
+contract rather than a tuning suggestion — and the contract lives in README.md,
+where it drifts silently. These tests pin both halves to the same source.
 """
 
+import re
+from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
@@ -178,3 +181,36 @@ class TestDeletesAreScoped:
     def test_an_empty_owner_set_deletes_nothing(self, store):
         store.delete_scoped(["file-owned"], [], BASE_TENANTS)
         assert store.get_documents_by_ids(["file-owned"], ["user-1"], BASE_TENANTS)
+
+
+class TestTheIndexesTheLookupsNeed:
+    """Every ordinary ``find`` this store makes has to have an index behind it."""
+
+    def documented_indexes(self):
+        readme = Path(__file__).resolve().parents[2] / "README.md"
+        keys = set()
+        for spec in re.findall(
+            r"createIndex\(\s*(\{.*?\})\s*\)", readme.read_text(encoding="utf-8")
+        ):
+            keys.add(tuple(re.findall(r"(\w+)\s*:\s*1", spec)))
+        return keys
+
+    def test_startup_creates_the_file_id_index(self, store):
+        store.ensure_indexes()
+        created = {tuple(key for key, _ in index["keys"]) for index in store.indexes()}
+        assert ("file_id",) in created
+
+    def test_startup_creates_the_digest_index_the_rerank_probe_needs(self, store):
+        """Candidate ids are normally digests, and each rerank resolves them twice."""
+        store.ensure_indexes()
+        created = {tuple(key for key, _ in index["keys"]) for index in store.indexes()}
+        assert ("digest", "user_id", "tenant_id") in created
+
+    def test_the_created_indexes_match_the_documented_ones(self, store):
+        store.ensure_indexes()
+        created = {tuple(key for key, _ in index["keys"]) for index in store.indexes()}
+        assert created == self.documented_indexes()
+
+    def test_every_index_is_named_so_it_is_recognisable(self, store):
+        store.ensure_indexes()
+        assert all(index["name"] for index in store.indexes())

--- a/tests/services/test_atlas_mongo_vector.py
+++ b/tests/services/test_atlas_mongo_vector.py
@@ -1,0 +1,180 @@
+"""AtlasMongoVector: the file lookups the document routes read and delete by.
+
+These lookups address rows by a caller-supplied file id, so the owner and tenant
+predicate has to be part of the query. The collection below evaluates the
+predicate it is handed, so a method that stops emitting one fails here.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from app.services.vector_store.atlas_mongo_vector import AtlasMongoVector
+
+BASE_TENANTS = ["__BASE__", None]
+
+ROWS = [
+    {
+        "_id": "file-owned_d1",
+        "file_id": "file-owned",
+        "user_id": "user-1",
+        "tenant_id": "__BASE__",
+        "digest": "d1",
+        "text": "owned chunk",
+        "source": "a.txt",
+    },
+    {
+        "_id": "file-foreign_d2",
+        "file_id": "file-foreign",
+        "user_id": "user-2",
+        "tenant_id": "__BASE__",
+        "digest": "d2",
+        "text": "foreign chunk",
+        "source": "b.txt",
+    },
+    {
+        "_id": "file-collided_d3",
+        "file_id": "file-collided",
+        "user_id": "user-2",
+        "tenant_id": "__BASE__",
+        "digest": "d3",
+        "text": "theirs",
+        "source": "c.txt",
+    },
+    {
+        "_id": "file-collided_d4",
+        "file_id": "file-collided",
+        "user_id": "user-1",
+        "tenant_id": "__BASE__",
+        "digest": "d4",
+        "text": "mine",
+        "source": "d.txt",
+    },
+]
+
+
+def _matches(row: Dict[str, Any], predicate: Dict[str, Any]) -> bool:
+    """Minimal evaluator for the MongoDB query dialect these methods emit."""
+    for key, clause in predicate.items():
+        if key == "$and":
+            if not all(_matches(row, sub) for sub in clause):
+                return False
+            continue
+        if key == "$or":
+            if not any(_matches(row, sub) for sub in clause):
+                return False
+            continue
+        operator, operand = next(iter(clause.items()))
+        if operator != "$in":
+            raise AssertionError(f"unexpected operator: {operator}")
+        if row.get(key) not in operand:
+            return False
+    return True
+
+
+class FakeCollection:
+    """In-memory stand-in that evaluates the predicate it is handed."""
+
+    def __init__(self, rows):
+        self.rows = [dict(row) for row in rows]
+        self.indexes: List[Any] = []
+
+    def create_index(self, keys, name=None, **kwargs):
+        self.indexes.append({"keys": list(keys), "name": name})
+        return name
+
+    def find(self, predicate, projection=None):
+        return [dict(row) for row in self.rows if _matches(row, predicate)]
+
+    def distinct(self, field, predicate=None):
+        return sorted(
+            {
+                row[field]
+                for row in self.rows
+                if predicate is None or _matches(row, predicate)
+            }
+        )
+
+    def delete_many(self, predicate):
+        self.rows = [row for row in self.rows if not _matches(row, predicate)]
+
+
+class Store(AtlasMongoVector):
+    """Bypasses MongoDBAtlasVectorSearch.__init__, which wants a live client."""
+
+    def __init__(self, collection):
+        self._collection = collection
+
+    def indexes(self):
+        return self._collection.indexes
+
+
+@pytest.fixture
+def store():
+    return Store(FakeCollection(ROWS))
+
+
+def contents(documents):
+    return sorted(document.page_content for document in documents)
+
+
+class TestFileLookupsAreScoped:
+    def test_a_foreign_file_resolves_to_nothing(self, store):
+        assert store.get_filtered_ids(["file-foreign"], ["user-1"], BASE_TENANTS) == []
+        assert (
+            store.get_documents_by_ids(["file-foreign"], ["user-1"], BASE_TENANTS) == []
+        )
+
+    def test_the_callers_own_file_resolves(self, store):
+        assert store.get_filtered_ids(["file-owned"], ["user-1"], BASE_TENANTS) == [
+            "file-owned"
+        ]
+        documents = store.get_documents_by_ids(["file-owned"], ["user-1"], BASE_TENANTS)
+        assert contents(documents) == ["owned chunk"]
+
+    def test_a_collided_file_id_yields_only_the_callers_chunks(self, store):
+        documents = store.get_documents_by_ids(
+            ["file-collided"], ["user-1"], BASE_TENANTS
+        )
+        assert contents(documents) == ["mine"]
+
+    def test_another_tenant_sees_nothing(self, store):
+        assert (
+            store.get_documents_by_ids(["file-owned"], ["user-1"], ["tenant-b"]) == []
+        )
+
+    def test_listing_is_scoped_to_the_caller(self, store):
+        assert store.get_all_ids(["user-1"], BASE_TENANTS) == [
+            "file-collided",
+            "file-owned",
+        ]
+
+    def test_an_empty_owner_set_authorizes_nothing(self, store):
+        assert store.get_all_ids([], BASE_TENANTS) == []
+        assert store.get_documents_by_ids(["file-owned"], [], BASE_TENANTS) == []
+
+
+class TestDeletesAreScoped:
+    def test_a_foreign_file_is_not_deleted(self, store):
+        store.delete_scoped(["file-foreign"], ["user-1"], BASE_TENANTS)
+        survivors = store.get_documents_by_ids(
+            ["file-foreign"], ["user-2"], BASE_TENANTS
+        )
+        assert contents(survivors) == ["foreign chunk"]
+
+    def test_a_collided_file_id_deletes_only_the_callers_rows(self, store):
+        store.delete_scoped(["file-collided"], ["user-1"], BASE_TENANTS)
+        survivors = store.get_documents_by_ids(
+            ["file-collided"], ["user-2"], BASE_TENANTS
+        )
+        assert contents(survivors) == ["theirs"]
+
+    def test_the_callers_own_file_is_deleted(self, store):
+        store.delete_scoped(["file-owned"], ["user-1"], BASE_TENANTS)
+        assert (
+            store.get_documents_by_ids(["file-owned"], ["user-1"], BASE_TENANTS) == []
+        )
+
+    def test_an_empty_owner_set_deletes_nothing(self, store):
+        store.delete_scoped(["file-owned"], [], BASE_TENANTS)
+        assert store.get_documents_by_ids(["file-owned"], ["user-1"], BASE_TENANTS)

--- a/tests/services/test_rerank_blend.py
+++ b/tests/services/test_rerank_blend.py
@@ -1,0 +1,89 @@
+"""Unit tests for the fast-v1 embed-blend scoring primitives."""
+
+import math
+
+from app.services.rerank import (
+    BlendConfig,
+    blend_scores,
+    cosine_similarity,
+    order_by_score,
+    rank_positions,
+)
+
+CONFIG = BlendConfig(k=60, similarity_weight=1.0, base_weight=1.0)
+
+
+class TestCosineSimilarity:
+    def test_identical_direction_is_one(self):
+        assert math.isclose(cosine_similarity([1.0, 0.0], [3.0, 0.0]), 1.0)
+
+    def test_orthogonal_is_zero(self):
+        assert math.isclose(cosine_similarity([1.0, 0.0], [0.0, 5.0]), 0.0)
+
+    def test_opposite_direction_is_negative_one(self):
+        assert math.isclose(cosine_similarity([1.0, 0.0], [-2.0, 0.0]), -1.0)
+
+    def test_zero_vector_has_no_similarity(self):
+        assert cosine_similarity([0.0, 0.0], [1.0, 0.0]) is None
+
+    def test_mismatched_width_has_no_similarity(self):
+        assert cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0]) is None
+
+
+class TestRankPositions:
+    def test_highest_value_ranks_first(self):
+        assert rank_positions([0.1, 0.9, 0.5]) == [3, 1, 2]
+
+    def test_ties_break_on_request_position(self):
+        assert rank_positions([0.5, 0.5, 0.5]) == [1, 2, 3]
+
+    def test_unscored_entries_rank_last_in_order(self):
+        assert rank_positions([None, 0.2, None, 0.9]) == [3, 2, 4, 1]
+
+
+class TestBlendScores:
+    def test_blend_is_not_pure_embedding_order(self):
+        """The whole point of the blend: base_score can overturn cosine order."""
+        similarities = [1.0, 0.9, 0.8]
+        base_scores = [1.0, 5.0, 10.0]
+        scores = blend_scores(similarities, base_scores, CONFIG)
+        pure = order_by_score(blend_scores(similarities, [None, None, None], CONFIG), 3)
+        blended = order_by_score(scores, 3)
+        assert [item.index for item in pure] == [0, 1, 2]
+        assert [item.index for item in blended] == [0, 2, 1]
+
+    def test_a_missing_arm_is_dropped_rather_than_treated_as_a_constant(self):
+        base_only = blend_scores([None, None, None], [1.0, 3.0, 2.0], CONFIG)
+        assert [item.index for item in order_by_score(base_only, 3)] == [1, 2, 0]
+
+    def test_candidates_without_vectors_still_rank_through_the_base_arm(self):
+        """A vectorless candidate is not buried: a strong base score lifts it."""
+        scores = blend_scores([0.9, None, 0.8], [3.0, 100.0, 1.0], CONFIG)
+        assert scores[1] > 0.0
+        assert [item.index for item in order_by_score(scores, 3)] == [0, 1, 2]
+
+    def test_exact_ties_break_on_request_position(self):
+        similarities = [1.0, 0.9, 0.8]
+        base_scores = [1.0, 5.0, 10.0]
+        scores = blend_scores(similarities, base_scores, CONFIG)
+        assert scores[0] == scores[2]
+        assert [item.index for item in order_by_score(scores, 3)] == [0, 2, 1]
+
+    def test_identical_inputs_produce_identical_output(self):
+        similarities = [0.4, 0.4, 0.4, 0.4]
+        base_scores = [1.0, 1.0, 1.0, 1.0]
+        first = order_by_score(blend_scores(similarities, base_scores, CONFIG), 4)
+        second = order_by_score(blend_scores(similarities, base_scores, CONFIG), 4)
+        assert [item.index for item in first] == [item.index for item in second]
+        assert [item.index for item in first] == [0, 1, 2, 3]
+
+
+class TestOrderByScore:
+    def test_truncates_to_top_n(self):
+        ranked = order_by_score([0.1, 0.5, 0.3, 0.9], 2)
+        assert [item.index for item in ranked] == [3, 1]
+
+    def test_weights_are_configurable(self):
+        similarity_heavy = BlendConfig(k=60, similarity_weight=10.0, base_weight=1.0)
+        scores = blend_scores([1.0, 0.9, 0.8], [1.0, 5.0, 10.0], similarity_heavy)
+        assert [item.index for item in order_by_score(scores, 3)] == [0, 1, 2]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -118,6 +118,13 @@ def test_missing_scope_is_forbidden(search_enabled):
     assert "rag:embed" in response.json()["detail"]
 
 
+def test_the_document_scope_does_not_buy_embedding(search_enabled):
+    """``rag:documents`` addresses stored chunks; it never spends inference."""
+    response = post_embed(strict_token(scopes=["rag:documents"]))
+    assert response.status_code == 403
+    assert "rag:embed" in response.json()["detail"]
+
+
 def test_rerank_requires_its_own_scope(search_enabled):
     body = {
         "profile": "fast-v1",
@@ -128,6 +135,11 @@ def test_rerank_requires_its_own_scope(search_enabled):
         "/v1/rerank", json=body, headers=bearer(strict_token(scopes=["rag:embed"]))
     )
     assert response.status_code == 403
+    documents_only = client.post(
+        "/v1/rerank", json=body, headers=bearer(strict_token(scopes=["rag:documents"]))
+    )
+    assert documents_only.status_code == 403
+    assert "rag:rerank" in documents_only.json()["detail"]
 
 
 def test_wrong_audience_is_rejected(search_enabled):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -199,6 +199,114 @@ def test_missing_authorization_header_is_rejected(search_enabled):
     assert client.post("/v1/embeddings", json=EMBED_BODY).status_code == 401
 
 
+def unsigned_claims(**claims) -> str:
+    """A RAG-key-signed token with exactly the claims given, and nothing else."""
+    import jwt as pyjwt
+
+    return pyjwt.encode(claims, RAG_SECRET, algorithm="HS256")
+
+
+class TestMalformedStrictTokensGainNothing:
+    """A strict token must not widen its own authority by failing validation.
+
+    With RAG_AUTH_ACCEPT_LEGACY=true a RAG-signed token that misses ``exp``, the
+    tenant or the scopes drops out of strict validation into the legacy
+    fallback. Legacy principals are grandfathered into every scope and into
+    arbitrary entity access, so a token that restricted itself to ``rag:embed``
+    and one entity would come back holding everything — privilege escalation by
+    malformation. The grandfather now applies only to the pre-scopes
+    ``{"id": userId}`` shape.
+    """
+
+    def _principal(self, token: str):
+        return auth.verify_token(token, auth.get_settings(), allow_legacy_secret=False)
+
+    def _rerank(self, token: str):
+        body = {
+            "profile": "fast-v1",
+            "query": "q",
+            "candidates": [{"id": "c1", "text": "t", "base_score": 1.0}],
+        }
+        return client.post("/v1/rerank", json=body, headers=bearer(token))
+
+    def _query(self, token: str, entity_id: str):
+        return client.post(
+            "/query",
+            json={**QUERY_BODY, "entity_id": entity_id},
+            headers=bearer(token),
+        )
+
+    def test_a_token_without_expiry_keeps_only_its_own_scopes(self, search_enabled):
+        token = unsigned_claims(
+            sub="user-1",
+            iss=ISSUER,
+            aud=AUDIENCE,
+            tenant="__BASE__",
+            scopes=["rag:embed"],
+        )
+        principal = self._principal(token)
+        assert principal.legacy is False
+        assert principal.has_scope("rag:embed")
+        assert not principal.has_scope("rag:rerank")
+        assert post_embed(token).status_code == 200
+        assert self._rerank(token).status_code == 403
+
+    def test_a_token_without_a_tenant_keeps_only_its_own_scopes(self, search_enabled):
+        token = strict_token(tenant=None, scopes=["rag:embed"])
+        assert self._principal(token).legacy is False
+        assert post_embed(token).status_code == 200
+        assert self._rerank(token).status_code == 403
+
+    def test_a_token_without_an_audience_keeps_only_its_own_scopes(
+        self, search_enabled
+    ):
+        token = strict_token(audience=None, scopes=["rag:embed"])
+        assert post_embed(token).status_code == 200
+        assert self._rerank(token).status_code == 403
+
+    def test_an_empty_scope_list_grants_nothing(self, search_enabled):
+        """Stating no scopes is a restriction, not an omission."""
+        token = strict_token(tenant=None, scopes=[])
+        assert post_embed(token).status_code == 403
+        assert self._rerank(token).status_code == 403
+
+    def test_entity_restrictions_survive_the_fallback(self, search_enabled, store_stub):
+        token = strict_token(
+            subject="user-1", tenant=None, scopes=["rag:embed"], entities=["agent-7"]
+        )
+        principal = self._principal(token)
+        assert principal.permits_entity("agent-7")
+        assert not principal.permits_entity("user-2")
+        assert self._query(token, "agent-7").status_code == 200
+        assert self._query(token, "user-2").status_code == 403
+
+    def test_a_declared_empty_entity_list_permits_no_other_entity(
+        self, search_enabled, store_stub
+    ):
+        token = unsigned_claims(
+            sub="user-1", iss=ISSUER, aud=AUDIENCE, scopes=["rag:embed"], entities=[]
+        )
+        assert self._query(token, "user-2").status_code == 403
+
+    def test_a_sub_shaped_token_is_not_grandfathered(self, search_enabled, store_stub):
+        """Only the ``{"id": ...}`` shape predates scopes, so only it is trusted."""
+        token = strict_token(tenant=None, scopes=None)
+        assert self._principal(token).legacy is False
+        assert post_embed(token).status_code == 403
+        assert self._query(token, "user-2").status_code == 403
+
+    def test_the_genuine_legacy_shape_is_still_grandfathered(
+        self, search_enabled, store_stub
+    ):
+        token = legacy_token(user_id="user-1", secret=RAG_SECRET)
+        principal = self._principal(token)
+        assert principal.legacy is True
+        assert principal.has_scope("rag:rerank")
+        assert principal.permits_entity("agent-7")
+        assert post_embed(token).status_code == 200
+        assert self._query(token, "agent-7").status_code == 200
+
+
 def test_service_endpoints_are_unavailable_when_the_search_api_is_off(monkeypatch):
     monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "false")
     monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
@@ -311,3 +419,52 @@ class TestStartupValidation:
         )
         with pytest.raises(RuntimeError, match="requires RAG_JWT_PUBLIC_KEY"):
             settings.validate()
+
+    def test_short_hmac_secret_is_refused_with_search_disabled(self, monkeypatch):
+        """The key still signs tokens the middleware accepts on /query.
+
+        RAG_SEARCH_API_ENABLED only decides whether the /v1 router is mounted.
+        A RAG-signed strict token is honoured on the document routes either way,
+        so a weak key is a weak key whether or not search is on.
+        """
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_JWT_SECRET="too-short",
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="at least 32 characters"):
+            settings.validate()
+
+    def test_empty_issuer_is_refused_with_search_disabled(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_JWT_SECRET=RAG_SECRET,
+            RAG_JWT_ISSUER="",
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="RAG_JWT_ISSUER"):
+            settings.validate()
+
+    def test_empty_audience_is_refused_with_search_disabled(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_JWT_SECRET=RAG_SECRET,
+            RAG_JWT_AUDIENCE="",
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="RAG_JWT_AUDIENCE"):
+            settings.validate()
+
+    def test_no_rag_key_and_no_search_still_passes(self, monkeypatch):
+        """The legacy-only deployment has no RAG key to validate."""
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_JWT_SECRET=None,
+            RAG_JWT_ISSUER="",
+            JWT_SECRET=APP_SECRET,
+        )
+        settings.validate()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,313 @@
+"""Fail-closed auth for the service endpoints.
+
+The load-bearing property is key separation: LibreChat's application
+``JWT_SECRET`` signs session tokens, and a session token must never be usable
+against ``/v1/*``. ``RAG_AUTH_ACCEPT_LEGACY`` relaxes the *claim shape* during
+the transition; it never relaxes which key is trusted on those endpoints.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import auth
+from app.services import space as space_module
+from main import app
+from tests.fakes import FakeEmbeddingClient, install_fake_space
+from tests.tokens import (
+    APP_SECRET,
+    AUDIENCE,
+    ISSUER,
+    RAG_SECRET,
+    SYSTEM_TENANT,
+    bearer,
+    legacy_token,
+    strict_token,
+)
+
+client = TestClient(app)
+
+EMBED_BODY = {
+    "space": space_module.CHAT_SPACE_SPEC.name,
+    "input_type": "query",
+    "inputs": [{"id": "a", "text": "hello world"}],
+}
+
+QUERY_BODY = {"query": "hello", "file_id": "file-1", "k": 4}
+
+
+@pytest.fixture
+def search_enabled(monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_JWT_ISSUER", ISSUER)
+    monkeypatch.setenv("RAG_JWT_AUDIENCE", AUDIENCE)
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "true")
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    auth.reset_settings()
+    install_fake_space(monkeypatch, FakeEmbeddingClient())
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+
+
+@pytest.fixture
+def store_stub(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.embedding.get_cached_query_embedding",
+        lambda query: [0.1, 0.2, 0.3],
+    )
+    monkeypatch.setattr(
+        "app.routes.document_routes.get_cached_query_embedding",
+        lambda query: [0.1, 0.2, 0.3],
+    )
+
+    async def asearch(self, embedding, k, filter=None, executor=None):
+        return []
+
+    from app.services.vector_store.async_pg_vector import AsyncPgVector
+
+    monkeypatch.setattr(
+        AsyncPgVector, "asimilarity_search_with_score_by_vector", asearch
+    )
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+
+
+def post_embed(token: str):
+    return client.post("/v1/embeddings", json=EMBED_BODY, headers=bearer(token))
+
+
+def test_strict_token_is_accepted(search_enabled):
+    assert post_embed(strict_token()).status_code == 200
+
+
+def test_librechat_session_token_is_rejected_by_the_service_endpoints(search_enabled):
+    """The gate: a captured session token must not reach /v1/embeddings."""
+    response = post_embed(legacy_token(user_id="user-1", secret=APP_SECRET))
+    assert response.status_code == 401
+
+
+def test_session_token_is_rejected_even_with_full_claims(search_enabled):
+    """Claim shape is not the control — the signing key is."""
+    token = strict_token(secret=APP_SECRET)
+    assert post_embed(token).status_code == 401
+
+
+def test_legacy_shape_signed_with_the_rag_key_is_accepted_during_transition(
+    search_enabled,
+):
+    token = legacy_token(user_id="user-1", secret=RAG_SECRET)
+    assert post_embed(token).status_code == 200
+
+
+def test_legacy_shape_is_rejected_once_the_transition_flag_flips(
+    search_enabled, monkeypatch
+):
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    token = legacy_token(user_id="user-1", secret=RAG_SECRET)
+    assert post_embed(token).status_code == 401
+    assert post_embed(strict_token()).status_code == 200
+
+
+def test_missing_scope_is_forbidden(search_enabled):
+    response = post_embed(strict_token(scopes=["rag:rerank"]))
+    assert response.status_code == 403
+    assert "rag:embed" in response.json()["detail"]
+
+
+def test_rerank_requires_its_own_scope(search_enabled):
+    body = {
+        "profile": "fast-v1",
+        "query": "q",
+        "candidates": [{"id": "c1", "text": "t", "base_score": 1.0}],
+    }
+    response = client.post(
+        "/v1/rerank", json=body, headers=bearer(strict_token(scopes=["rag:embed"]))
+    )
+    assert response.status_code == 403
+
+
+def test_wrong_audience_is_rejected(search_enabled):
+    assert post_embed(strict_token(audience="librechat")).status_code == 401
+
+
+def test_wrong_issuer_is_rejected(search_enabled):
+    assert post_embed(strict_token(issuer="somebody-else")).status_code == 401
+
+
+def test_missing_audience_falls_back_to_legacy_only_while_permitted(
+    search_enabled, monkeypatch
+):
+    token = strict_token(audience=None)
+    assert post_embed(token).status_code == 200
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    assert post_embed(strict_token(audience=None)).status_code == 401
+
+
+def test_missing_tenant_claim_is_rejected_under_strict_acceptance(
+    search_enabled, monkeypatch
+):
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    assert post_embed(strict_token(tenant=None)).status_code == 401
+
+
+def test_missing_scopes_claim_is_rejected_under_strict_acceptance(
+    search_enabled, monkeypatch
+):
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    assert post_embed(strict_token(scopes=None)).status_code == 401
+
+
+def test_system_tenant_is_forbidden(search_enabled):
+    response = post_embed(strict_token(tenant=SYSTEM_TENANT))
+    assert response.status_code == 403
+    assert "System tenant" in response.json()["detail"]
+
+
+def test_expired_token_is_rejected(search_enabled):
+    assert post_embed(strict_token(expires_in=-60)).status_code == 401
+
+
+def test_token_without_expiry_is_rejected_under_strict_acceptance(
+    search_enabled, monkeypatch
+):
+    import jwt as pyjwt
+
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    token = pyjwt.encode(
+        {
+            "sub": "user-1",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "tenant": "__BASE__",
+            "scopes": ["rag:embed"],
+        },
+        RAG_SECRET,
+        algorithm="HS256",
+    )
+    assert post_embed(token).status_code == 401
+
+
+def test_missing_authorization_header_is_rejected(search_enabled):
+    assert client.post("/v1/embeddings", json=EMBED_BODY).status_code == 401
+
+
+def test_service_endpoints_are_unavailable_when_the_search_api_is_off(monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "false")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    auth.reset_settings()
+    assert post_embed(strict_token()).status_code == 503
+
+
+def test_legacy_routes_still_accept_the_application_secret(search_enabled, store_stub):
+    response = client.post(
+        "/query", json=QUERY_BODY, headers=bearer(legacy_token(secret=APP_SECRET))
+    )
+    assert response.status_code == 200
+
+
+def test_legacy_routes_reject_the_application_secret_once_the_flag_flips(
+    search_enabled, store_stub, monkeypatch
+):
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    response = client.post(
+        "/query", json=QUERY_BODY, headers=bearer(legacy_token(secret=APP_SECRET))
+    )
+    assert response.status_code == 401
+    assert (
+        client.post(
+            "/query", json=QUERY_BODY, headers=bearer(strict_token())
+        ).status_code
+        == 200
+    )
+
+
+class TestStartupValidation:
+    def _settings(self, monkeypatch, **env):
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+        auth.reset_settings()
+        return auth.get_settings()
+
+    def test_valid_configuration_passes(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=RAG_SECRET,
+            JWT_SECRET=APP_SECRET,
+        )
+        settings.validate()
+
+    def test_shared_signing_key_is_refused(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=APP_SECRET,
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="must differ from JWT_SECRET"):
+            settings.validate()
+
+    def test_enabled_without_a_signing_key_is_refused(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=None,
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="requires RAG_JWT_SECRET"):
+            settings.validate()
+
+    def test_short_hmac_secret_is_refused(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET="too-short",
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="at least 32 characters"):
+            settings.validate()
+
+    def test_unsupported_algorithm_is_refused(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=RAG_SECRET,
+            RAG_JWT_ALGORITHM="none",
+        )
+        with pytest.raises(RuntimeError, match="not supported"):
+            settings.validate()
+
+    def test_strict_acceptance_without_a_key_is_refused(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_AUTH_ACCEPT_LEGACY="false",
+            RAG_JWT_SECRET=None,
+            JWT_SECRET=APP_SECRET,
+        )
+        with pytest.raises(RuntimeError, match="requires a verification key"):
+            settings.validate()
+
+    def test_asymmetric_configuration_requires_a_public_key(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_ALGORITHM="RS256",
+            RAG_JWT_SECRET=RAG_SECRET,
+            RAG_JWT_PUBLIC_KEY=None,
+        )
+        with pytest.raises(RuntimeError, match="requires RAG_JWT_PUBLIC_KEY"):
+            settings.validate()

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -156,7 +156,14 @@ class TestBatchProcessing:
     def mock_documents(self):
         """Create mock documents for testing."""
         return [
-            Document(page_content=f"content_{i}", metadata={"file_id": "test_file"})
+            Document(
+                page_content=f"content_{i}",
+                metadata={
+                    "file_id": "test_file",
+                    "user_id": "user-1",
+                    "tenant_id": "__BASE__",
+                },
+            )
             for i in range(10)
         ]
 
@@ -175,6 +182,7 @@ class TestBatchProcessing:
         store = Mock()
         store.add_documents = Mock(return_value=["id1", "id2"])
         store.delete = Mock()
+        store.delete_scoped = Mock()
         return store
 
     # --- Async Pipeline Tests ---
@@ -393,7 +401,13 @@ class TestBatchProcessing:
                         executor=executor,
                     )
 
-        mock_sync_vector_store.delete.assert_called_once()
+        # The rollback deletes by the caller-supplied file id, so it carries the
+        # writer's owner and tenant: another owner's chunks under the same id
+        # are not this request's to remove.
+        mock_sync_vector_store.delete_scoped.assert_called_once_with(
+            ["test_file"], ["user-1"], ["__BASE__"]
+        )
+        assert not mock_sync_vector_store.delete.called
 
     @pytest.mark.asyncio
     async def test_sync_batched_no_rollback_on_first_error(
@@ -417,6 +431,7 @@ class TestBatchProcessing:
 
         # Should not attempt rollback since nothing was inserted
         assert not mock_sync_vector_store.delete.called
+        assert not mock_sync_vector_store.delete_scoped.called
 
 
 class TestBatchConfiguration:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,168 @@
+"""No hardcoded credentials anywhere in the tracked configuration surface.
+
+A working fallback default is the defect, not the convenience: a sample
+user/password pair in a compose file is how a database ends up reachable with
+credentials that are public in the repository.
+"""
+
+import importlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app import auth
+from app.config import require_env_variable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Values that used to ship as working defaults.
+BANNED_LITERALS = ("mypassword", "myuser", "mydatabase")
+
+CONFIG_FILES = (
+    "app/config.py",
+    "docker-compose.yaml",
+    "db-compose.yaml",
+    "api-compose.yaml",
+    "README.md",
+    ".env.example",
+)
+
+
+def _tracked_files() -> list:
+    result = subprocess.run(
+        ["git", "ls-files"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+class TestNoHardcodedCredentials:
+    @pytest.mark.parametrize("relative_path", CONFIG_FILES)
+    def test_config_file_carries_no_default_credential(self, relative_path):
+        content = (REPO_ROOT / relative_path).read_text()
+        for literal in BANNED_LITERALS:
+            assert literal not in content, f"{relative_path} still ships '{literal}'"
+
+    def test_no_tracked_file_ships_a_default_credential(self):
+        offenders = []
+        for relative_path in _tracked_files():
+            # This file names the banned literals in order to search for them.
+            if relative_path == "tests/test_credentials.py":
+                continue
+            path = REPO_ROOT / relative_path
+            if not path.is_file() or path.suffix in (".png", ".jpg", ".ico"):
+                continue
+            try:
+                content = path.read_text()
+            except UnicodeDecodeError:
+                continue
+            if any(literal in content for literal in BANNED_LITERALS):
+                offenders.append(relative_path)
+        assert offenders == []
+
+    def test_compose_files_require_their_credentials(self):
+        for relative_path in ("docker-compose.yaml", "db-compose.yaml"):
+            content = (REPO_ROOT / relative_path).read_text()
+            for variable in ("POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD"):
+                assert (
+                    f"${{{variable}:?" in content
+                ), f"{relative_path} does not require {variable}"
+
+    def test_env_example_is_tracked_and_only_holds_placeholders(self):
+        assert ".env.example" in _tracked_files()
+        assert ".env" not in _tracked_files()
+        for line in (REPO_ROOT / ".env.example").read_text().splitlines():
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            _, _, value = line.partition("=")
+            assert value.startswith("REPLACE_ME_") or value in ("db", "5432"), line
+
+
+class TestRequiredEnvVariable:
+    def test_a_missing_variable_is_refused(self, monkeypatch):
+        monkeypatch.delenv("SOME_CREDENTIAL", raising=False)
+        with pytest.raises(ValueError, match="required and has no default"):
+            require_env_variable("SOME_CREDENTIAL")
+
+    def test_an_empty_variable_is_refused(self, monkeypatch):
+        monkeypatch.setenv("SOME_CREDENTIAL", "")
+        with pytest.raises(ValueError, match="required and has no default"):
+            require_env_variable("SOME_CREDENTIAL")
+
+    def test_an_empty_variable_is_allowed_only_when_asked_for(self, monkeypatch):
+        monkeypatch.setenv("SOME_CREDENTIAL", "")
+        assert require_env_variable("SOME_CREDENTIAL", allow_empty=True) == ""
+
+    def test_a_present_variable_is_returned(self, monkeypatch):
+        monkeypatch.setenv("SOME_CREDENTIAL", "value")
+        assert require_env_variable("SOME_CREDENTIAL") == "value"
+
+    def test_the_postgres_credentials_have_no_fallback(self, monkeypatch):
+        """Re-importing app.config without credentials must fail, not default."""
+        monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+        import app.config
+
+        with pytest.raises(ValueError, match="POSTGRES_PASSWORD"):
+            importlib.reload(app.config)
+        # Restore the module for the rest of the session.
+        monkeypatch.setenv("POSTGRES_PASSWORD", "rag_api_test_password")
+        importlib.reload(app.config)
+
+
+class TestSigningConfigHasNoFallback:
+    def _settings(self, monkeypatch, **env):
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+        auth.reset_settings()
+        return auth.get_settings()
+
+    def test_startup_fails_without_a_signing_key(self, monkeypatch):
+        self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=None,
+            RAG_JWT_PUBLIC_KEY=None,
+        )
+        with pytest.raises(RuntimeError, match="requires RAG_JWT_SECRET"):
+            auth.validate_startup_config()
+
+    def test_there_is_no_generated_or_default_signing_key(self, monkeypatch):
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="false",
+            RAG_JWT_SECRET=None,
+            RAG_JWT_PUBLIC_KEY=None,
+        )
+        assert settings.rag_secret is None
+        assert settings.verification_key is None
+
+    def test_secrets_never_appear_in_the_startup_log(self, monkeypatch, caplog):
+        import logging
+
+        secret = "a-very-secret-signing-key-0123456789"
+        self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=secret,
+            JWT_SECRET="a-different-application-secret-0123456789",
+        )
+        with caplog.at_level(logging.DEBUG):
+            auth.validate_startup_config()
+        assert secret not in caplog.text
+
+    def test_a_rejected_token_never_echoes_a_secret(self, monkeypatch):
+        secret = "a-very-secret-signing-key-0123456789"
+        settings = self._settings(
+            monkeypatch,
+            RAG_SEARCH_API_ENABLED="true",
+            RAG_JWT_SECRET=secret,
+            JWT_SECRET="a-different-application-secret-0123456789",
+            RAG_AUTH_ACCEPT_LEGACY="false",
+        )
+        with pytest.raises(auth.AuthError) as excinfo:
+            auth.verify_token("not-a-token", settings, allow_legacy_secret=False)
+        assert secret not in str(excinfo.value)

--- a/tests/test_document_authorization.py
+++ b/tests/test_document_authorization.py
@@ -4,8 +4,13 @@
 ``DELETE /documents`` addressed the store by caller-supplied file id alone. A
 file id is not an authorization: anyone who learns one — or simply lists them
 from ``/ids`` — could read another owner's document text or delete their chunks.
-The strict tokens this release introduces made that reachable from a service
-credential holding nothing but ``rag:embed``.
+The strict tokens this release introduces made that reachable from any service
+credential at all.
+
+Those routes now carry their own scope, ``rag:documents``, so a token minted to
+delete a file also has to be minted for the document plane — the inference
+scopes buy nothing here, and this scope buys no inference. The two planes are
+tested against each other in :class:`TestThePlanesAreSeparable`.
 
 The store below evaluates the owner and tenant predicate the route actually
 passes, and answers unscoped when it is passed none. A route that stops putting
@@ -21,8 +26,10 @@ from fastapi.testclient import TestClient
 from langchain_core.documents import Document
 
 from app import auth
+from app.services import space as space_module
 from app.services.vector_store.async_pg_vector import AsyncPgVector
 from main import app
+from tests.fakes import FakeEmbeddingClient, install_fake_space
 from tests.tokens import APP_SECRET, RAG_SECRET, bearer, legacy_token, strict_token
 
 client = TestClient(app)
@@ -105,9 +112,9 @@ def strict_auth(monkeypatch):
     auth.reset_settings()
 
 
-def embed_only_token(subject: str = "attacker", **kwargs) -> str:
-    """The credential the finding is about: a strict token holding only rag:embed."""
-    return strict_token(subject=subject, scopes=("rag:embed",), **kwargs)
+def documents_token(subject: str = "attacker", **kwargs) -> str:
+    """The credential these routes now require: strict, ``rag:documents`` alone."""
+    return strict_token(subject=subject, scopes=("rag:documents",), **kwargs)
 
 
 def file_ids(rows: List[Dict[str, str]]) -> List[str]:
@@ -135,32 +142,36 @@ def delete_documents(ids, token, entity_id=None):
     return client.request("DELETE", url, json=ids, headers=bearer(token))
 
 
-class TestAnEmbedOnlyTokenCannotReadByFileId:
-    """The credential in the finding: strict, RAG-signed, ``rag:embed`` alone."""
+class TestADocumentTokenCannotReadByFileIdAlone:
+    """The credential in the finding: strict, RAG-signed, scoped to documents.
+
+    Holding the document scope is permission to address this plane, never
+    permission to address another owner's rows inside it.
+    """
 
     def test_get_documents_refuses_a_foreign_file(self, rows, strict_auth):
-        response = get_documents(["file-foreign"], embed_only_token())
+        response = get_documents(["file-foreign"], documents_token())
         assert response.status_code == 404
         assert "file-foreign content" not in response.text
 
     def test_get_context_refuses_a_foreign_file(self, rows, strict_auth):
-        response = get_context("file-foreign", embed_only_token())
+        response = get_context("file-foreign", documents_token())
         assert response.status_code == 404
         assert "file-foreign content" not in response.text
 
     def test_delete_refuses_a_foreign_file(self, rows, strict_auth):
-        response = delete_documents(["file-foreign"], embed_only_token())
+        response = delete_documents(["file-foreign"], documents_token())
         assert response.status_code == 404
         assert "file-foreign" in file_ids(rows)
 
     def test_ids_does_not_enumerate_the_deployment(self, rows, strict_auth):
-        response = client.get("/ids", headers=bearer(embed_only_token()))
+        response = client.get("/ids", headers=bearer(documents_token()))
         assert response.status_code == 200
         assert response.json() == []
 
     def test_a_mixed_request_leaks_nothing(self, rows, strict_auth):
         """One readable id alongside a foreign one must not carry it along."""
-        token = embed_only_token(subject="user-1")
+        token = documents_token(subject="user-1")
         response = get_documents(["file-owned", "file-foreign"], token)
         assert response.status_code == 404
         assert "file-foreign content" not in response.text
@@ -185,24 +196,22 @@ class TestLegacyTokensAreScopedToo:
 
 class TestTheOwnersOwnFilesStillWork:
     def test_get_documents_returns_the_callers_file(self, rows, strict_auth):
-        response = get_documents(["file-owned"], embed_only_token(subject="user-1"))
+        response = get_documents(["file-owned"], documents_token(subject="user-1"))
         assert response.status_code == 200
         assert response.json()[0]["page_content"] == "file-owned content"
 
     def test_get_context_returns_the_callers_file(self, rows, strict_auth):
-        response = get_context("file-owned", embed_only_token(subject="user-1"))
+        response = get_context("file-owned", documents_token(subject="user-1"))
         assert response.status_code == 200
         assert "file-owned content" in response.text
 
     def test_delete_removes_the_callers_file(self, rows, strict_auth):
-        response = delete_documents(["file-owned"], embed_only_token(subject="user-1"))
+        response = delete_documents(["file-owned"], documents_token(subject="user-1"))
         assert response.status_code == 200
         assert "file-owned" not in file_ids(rows)
 
     def test_ids_lists_the_callers_files(self, rows, strict_auth):
-        response = client.get(
-            "/ids", headers=bearer(embed_only_token(subject="user-1"))
-        )
+        response = client.get("/ids", headers=bearer(documents_token(subject="user-1")))
         assert sorted(response.json()) == [
             "file-collided",
             "file-owned",
@@ -212,7 +221,7 @@ class TestTheOwnersOwnFilesStillWork:
     def test_chunks_written_before_tenants_were_recorded_stay_readable(
         self, rows, strict_auth
     ):
-        response = get_documents(["file-untagged"], embed_only_token(subject="user-1"))
+        response = get_documents(["file-untagged"], documents_token(subject="user-1"))
         assert response.status_code == 200
 
 
@@ -221,7 +230,7 @@ class TestScopeIsPartOfTheDeletePredicate:
 
     def test_only_the_callers_rows_are_removed(self, rows, strict_auth):
         response = delete_documents(
-            ["file-collided"], embed_only_token(subject="user-1")
+            ["file-collided"], documents_token(subject="user-1")
         )
         assert response.status_code == 200
         survivors = [row for row in rows if row["file_id"] == "file-collided"]
@@ -229,22 +238,22 @@ class TestScopeIsPartOfTheDeletePredicate:
 
     def test_a_foreign_delete_removes_nothing_at_all(self, rows, strict_auth):
         before = list(rows)
-        assert delete_documents(["file-foreign"], embed_only_token()).status_code == 404
+        assert delete_documents(["file-foreign"], documents_token()).status_code == 404
         assert rows == before
 
 
 class TestTenantSeparation:
     def test_a_file_in_another_tenant_is_not_readable(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", tenant="tenant-a")
+        token = documents_token(subject="user-1", tenant="tenant-a")
         assert get_documents(["file-other-tenant"], token).status_code == 404
 
     def test_a_file_in_another_tenant_is_not_deletable(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", tenant="tenant-a")
+        token = documents_token(subject="user-1", tenant="tenant-a")
         assert delete_documents(["file-other-tenant"], token).status_code == 404
         assert "file-other-tenant" in file_ids(rows)
 
     def test_the_owning_tenant_still_reads_it(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", tenant="tenant-b")
+        token = documents_token(subject="user-1", tenant="tenant-b")
         assert get_documents(["file-other-tenant"], token).status_code == 200
 
 
@@ -252,24 +261,24 @@ class TestEntityScopedFiles:
     """Agent knowledge-base files are reachable exactly as they are on /query."""
 
     def test_a_permitted_entity_widens_the_scope(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        token = documents_token(subject="user-1", entities=("agent-7",))
         response = get_documents(["file-agent"], token, entity_id="agent-7")
         assert response.status_code == 200
 
     def test_a_permitted_entity_can_be_deleted(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        token = documents_token(subject="user-1", entities=("agent-7",))
         response = delete_documents(["file-agent"], token, entity_id="agent-7")
         assert response.status_code == 200
         assert "file-agent" not in file_ids(rows)
 
     def test_an_unlisted_entity_is_refused(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1")
+        token = documents_token(subject="user-1")
         response = get_documents(["file-agent"], token, entity_id="agent-7")
         assert response.status_code == 403
         assert "file-agent content" not in response.text
 
     def test_an_unlisted_entity_cannot_delete(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1")
+        token = documents_token(subject="user-1")
         assert (
             delete_documents(["file-agent"], token, entity_id="agent-7").status_code
             == 403
@@ -277,7 +286,7 @@ class TestEntityScopedFiles:
         assert "file-agent" in file_ids(rows)
 
     def test_the_context_route_takes_an_entity_too(self, rows, strict_auth):
-        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        token = documents_token(subject="user-1", entities=("agent-7",))
         response = get_context("file-agent", token, entity_id="agent-7")
         assert response.status_code == 200
 
@@ -303,7 +312,7 @@ class TestTheScopeReachesTheStore:
         monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", record_documents)
         monkeypatch.setattr(AsyncPgVector, "delete_scoped", record_delete)
 
-        token = embed_only_token(subject="user-1")
+        token = documents_token(subject="user-1")
         get_documents(["file-owned"], token)
         get_context("file-owned", token)
         delete_documents(["file-owned"], token)
@@ -312,3 +321,104 @@ class TestTheScopeReachesTheStore:
         for call in seen:
             assert call["owners"] == ["user-1"]
             assert call["tenants"] == ["__BASE__", None]
+
+
+EMBED_BODY = {
+    "space": space_module.CHAT_SPACE_SPEC.name,
+    "input_type": "query",
+    "inputs": [{"id": "a", "text": "hello world"}],
+}
+
+RERANK_BODY = {
+    "profile": "fast-v1",
+    "query": "q",
+    "candidates": [{"id": "c1", "text": "t", "base_score": 1.0}],
+}
+
+
+@pytest.fixture
+def both_planes(monkeypatch, strict_auth):
+    """Document routes and the ``/v1`` router, mounted at the same time."""
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    auth.reset_settings()
+    install_fake_space(monkeypatch, FakeEmbeddingClient())
+
+
+def post_embeddings(token):
+    return client.post("/v1/embeddings", json=EMBED_BODY, headers=bearer(token))
+
+
+def post_rerank(token):
+    return client.post("/v1/rerank", json=RERANK_BODY, headers=bearer(token))
+
+
+def reach_every_document_route(token):
+    return [
+        client.get("/ids", headers=bearer(token)),
+        get_documents(["file-owned"], token),
+        get_context("file-owned", token),
+        delete_documents(["file-owned"], token),
+    ]
+
+
+class TestThePlanesAreSeparable:
+    """Reading documents and buying inference are distinct capabilities.
+
+    A token minted to delete a file should not also be spendable against an
+    embedding provider, and a token minted to embed should not be able to read
+    or destroy stored chunks. Neither scope substitutes for the other, in either
+    direction — that is the entire point of splitting them.
+    """
+
+    def test_a_documents_token_reaches_every_document_route(self, rows, both_planes):
+        token = documents_token(subject="user-1")
+        assert [
+            response.status_code for response in reach_every_document_route(token)
+        ] == [200, 200, 200, 200]
+
+    def test_a_documents_token_buys_no_embedding(self, rows, both_planes):
+        response = post_embeddings(documents_token(subject="user-1"))
+        assert response.status_code == 403
+        assert "rag:embed" in response.json()["detail"]
+
+    def test_a_documents_token_buys_no_rerank(self, rows, both_planes):
+        response = post_rerank(documents_token(subject="user-1"))
+        assert response.status_code == 403
+        assert "rag:rerank" in response.json()["detail"]
+
+    def test_an_embed_token_reaches_no_document_route(self, rows, both_planes):
+        token = strict_token(subject="user-1", scopes=("rag:embed",))
+        assert post_embeddings(token).status_code == 200
+        for response in reach_every_document_route(token):
+            assert response.status_code == 403
+            assert "rag:documents" in response.json()["detail"]
+
+    def test_a_rerank_token_reaches_no_document_route(self, rows, both_planes):
+        token = strict_token(subject="user-1", scopes=("rag:rerank",))
+        for response in reach_every_document_route(token):
+            assert response.status_code == 403
+
+    def test_an_embed_token_cannot_delete_a_file_it_could_before(
+        self, rows, both_planes
+    ):
+        token = strict_token(subject="user-1", scopes=("rag:embed",))
+        assert delete_documents(["file-owned"], token).status_code == 403
+        assert "file-owned" in file_ids(rows)
+
+    def test_a_legacy_token_still_reaches_both_planes(self, rows, both_planes):
+        """The ``{"id": ...}`` shape predates every scope, including this one."""
+        token = legacy_token(user_id="user-1", secret=RAG_SECRET)
+        assert [
+            response.status_code for response in reach_every_document_route(token)
+        ] == [200, 200, 200, 200]
+        assert post_embeddings(token).status_code == 200
+
+    def test_an_application_signed_legacy_token_still_reaches_the_document_routes(
+        self, rows, both_planes
+    ):
+        """``RAG_AUTH_ACCEPT_LEGACY=true`` keeps today's callers working."""
+        token = legacy_token(user_id="user-1", secret=APP_SECRET)
+        assert [
+            response.status_code for response in reach_every_document_route(token)
+        ] == [200, 200, 200, 200]

--- a/tests/test_document_authorization.py
+++ b/tests/test_document_authorization.py
@@ -1,0 +1,314 @@
+"""Regression tests for the unscoped file-addressed document routes.
+
+``GET /ids``, ``GET /documents``, ``GET /documents/{id}/context`` and
+``DELETE /documents`` addressed the store by caller-supplied file id alone. A
+file id is not an authorization: anyone who learns one — or simply lists them
+from ``/ids`` — could read another owner's document text or delete their chunks.
+The strict tokens this release introduces made that reachable from a service
+credential holding nothing but ``rag:embed``.
+
+The store below evaluates the owner and tenant predicate the route actually
+passes, and answers unscoped when it is passed none. A route that stops putting
+scope in the query therefore fails these tests rather than passing on a check
+performed somewhere else.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List, Optional, Sequence
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.documents import Document
+
+from app import auth
+from app.services.vector_store.async_pg_vector import AsyncPgVector
+from main import app
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, legacy_token, strict_token
+
+client = TestClient(app)
+
+CORPUS = [
+    {"file_id": "file-owned", "user_id": "user-1", "tenant_id": "__BASE__"},
+    {"file_id": "file-foreign", "user_id": "user-2", "tenant_id": "__BASE__"},
+    {"file_id": "file-agent", "user_id": "agent-7", "tenant_id": "__BASE__"},
+    {"file_id": "file-other-tenant", "user_id": "user-1", "tenant_id": "tenant-b"},
+    # One file id, two owners — a file id is chosen by whoever uploads.
+    {"file_id": "file-collided", "user_id": "user-1", "tenant_id": "__BASE__"},
+    {"file_id": "file-collided", "user_id": "user-2", "tenant_id": "__BASE__"},
+    # Written before tenants were recorded: no tenant_id at all.
+    {"file_id": "file-untagged", "user_id": "user-1"},
+]
+
+
+def _in_scope(
+    row: Dict[str, str],
+    owners: Optional[Sequence[str]],
+    tenants: Optional[Sequence[Optional[str]]],
+) -> bool:
+    """Whether ``row`` satisfies the scope the route passed.
+
+    ``None`` for either argument models the store call the routes made before
+    the fix — no owner predicate, no tenant predicate, every row visible.
+    """
+    if owners is None and tenants is None:
+        return True
+    return row["user_id"] in owners and row.get("tenant_id") in tenants
+
+
+@pytest.fixture
+def rows(monkeypatch) -> List[Dict[str, str]]:
+    live = [dict(row) for row in CORPUS]
+
+    def visible(owners, tenants, ids=None):
+        return [
+            row
+            for row in live
+            if (ids is None or row["file_id"] in ids)
+            and _in_scope(row, owners, tenants)
+        ]
+
+    async def get_all_ids(self, owners=None, tenants=None, executor=None):
+        return sorted({row["file_id"] for row in visible(owners, tenants)})
+
+    async def get_filtered_ids(self, ids, owners=None, tenants=None, executor=None):
+        return sorted({row["file_id"] for row in visible(owners, tenants, ids)})
+
+    async def get_documents_by_ids(self, ids, owners=None, tenants=None, executor=None):
+        return [
+            Document(page_content=f"{row['file_id']} content", metadata=dict(row))
+            for row in visible(owners, tenants, ids)
+        ]
+
+    async def delete_scoped(self, ids, owners=None, tenants=None, executor=None):
+        doomed = visible(owners, tenants, ids)
+        live[:] = [row for row in live if row not in doomed]
+
+    async def delete(self, ids=None, collection_only=False, executor=None):
+        """The unscoped delete the route reached for before the fix."""
+        live[:] = [row for row in live if row["file_id"] not in (ids or [])]
+
+    monkeypatch.setattr(AsyncPgVector, "get_all_ids", get_all_ids)
+    monkeypatch.setattr(AsyncPgVector, "get_filtered_ids", get_filtered_ids)
+    monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", get_documents_by_ids)
+    monkeypatch.setattr(AsyncPgVector, "delete_scoped", delete_scoped, raising=False)
+    monkeypatch.setattr(AsyncPgVector, "delete", delete)
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+    return live
+
+
+@pytest.fixture
+def strict_auth(monkeypatch):
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "true")
+    auth.reset_settings()
+
+
+def embed_only_token(subject: str = "attacker", **kwargs) -> str:
+    """The credential the finding is about: a strict token holding only rag:embed."""
+    return strict_token(subject=subject, scopes=("rag:embed",), **kwargs)
+
+
+def file_ids(rows: List[Dict[str, str]]) -> List[str]:
+    return [row["file_id"] for row in rows]
+
+
+def get_documents(ids, token, entity_id=None):
+    params = {"ids": ids}
+    if entity_id is not None:
+        params["entity_id"] = entity_id
+    return client.get("/documents", params=params, headers=bearer(token))
+
+
+def get_context(file_id, token, entity_id=None):
+    url = f"/documents/{file_id}/context"
+    if entity_id is not None:
+        url = f"{url}?entity_id={entity_id}"
+    return client.get(url, headers=bearer(token))
+
+
+def delete_documents(ids, token, entity_id=None):
+    url = "/documents"
+    if entity_id is not None:
+        url = f"{url}?entity_id={entity_id}"
+    return client.request("DELETE", url, json=ids, headers=bearer(token))
+
+
+class TestAnEmbedOnlyTokenCannotReadByFileId:
+    """The credential in the finding: strict, RAG-signed, ``rag:embed`` alone."""
+
+    def test_get_documents_refuses_a_foreign_file(self, rows, strict_auth):
+        response = get_documents(["file-foreign"], embed_only_token())
+        assert response.status_code == 404
+        assert "file-foreign content" not in response.text
+
+    def test_get_context_refuses_a_foreign_file(self, rows, strict_auth):
+        response = get_context("file-foreign", embed_only_token())
+        assert response.status_code == 404
+        assert "file-foreign content" not in response.text
+
+    def test_delete_refuses_a_foreign_file(self, rows, strict_auth):
+        response = delete_documents(["file-foreign"], embed_only_token())
+        assert response.status_code == 404
+        assert "file-foreign" in file_ids(rows)
+
+    def test_ids_does_not_enumerate_the_deployment(self, rows, strict_auth):
+        response = client.get("/ids", headers=bearer(embed_only_token()))
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_a_mixed_request_leaks_nothing(self, rows, strict_auth):
+        """One readable id alongside a foreign one must not carry it along."""
+        token = embed_only_token(subject="user-1")
+        response = get_documents(["file-owned", "file-foreign"], token)
+        assert response.status_code == 404
+        assert "file-foreign content" not in response.text
+
+
+class TestLegacyTokensAreScopedToo:
+    """The grandfather covers scopes and entities, never other owners' files."""
+
+    def test_get_documents_refuses_another_users_file(self, rows, strict_auth):
+        token = legacy_token(user_id="user-1")
+        assert get_documents(["file-foreign"], token).status_code == 404
+
+    def test_get_context_refuses_another_users_file(self, rows, strict_auth):
+        token = legacy_token(user_id="user-1")
+        assert get_context("file-foreign", token).status_code == 404
+
+    def test_delete_refuses_another_users_file(self, rows, strict_auth):
+        token = legacy_token(user_id="user-1")
+        assert delete_documents(["file-foreign"], token).status_code == 404
+        assert "file-foreign" in file_ids(rows)
+
+
+class TestTheOwnersOwnFilesStillWork:
+    def test_get_documents_returns_the_callers_file(self, rows, strict_auth):
+        response = get_documents(["file-owned"], embed_only_token(subject="user-1"))
+        assert response.status_code == 200
+        assert response.json()[0]["page_content"] == "file-owned content"
+
+    def test_get_context_returns_the_callers_file(self, rows, strict_auth):
+        response = get_context("file-owned", embed_only_token(subject="user-1"))
+        assert response.status_code == 200
+        assert "file-owned content" in response.text
+
+    def test_delete_removes_the_callers_file(self, rows, strict_auth):
+        response = delete_documents(["file-owned"], embed_only_token(subject="user-1"))
+        assert response.status_code == 200
+        assert "file-owned" not in file_ids(rows)
+
+    def test_ids_lists_the_callers_files(self, rows, strict_auth):
+        response = client.get(
+            "/ids", headers=bearer(embed_only_token(subject="user-1"))
+        )
+        assert sorted(response.json()) == [
+            "file-collided",
+            "file-owned",
+            "file-untagged",
+        ]
+
+    def test_chunks_written_before_tenants_were_recorded_stay_readable(
+        self, rows, strict_auth
+    ):
+        response = get_documents(["file-untagged"], embed_only_token(subject="user-1"))
+        assert response.status_code == 200
+
+
+class TestScopeIsPartOfTheDeletePredicate:
+    """Two owners can hold rows under one file id, so the DELETE must discriminate."""
+
+    def test_only_the_callers_rows_are_removed(self, rows, strict_auth):
+        response = delete_documents(
+            ["file-collided"], embed_only_token(subject="user-1")
+        )
+        assert response.status_code == 200
+        survivors = [row for row in rows if row["file_id"] == "file-collided"]
+        assert [row["user_id"] for row in survivors] == ["user-2"]
+
+    def test_a_foreign_delete_removes_nothing_at_all(self, rows, strict_auth):
+        before = list(rows)
+        assert delete_documents(["file-foreign"], embed_only_token()).status_code == 404
+        assert rows == before
+
+
+class TestTenantSeparation:
+    def test_a_file_in_another_tenant_is_not_readable(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", tenant="tenant-a")
+        assert get_documents(["file-other-tenant"], token).status_code == 404
+
+    def test_a_file_in_another_tenant_is_not_deletable(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", tenant="tenant-a")
+        assert delete_documents(["file-other-tenant"], token).status_code == 404
+        assert "file-other-tenant" in file_ids(rows)
+
+    def test_the_owning_tenant_still_reads_it(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", tenant="tenant-b")
+        assert get_documents(["file-other-tenant"], token).status_code == 200
+
+
+class TestEntityScopedFiles:
+    """Agent knowledge-base files are reachable exactly as they are on /query."""
+
+    def test_a_permitted_entity_widens_the_scope(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        response = get_documents(["file-agent"], token, entity_id="agent-7")
+        assert response.status_code == 200
+
+    def test_a_permitted_entity_can_be_deleted(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        response = delete_documents(["file-agent"], token, entity_id="agent-7")
+        assert response.status_code == 200
+        assert "file-agent" not in file_ids(rows)
+
+    def test_an_unlisted_entity_is_refused(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1")
+        response = get_documents(["file-agent"], token, entity_id="agent-7")
+        assert response.status_code == 403
+        assert "file-agent content" not in response.text
+
+    def test_an_unlisted_entity_cannot_delete(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1")
+        assert (
+            delete_documents(["file-agent"], token, entity_id="agent-7").status_code
+            == 403
+        )
+        assert "file-agent" in file_ids(rows)
+
+    def test_the_context_route_takes_an_entity_too(self, rows, strict_auth):
+        token = embed_only_token(subject="user-1", entities=("agent-7",))
+        response = get_context("file-agent", token, entity_id="agent-7")
+        assert response.status_code == 200
+
+
+class TestTheScopeReachesTheStore:
+    """Authorization is the store predicate, not a filter applied to its answer."""
+
+    def test_every_route_passes_its_scope_down(self, rows, strict_auth, monkeypatch):
+        seen: List[Dict[str, object]] = []
+
+        async def record_filtered(self, ids, owners=None, tenants=None, executor=None):
+            seen.append({"call": "filtered", "owners": owners, "tenants": tenants})
+            return list(ids)
+
+        async def record_documents(self, ids, owners=None, tenants=None, executor=None):
+            seen.append({"call": "documents", "owners": owners, "tenants": tenants})
+            return [Document(page_content="x", metadata={"file_id": ids[0]})]
+
+        async def record_delete(self, ids, owners=None, tenants=None, executor=None):
+            seen.append({"call": "delete", "owners": owners, "tenants": tenants})
+
+        monkeypatch.setattr(AsyncPgVector, "get_filtered_ids", record_filtered)
+        monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", record_documents)
+        monkeypatch.setattr(AsyncPgVector, "delete_scoped", record_delete)
+
+        token = embed_only_token(subject="user-1")
+        get_documents(["file-owned"], token)
+        get_context("file-owned", token)
+        delete_documents(["file-owned"], token)
+
+        assert {call["call"] for call in seen} == {"filtered", "documents", "delete"}
+        for call in seen:
+            assert call["owners"] == ["user-1"]
+            assert call["tenants"] == ["__BASE__", None]

--- a/tests/test_embeddings_endpoint.py
+++ b/tests/test_embeddings_endpoint.py
@@ -383,3 +383,85 @@ class TestAuthorizeBeforeEgress:
         ):
             monkeypatch.setattr(vector_store, name, explode, raising=False)
         assert post([{"id": "a", "text": "hello"}]).status_code == 200
+
+
+class TestTaskPrefixesCountTowardTheLimit:
+    """The limit binds the payload, and the task prefix is part of the payload.
+
+    ``EmbeddingSpace.embed`` prepends the space's prefix to every input, so a
+    request measured on caller text alone can pass the check and still exceed
+    the provider limit — by the prefix length times up to 64 inputs.
+    """
+
+    def prefixed(self, backend, monkeypatch, prefix):
+        space = install_fake_space(monkeypatch, backend)
+        monkeypatch.setattr(
+            space,
+            "spec",
+            replace(space.spec, query_prefix=prefix, document_prefix=prefix),
+        )
+        return space
+
+    def test_a_request_at_the_boundary_is_rejected_once_prefixed(
+        self, backend, monkeypatch
+    ):
+        self.prefixed(backend, monkeypatch, "Instruct: retrieve\n")
+        response = post(
+            [{"id": "a", "text": "x" * MAX_EMBEDDING_CHARS}], input_type="query"
+        )
+        assert response.status_code == 422
+        assert str(MAX_EMBEDDING_CHARS) in response.json()["detail"]
+
+    def test_nothing_is_embedded_when_the_prefixed_payload_is_too_large(
+        self, backend, monkeypatch
+    ):
+        self.prefixed(backend, monkeypatch, "Instruct: retrieve\n")
+        assert (
+            post(
+                [{"id": "a", "text": "x" * MAX_EMBEDDING_CHARS}], input_type="query"
+            ).status_code
+            == 422
+        )
+        assert backend.calls == []
+
+    def test_the_prefix_is_charged_once_per_input(self, backend, monkeypatch):
+        prefix_length = 100
+        self.prefixed(backend, monkeypatch, "p" * prefix_length)
+        share = MAX_EMBEDDING_CHARS // MAX_EMBEDDING_INPUTS
+
+        exact = [
+            {"id": f"i{n}", "text": "x" * (share - prefix_length)}
+            for n in range(MAX_EMBEDDING_INPUTS)
+        ]
+        assert post(exact, input_type="query").status_code == 200
+
+        # One more character per input: still under the limit as written, over
+        # it once each input carries the prefix.
+        over = [
+            {"id": f"i{n}", "text": "x" * (share - prefix_length + 1)}
+            for n in range(MAX_EMBEDDING_INPUTS)
+        ]
+        assert sum(len(item["text"]) for item in over) < MAX_EMBEDDING_CHARS
+        assert post(over, input_type="query").status_code == 422
+
+    def test_the_document_prefix_is_charged_on_documents(self, backend, monkeypatch):
+        self.prefixed(backend, monkeypatch, "Instruct: retrieve\n")
+        response = post(
+            [{"id": "a", "text": "x" * MAX_EMBEDDING_CHARS}], input_type="document"
+        )
+        assert response.status_code == 422
+        assert backend.calls == []
+
+    def test_expansion_and_prefix_are_counted_together(self, backend, monkeypatch):
+        """NFKC expansion and the prefix both apply to the same payload."""
+        self.prefixed(backend, monkeypatch, "p" * 1000)
+        # Each ﬃ normalizes to three characters, landing just under the limit;
+        # the 1,000-character prefix is what carries the payload over it.
+        text = "ﬃ" * (MAX_EMBEDDING_CHARS // 3 - 300)
+        assert len(text) < MAX_EMBEDDING_CHARS
+        assert len(text) * 3 < MAX_EMBEDDING_CHARS
+        assert post([{"id": "a", "text": text}], input_type="query").status_code == 422
+
+    def test_an_unprefixed_space_still_accepts_the_full_payload(self, backend):
+        response = post([{"id": "a", "text": "x" * MAX_EMBEDDING_CHARS}])
+        assert response.status_code == 200

--- a/tests/test_embeddings_endpoint.py
+++ b/tests/test_embeddings_endpoint.py
@@ -9,11 +9,12 @@ from fastapi.testclient import TestClient
 
 from app import auth
 from app.constants import MAX_EMBEDDING_CHARS, MAX_EMBEDDING_INPUTS
+from app.services import ratelimit
 from app.services import space as space_module
 from app.utils.text import content_hash, normalize_text
 from main import app
 from tests.fakes import FAKE_MODEL, FakeEmbeddingClient, install_fake_space
-from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, legacy_token, strict_token
 
 client = TestClient(app)
 
@@ -151,3 +152,78 @@ def test_input_text_never_reaches_the_logs_on_failure(backend, caplog, monkeypat
     with caplog.at_level(logging.DEBUG):
         assert post([{"id": "a", "text": secret}]).status_code == 503
     assert secret not in caplog.text
+
+
+class TestAuthorizeBeforeEgress:
+    """Nothing is embedded until the request is fully authorized.
+
+    Text sent to the inference gateway has left the trust boundary whether or
+    not the caller ever sees a response, so every rejection has to happen before
+    the backend is touched.
+    """
+
+    def test_a_token_without_the_embed_scope_embeds_nothing(self, backend):
+        response = post(
+            [{"id": "a", "text": "secret"}], token=strict_token(scopes=["rag:rerank"])
+        )
+        assert response.status_code == 403
+        assert backend.calls == []
+
+    def test_the_system_tenant_embeds_nothing(self, backend):
+        response = post(
+            [{"id": "a", "text": "secret"}], token=strict_token(tenant="__SYSTEM__")
+        )
+        assert response.status_code == 403
+        assert backend.calls == []
+
+    def test_an_unauthenticated_request_embeds_nothing(self, backend):
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "space": SPACE,
+                "input_type": "query",
+                "inputs": [{"id": "a", "text": "secret"}],
+            },
+        )
+        assert response.status_code == 401
+        assert backend.calls == []
+
+    def test_a_session_token_embeds_nothing(self, backend):
+        response = post(
+            [{"id": "a", "text": "secret"}], token=legacy_token(secret=APP_SECRET)
+        )
+        assert response.status_code == 401
+        assert backend.calls == []
+
+    def test_an_over_limit_request_embeds_nothing(self, backend):
+        inputs = [{"id": f"i{n}", "text": "x"} for n in range(MAX_EMBEDDING_INPUTS + 1)]
+        assert post(inputs).status_code == 422
+        assert backend.calls == []
+
+    def test_an_unknown_space_embeds_nothing(self, backend):
+        assert post([{"id": "a", "text": "secret"}], space="chat-v2").status_code == 400
+        assert backend.calls == []
+
+    def test_a_rate_limited_request_embeds_nothing(self, backend, monkeypatch):
+        monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "true")
+        monkeypatch.setenv("RAG_RATE_LIMIT_EMBED_SUBJECT", "1")
+        ratelimit.reset()
+        assert post([{"id": "a", "text": "first"}]).status_code == 200
+        assert len(backend.calls) == 1
+        assert post([{"id": "a", "text": "second"}]).status_code == 429
+        assert len(backend.calls) == 1
+
+    def test_the_endpoint_reads_no_document_store_at_all(self, backend, monkeypatch):
+        """/v1/embeddings only ever embeds text the caller itself supplied."""
+        from app.config import vector_store
+
+        def explode(*args, **kwargs):
+            raise AssertionError("the embeddings path must not touch the store")
+
+        for name in (
+            "get_vectors_by_ids",
+            "probe_candidate_ids",
+            "get_documents_by_ids",
+        ):
+            monkeypatch.setattr(vector_store, name, explode, raising=False)
+        assert post([{"id": "a", "text": "hello"}]).status_code == 200

--- a/tests/test_embeddings_endpoint.py
+++ b/tests/test_embeddings_endpoint.py
@@ -465,3 +465,91 @@ class TestTaskPrefixesCountTowardTheLimit:
     def test_an_unprefixed_space_still_accepts_the_full_payload(self, backend):
         response = post([{"id": "a", "text": "x" * MAX_EMBEDDING_CHARS}])
         assert response.status_code == 200
+
+
+class FixedResponseClient:
+    """A backend that answers with whatever payload the test hands it."""
+
+    def __init__(self, payload, dimensions=8):
+        self.payload = payload
+        self.dimensions = dimensions
+
+    def embed_documents(self, texts):
+        return self.payload
+
+    def embed_query(self, text):
+        return self.payload[0]
+
+
+class TestMalformedBackendPayloadsStaySubstitutionLocked:
+    """Reading the response is as much "the backend" as calling it.
+
+    A payload that is not a list of correctly-sized numbers used to raise
+    ``TypeError`` from inside ``_finalize`` — outside the guarded call — so the
+    route's ``SpaceBackendError`` handler never saw it and the caller got an
+    unhandled 500 instead of the documented sanitized 503.
+    """
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(None, id="null-response"),
+            pytest.param("a vector", id="string-response"),
+            pytest.param({"data": []}, id="object-response"),
+            pytest.param([None], id="null-vector"),
+            pytest.param([3.5], id="scalar-vector"),
+            pytest.param(["12345678"], id="string-vector"),
+            pytest.param([["x"] * 8], id="non-numeric-components"),
+            pytest.param([[True] * 8], id="boolean-components"),
+            pytest.param([[1.0] * 7 + [None]], id="one-null-component"),
+            pytest.param([[float("nan")] * 8], id="nan-components"),
+            pytest.param([[float("inf")] * 8], id="infinite-components"),
+        ],
+    )
+    def test_a_malformed_payload_is_a_sanitized_503(
+        self, backend, monkeypatch, payload
+    ):
+        install_fake_space(monkeypatch, FixedResponseClient(payload))
+        response = post([{"id": "a", "text": "alpha"}])
+        assert response.status_code == 503
+        assert response.json()["detail"] == f"Embedding space '{SPACE}' is unavailable"
+
+    def test_a_malformed_payload_is_a_backend_error_at_the_space(self, monkeypatch):
+        space = install_fake_space(monkeypatch, FixedResponseClient(None))
+        with pytest.raises(space_module.SpaceBackendError):
+            space.embed(["alpha"])
+
+    def test_non_finite_components_are_refused_rather_than_normalized(
+        self, monkeypatch
+    ):
+        """Normalization hides them: inf/inf is NaN and poisons every score."""
+        space = install_fake_space(
+            monkeypatch, FixedResponseClient([[float("inf")] * 8])
+        )
+        with pytest.raises(space_module.SpaceBackendError):
+            space.embed(["alpha"])
+
+    def test_a_malformed_payload_leaks_nothing_to_the_logs(
+        self, backend, caplog, monkeypatch
+    ):
+        install_fake_space(monkeypatch, FixedResponseClient(["provider-echo-of-input"]))
+        with caplog.at_level(logging.ERROR):
+            assert post([{"id": "a", "text": "alpha"}]).status_code == 503
+        assert "provider-echo-of-input" not in caplog.text
+        assert "Traceback" not in caplog.text
+        assert "SpaceBackendError" in caplog.text
+
+    def test_integral_components_are_still_accepted(self, backend, monkeypatch):
+        """A backend that answers 0/1 exactly is well-formed, not malformed."""
+        install_fake_space(monkeypatch, FixedResponseClient([[1, 0, 0, 0, 0, 0, 0, 0]]))
+        response = post([{"id": "a", "text": "alpha"}])
+        assert response.status_code == 200
+        assert response.json()["items"][0]["embedding"] == [1.0] + [0.0] * 7
+
+    def test_an_unnormalized_space_checks_its_components_too(self, monkeypatch):
+        """Without normalization nothing else would ever touch the components."""
+        space = install_fake_space(
+            monkeypatch, FixedResponseClient([["x"] * 8]), normalized=False
+        )
+        with pytest.raises(space_module.SpaceBackendError):
+            space.embed(["alpha"])

--- a/tests/test_embeddings_endpoint.py
+++ b/tests/test_embeddings_endpoint.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from dataclasses import replace
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -13,7 +14,12 @@ from app.services import ratelimit
 from app.services import space as space_module
 from app.utils.text import content_hash, normalize_text
 from main import app
-from tests.fakes import FAKE_MODEL, FakeEmbeddingClient, install_fake_space
+from tests.fakes import (
+    FAKE_MODEL,
+    FakeEmbeddingClient,
+    deterministic_vector,
+    install_fake_space,
+)
 from tests.tokens import APP_SECRET, RAG_SECRET, bearer, legacy_token, strict_token
 
 client = TestClient(app)
@@ -120,6 +126,132 @@ def test_input_type_is_constrained(backend):
     assert post([{"id": "a", "text": "x"}], input_type="passage").status_code == 422
 
 
+class TestNormalizedSizeLimit:
+    """The advertised limit is a provider limit, so it binds the sent text.
+
+    NFKC expands compatibility characters — U+FB03 becomes three characters —
+    so a request that fits the limit as written can exceed it as sent. The
+    aggregate is therefore re-checked after normalization, before egress.
+    """
+
+    def test_expansion_past_the_limit_is_rejected(self, backend):
+        # Each ﬃ normalizes to three characters, so this is under the limit as
+        # written and comfortably over it once normalized.
+        text = "ﬃ" * (MAX_EMBEDDING_CHARS // 2)
+        response = post([{"id": "a", "text": text}])
+        assert response.status_code == 422
+        assert str(MAX_EMBEDDING_CHARS) in response.json()["detail"]
+
+    def test_nothing_is_embedded_when_the_normalized_form_is_too_large(self, backend):
+        text = "ﬃ" * (MAX_EMBEDDING_CHARS // 2)
+        assert post([{"id": "a", "text": text}]).status_code == 422
+        assert backend.calls == []
+
+    def test_the_limit_is_measured_across_all_inputs(self, backend):
+        share = MAX_EMBEDDING_CHARS // 6
+        inputs = [{"id": f"i{n}", "text": "ﬃ" * share} for n in range(3)]
+        assert post(inputs).status_code == 422
+        assert backend.calls == []
+
+    def test_expansion_within_the_limit_still_succeeds(self, backend):
+        text = "ﬃ" * (MAX_EMBEDDING_CHARS // 6)
+        response = post([{"id": "a", "text": text}])
+        assert response.status_code == 200
+        assert response.json()["usage"]["total_characters"] == len(text) * 3
+
+    def test_a_request_that_does_not_expand_is_unaffected(self, backend):
+        text = "x" * (MAX_EMBEDDING_CHARS - 1)
+        assert post([{"id": "a", "text": text}]).status_code == 200
+
+
+class TestInputTypeIsHonoured:
+    """``input_type`` selects the encoder, rather than being recorded and ignored."""
+
+    def test_a_query_goes_through_the_query_encoder_when_one_exists(
+        self, backend, monkeypatch
+    ):
+        seen = {}
+
+        def embed_queries(texts):
+            seen["queries"] = list(texts)
+            return [deterministic_vector(text) for text in texts]
+
+        monkeypatch.setattr(backend, "embed_queries", embed_queries, raising=False)
+        assert (
+            post([{"id": "a", "text": "alpha"}], input_type="query").status_code == 200
+        )
+        assert seen["queries"] == ["alpha"]
+        assert backend.calls == []
+
+    def test_a_document_never_goes_through_the_query_encoder(
+        self, backend, monkeypatch
+    ):
+        def explode(texts):
+            raise AssertionError("documents must not use the query encoder")
+
+        monkeypatch.setattr(backend, "embed_queries", explode, raising=False)
+        response = post([{"id": "a", "text": "alpha"}], input_type="document")
+        assert response.status_code == 200
+        assert backend.embedded_texts == ["alpha"]
+
+    def test_the_query_task_prefix_reaches_the_backend(self, backend, monkeypatch):
+        space = install_fake_space(monkeypatch, backend)
+        monkeypatch.setattr(
+            space,
+            "spec",
+            replace(space.spec, query_prefix="Q: ", document_prefix="D: "),
+        )
+        assert (
+            post([{"id": "a", "text": "alpha"}], input_type="query").status_code == 200
+        )
+        assert backend.embedded_texts == ["Q: alpha"]
+
+    def test_the_document_task_prefix_reaches_the_backend(self, backend, monkeypatch):
+        space = install_fake_space(monkeypatch, backend)
+        monkeypatch.setattr(
+            space,
+            "spec",
+            replace(space.spec, query_prefix="Q: ", document_prefix="D: "),
+        )
+        response = post([{"id": "a", "text": "alpha"}], input_type="document")
+        assert response.status_code == 200
+        assert backend.embedded_texts == ["D: alpha"]
+
+    def test_the_two_input_types_produce_different_vectors(self, backend, monkeypatch):
+        space = install_fake_space(monkeypatch, backend)
+        monkeypatch.setattr(
+            space,
+            "spec",
+            replace(space.spec, query_prefix="Q: ", document_prefix="D: "),
+        )
+        as_query = post([{"id": "a", "text": "alpha"}], input_type="query").json()
+        as_document = post([{"id": "a", "text": "alpha"}], input_type="document").json()
+        assert as_query["items"][0]["embedding"] != as_document["items"][0]["embedding"]
+
+    def test_the_content_hash_identifies_the_text_not_the_encoding(
+        self, backend, monkeypatch
+    ):
+        """The hash is the caller's cache key, so the task prefix stays out of it."""
+        space = install_fake_space(monkeypatch, backend)
+        monkeypatch.setattr(
+            space,
+            "spec",
+            replace(space.spec, query_prefix="Q: ", document_prefix="D: "),
+        )
+        as_query = post([{"id": "a", "text": "alpha"}], input_type="query").json()
+        as_document = post([{"id": "a", "text": "alpha"}], input_type="document").json()
+        assert as_query["items"][0]["content_hash"] == content_hash("alpha")
+        assert (
+            as_query["items"][0]["content_hash"]
+            == as_document["items"][0]["content_hash"]
+        )
+
+    def test_an_unprefixed_space_is_unchanged_by_the_input_type(self, backend):
+        as_query = post([{"id": "a", "text": "alpha"}], input_type="query").json()
+        as_document = post([{"id": "a", "text": "alpha"}], input_type="document").json()
+        assert as_query["items"] == as_document["items"]
+
+
 def test_unknown_space_is_rejected(backend):
     assert post([{"id": "a", "text": "x"}], space="chat-v2").status_code == 400
 
@@ -152,6 +284,30 @@ def test_input_text_never_reaches_the_logs_on_failure(backend, caplog, monkeypat
     with caplog.at_level(logging.DEBUG):
         assert post([{"id": "a", "text": secret}]).status_code == 503
     assert secret not in caplog.text
+
+
+def test_a_provider_that_echoes_the_input_still_leaks_nothing(
+    backend, caplog, monkeypatch
+):
+    """Gateways routinely quote the rejected input back in the error message.
+
+    SpaceBackendError wraps that message verbatim, so logging the exception —
+    or its traceback — would write the caller's text into the log despite this
+    endpoint's no-raw-text guarantee.
+    """
+    secret = "correcthorsebatterystaple"
+    install_fake_space(
+        monkeypatch,
+        FakeEmbeddingClient(error=RuntimeError(f"input rejected: '{secret}'")),
+    )
+    with caplog.at_level(logging.DEBUG):
+        response = post([{"id": "a", "text": secret}])
+    assert response.status_code == 503
+    assert secret not in caplog.text
+    assert secret not in response.text
+    # The failure is still diagnosable: the class chain identifies the cause.
+    assert "SpaceBackendError" in caplog.text
+    assert "RuntimeError" in caplog.text
 
 
 class TestAuthorizeBeforeEgress:

--- a/tests/test_embeddings_endpoint.py
+++ b/tests/test_embeddings_endpoint.py
@@ -1,0 +1,153 @@
+"""POST /v1/embeddings — contract, limits, and the chat-v1 substitution lock."""
+
+import logging
+import math
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import auth
+from app.constants import MAX_EMBEDDING_CHARS, MAX_EMBEDDING_INPUTS
+from app.services import space as space_module
+from app.utils.text import content_hash, normalize_text
+from main import app
+from tests.fakes import FAKE_MODEL, FakeEmbeddingClient, install_fake_space
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
+
+client = TestClient(app)
+
+SPACE = space_module.CHAT_SPACE_SPEC.name
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    auth.reset_settings()
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+    fake = FakeEmbeddingClient()
+    install_fake_space(monkeypatch, fake)
+    return fake
+
+
+def post(inputs, space=SPACE, input_type="query", token=None):
+    return client.post(
+        "/v1/embeddings",
+        json={"space": space, "input_type": input_type, "inputs": inputs},
+        headers=bearer(token or strict_token()),
+    )
+
+
+def test_response_shape_matches_the_contract(backend):
+    response = post([{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}])
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {
+        "space",
+        "model",
+        "dimensions",
+        "normalized",
+        "items",
+        "usage",
+    }
+    assert payload["space"] == SPACE
+    assert payload["model"] == FAKE_MODEL
+    assert payload["dimensions"] == 8
+    assert payload["normalized"] is True
+    assert [item["id"] for item in payload["items"]] == ["a", "b"]
+    assert set(payload["items"][0]) == {"id", "content_hash", "embedding"}
+    assert payload["usage"] == {"input_count": 2, "total_characters": 9}
+
+
+def test_caller_ids_and_order_are_preserved(backend):
+    ids = ["z", "m", "a"]
+    response = post([{"id": i, "text": f"text {i}"} for i in ids])
+    assert [item["id"] for item in response.json()["items"]] == ids
+
+
+def test_vectors_are_l2_normalized(backend):
+    response = post([{"id": "a", "text": "alpha"}])
+    vector = response.json()["items"][0]["embedding"]
+    assert math.isclose(
+        math.sqrt(sum(component**2 for component in vector)), 1.0, rel_tol=1e-9
+    )
+
+
+def test_content_hash_is_over_the_normalized_text(backend):
+    response = post([{"id": "a", "text": "  Hello   world \n"}])
+    item = response.json()["items"][0]
+    assert item["content_hash"] == content_hash("Hello world")
+    assert normalize_text("  Hello   world \n") == "Hello world"
+
+
+def test_whitespace_variants_share_a_content_hash(backend):
+    first = post([{"id": "a", "text": "one two"}]).json()["items"][0]
+    second = post([{"id": "a", "text": "one\n\ttwo  "}]).json()["items"][0]
+    assert first["content_hash"] == second["content_hash"]
+    assert first["embedding"] == second["embedding"]
+
+
+def test_input_limit_is_enforced(backend):
+    inputs = [{"id": f"i{n}", "text": "x"} for n in range(MAX_EMBEDDING_INPUTS)]
+    assert post(inputs).status_code == 200
+    inputs.append({"id": "overflow", "text": "x"})
+    assert post(inputs).status_code == 422
+
+
+def test_aggregate_character_limit_is_enforced(backend):
+    oversized = [
+        {"id": "a", "text": "x" * (MAX_EMBEDDING_CHARS // 2)},
+        {"id": "b", "text": "x" * (MAX_EMBEDDING_CHARS // 2 + 1)},
+    ]
+    assert post(oversized).status_code == 422
+
+
+def test_duplicate_ids_are_rejected(backend):
+    assert post([{"id": "a", "text": "x"}, {"id": "a", "text": "y"}]).status_code == 422
+
+
+def test_empty_and_whitespace_only_text_is_rejected(backend):
+    assert post([{"id": "a", "text": ""}]).status_code == 422
+    assert post([{"id": "a", "text": "   \n "}]).status_code == 422
+
+
+def test_input_type_is_constrained(backend):
+    assert post([{"id": "a", "text": "x"}], input_type="passage").status_code == 422
+
+
+def test_unknown_space_is_rejected(backend):
+    assert post([{"id": "a", "text": "x"}], space="chat-v2").status_code == 400
+
+
+def test_backend_failure_returns_503_rather_than_a_substitute(backend, monkeypatch):
+    install_fake_space(
+        monkeypatch, FakeEmbeddingClient(error=RuntimeError("gateway down"))
+    )
+    response = post([{"id": "a", "text": "x"}])
+    assert response.status_code == 503
+    assert "gateway down" not in response.text
+
+
+def test_wrong_dimensionality_is_a_backend_failure(backend, monkeypatch):
+    """A model swap behind the gateway must surface, not silently re-dimension."""
+    install_fake_space(monkeypatch, FakeEmbeddingClient(dimensions=4), dimensions=8)
+    assert post([{"id": "a", "text": "x"}]).status_code == 503
+
+
+def test_input_text_never_reaches_the_logs(backend, caplog):
+    secret = "correcthorsebatterystaple"
+    with caplog.at_level(logging.DEBUG):
+        assert post([{"id": "a", "text": secret}]).status_code == 200
+    assert secret not in caplog.text
+
+
+def test_input_text_never_reaches_the_logs_on_failure(backend, caplog, monkeypatch):
+    install_fake_space(monkeypatch, FakeEmbeddingClient(error=RuntimeError("boom")))
+    secret = "correcthorsebatterystaple"
+    with caplog.at_level(logging.DEBUG):
+        assert post([{"id": "a", "text": secret}]).status_code == 503
+    assert secret not in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,20 +48,20 @@ def override_vector_store(monkeypatch):
         )
 
     # Override get_all_ids as an async function - patch at CLASS level to bypass run_in_executor
-    async def dummy_get_all_ids(self, executor=None):
+    async def dummy_get_all_ids(self, owners, tenants, executor=None):
         return ["testid1", "testid2"]
 
     monkeypatch.setattr(AsyncPgVector, "get_all_ids", dummy_get_all_ids)
 
     # Override get_filtered_ids as an async function.
-    async def dummy_get_filtered_ids(self, ids, executor=None):
+    async def dummy_get_filtered_ids(self, ids, owners, tenants, executor=None):
         dummy_ids = ["testid1", "testid2"]
         return [id for id in dummy_ids if id in ids]
 
     monkeypatch.setattr(AsyncPgVector, "get_filtered_ids", dummy_get_filtered_ids)
 
     # Override get_documents_by_ids as an async function.
-    async def dummy_get_documents_by_ids(self, ids, executor=None):
+    async def dummy_get_documents_by_ids(self, ids, owners, tenants, executor=None):
         return [
             Document(page_content="Test content", metadata={"file_id": id})
             for id in ids
@@ -126,7 +126,11 @@ def override_vector_store(monkeypatch):
     async def dummy_delete(self, ids=None, collection_only=False, executor=None):
         return None
 
+    async def dummy_delete_scoped(self, ids, owners, tenants, executor=None):
+        return None
+
     monkeypatch.setattr(AsyncPgVector, "delete", dummy_delete)
+    monkeypatch.setattr(AsyncPgVector, "delete_scoped", dummy_delete_scoped)
 
 
 def test_get_all_ids(auth_headers):
@@ -221,7 +225,7 @@ def test_load_document_context(auth_headers):
 def test_load_document_context_restores_parallel_chunk_order(auth_headers, monkeypatch):
     from app.services.vector_store.async_pg_vector import AsyncPgVector
 
-    async def out_of_order_documents(self, ids, executor=None):
+    async def out_of_order_documents(self, ids, owners, tenants, executor=None):
         return [
             Document(
                 page_content="third",
@@ -272,7 +276,7 @@ def test_load_document_context_groups_repeated_ingestion_attempts(
             },
         )
 
-    async def interleaved_attempts(self, ids, executor=None):
+    async def interleaved_attempts(self, ids, owners, tenants, executor=None):
         return [
             marked("old-second", 1, "old", 100),
             marked("new-second", 1, "new", 200),

--- a/tests/test_query_authorization.py
+++ b/tests/test_query_authorization.py
@@ -356,3 +356,49 @@ class TestTenantScope:
         response = self._query("file-owned", "__SYSTEM__")
         assert response.status_code == 403
         assert captured_filters == []
+
+
+class TestDocumentedAtlasIndex:
+    """The documented Atlas index has to cover what the predicate pre-filters on.
+
+    On Atlas the scope clauses become ``$vectorSearch`` pre-filters, and Atlas
+    rejects a pre-filter that references a path the index does not declare as a
+    filter field. An index carrying only ``file_id`` therefore makes /query and
+    /query_multiple fail outright, so the README's definition is not decoration
+    — it is part of the deployment contract, and it drifts silently.
+    """
+
+    def _documented_filter_paths(self) -> set:
+        import json
+        import re
+        from pathlib import Path
+
+        readme = Path(__file__).resolve().parents[1] / "README.md"
+        blocks = re.findall(
+            r"```json\n(.*?)\n```", readme.read_text(encoding="utf-8"), re.DOTALL
+        )
+        for block in blocks:
+            definition = json.loads(block)
+            fields = definition.get("fields")
+            if not isinstance(fields, list):
+                continue
+            if not any(field.get("type") == "vector" for field in fields):
+                continue
+            return {field["path"] for field in fields if field.get("type") == "filter"}
+        raise AssertionError("no Atlas vector index definition found in README.md")
+
+    def test_every_scoped_path_is_declared_as_a_filter_field(self):
+        from app.scope import ScopeFilter
+
+        scope = ScopeFilter(tenant="tenant-a", owners=("user-1",))
+        referenced = {key for clause in scope.scope_clauses() for key in clause}
+        documented = self._documented_filter_paths()
+        assert referenced <= documented, (
+            f"README Atlas index is missing filter fields for "
+            f"{sorted(referenced - documented)}"
+        )
+
+    def test_the_file_predicate_is_declared_too(self):
+        from app.scope import file_clause
+
+        assert set(file_clause("file-1")) <= self._documented_filter_paths()

--- a/tests/test_query_authorization.py
+++ b/tests/test_query_authorization.py
@@ -241,6 +241,30 @@ def test_legacy_token_entity_id_never_widens_beyond_two_owners(
     assert "user-2" not in owners_in(captured_filters[0])
 
 
+def test_legacy_entity_id_is_still_trusted_until_the_flag_flips(
+    captured_filters, strict_auth, monkeypatch
+):
+    """Documents the residual transition risk, and that flipping the flag ends it.
+
+    A legacy token carries no entity list, so rag_api cannot tell a legitimate
+    agent id from a victim's user id. This is the whole reason the six LibreChat
+    call paths must migrate and RAG_AUTH_ACCEPT_LEGACY must go false.
+    """
+    body = {"query": "q", "file_id": "file-foreign", "k": 10, "entity_id": "user-2"}
+    response = client.post("/query", json=body, headers=bearer(legacy_token("user-1")))
+    assert response.status_code == 200
+    assert owners_in(captured_filters[0]) == ["user-1", "user-2"]
+
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "false")
+    auth.reset_settings()
+    rejected = client.post("/query", json=body, headers=bearer(legacy_token("user-1")))
+    assert rejected.status_code == 401
+    strict = client.post(
+        "/query", json=body, headers=bearer(strict_token(subject="user-1"))
+    )
+    assert strict.status_code == 403
+
+
 def test_tenant_claim_does_not_widen_owner_scope(captured_filters, strict_auth):
     token = strict_token(subject="user-1", tenant=BASE_TENANT)
     client.post(

--- a/tests/test_query_authorization.py
+++ b/tests/test_query_authorization.py
@@ -39,6 +39,14 @@ CORPUS = [
     {"file_id": "file-shared", "user_id": "user-1", "chunk": "shared owner chunk"},
     {"file_id": "file-shared", "user_id": "user-2", "chunk": "shared foreign chunk"},
     {"file_id": "file-agent", "user_id": "agent-7", "chunk": "agent chunk"},
+    # Same owner, different tenant, and a pre-tenant chunk with no tenant_id.
+    {
+        "file_id": "file-owned",
+        "user_id": "user-1",
+        "tenant_id": "tenant-b",
+        "chunk": "other tenant chunk",
+    },
+    {"file_id": "file-legacy", "user_id": "user-1", "chunk": "untagged legacy chunk"},
 ]
 
 
@@ -74,6 +82,8 @@ def captured_filters(monkeypatch):
         hits = []
         for position, row in enumerate(CORPUS):
             metadata = {"file_id": row["file_id"], "user_id": row["user_id"]}
+            if "tenant_id" in row:
+                metadata["tenant_id"] = row["tenant_id"]
             if filter is not None and not _matches(metadata, filter):
                 continue
             hits.append(
@@ -108,11 +118,19 @@ def strict_auth(monkeypatch):
     auth.reset_settings()
 
 
-def owners_in(predicate: Dict[str, Any]) -> List[str]:
+def _clause(predicate: Dict[str, Any], key: str) -> List[Any]:
     for clause in predicate["$and"]:
-        if "user_id" in clause:
-            return clause["user_id"]["$in"]
-    raise AssertionError(f"no owner predicate in {predicate}")
+        if key in clause:
+            return clause[key]["$in"]
+    raise AssertionError(f"no {key} predicate in {predicate}")
+
+
+def owners_in(predicate: Dict[str, Any]) -> List[str]:
+    return _clause(predicate, "user_id")
+
+
+def tenants_in(predicate: Dict[str, Any]) -> List[Any]:
+    return _clause(predicate, "tenant_id")
 
 
 def test_owner_predicate_is_part_of_the_store_query(captured_filters, strict_auth):
@@ -273,3 +291,68 @@ def test_tenant_claim_does_not_widen_owner_scope(captured_filters, strict_auth):
         headers=bearer(token),
     )
     assert owners_in(captured_filters[0]) == ["user-1"]
+
+
+class TestTenantScope:
+    """Tenant is part of the store predicate, alongside owner and file id."""
+
+    def _query(self, file_id, tenant, subject="user-1"):
+        return client.post(
+            "/query",
+            json={"query": "q", "file_id": file_id, "k": 10},
+            headers=bearer(strict_token(subject=subject, tenant=tenant)),
+        )
+
+    def test_the_predicate_carries_tenant_owner_and_file(
+        self, captured_filters, strict_auth
+    ):
+        self._query("file-owned", "tenant-a")
+        predicate = captured_filters[0]
+        assert tenants_in(predicate) == ["tenant-a"]
+        assert owners_in(predicate) == ["user-1"]
+        assert {"file_id": {"$eq": "file-owned"}} in predicate["$and"]
+
+    def test_the_same_owner_in_another_tenant_is_invisible(
+        self, captured_filters, strict_auth
+    ):
+        response = self._query("file-owned", "tenant-a")
+        assert response.status_code == 200
+        # Only the tenant-b copy carries tenant_id; everything else is untagged.
+        assert response.json() == []
+
+    def test_base_tenant_absorbs_chunks_written_before_tenants_existed(
+        self, captured_filters, strict_auth
+    ):
+        response = self._query("file-legacy", BASE_TENANT)
+        assert response.status_code == 200
+        assert tenants_in(captured_filters[0]) == [BASE_TENANT, None]
+        assert len(response.json()) == 1
+
+    def test_a_real_tenant_never_absorbs_untagged_chunks(
+        self, captured_filters, strict_auth
+    ):
+        response = self._query("file-legacy", "tenant-a")
+        assert response.status_code == 200
+        assert tenants_in(captured_filters[0]) == ["tenant-a"]
+        assert response.json() == []
+
+    def test_a_foreign_tenants_chunk_is_invisible(self, captured_filters, strict_auth):
+        response = self._query("file-owned", "tenant-b", subject="user-2")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_query_multiple_is_tenant_scoped_too(self, captured_filters, strict_auth):
+        response = client.post(
+            "/query_multiple",
+            json={"query": "q", "file_ids": ["file-owned", "file-legacy"], "k": 10},
+            headers=bearer(strict_token(subject="user-1", tenant="tenant-a")),
+        )
+        assert response.status_code == 404
+        assert tenants_in(captured_filters[0]) == ["tenant-a"]
+
+    def test_system_tenant_is_refused_before_any_store_query(
+        self, captured_filters, strict_auth
+    ):
+        response = self._query("file-owned", "__SYSTEM__")
+        assert response.status_code == 403
+        assert captured_filters == []

--- a/tests/test_query_authorization.py
+++ b/tests/test_query_authorization.py
@@ -1,0 +1,251 @@
+"""Regression tests for the /query and /query_multiple authorization holes.
+
+Before the fix, ``/query`` authorized an entire result set from the metadata of
+``documents[0]`` — the first *returned* hit — and ``/query_multiple`` performed
+no authorization at all. Both accepted a caller-supplied ``entity_id`` as the
+identity to compare against, so naming a victim's id authorized the victim's
+chunks.
+
+The store here evaluates the metadata filter the route actually builds, so a
+route that stops putting the owner predicate in the query predicate fails these
+tests rather than passing on a post-hoc check.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.documents import Document
+
+from app import auth
+from app.services.vector_store.async_pg_vector import AsyncPgVector
+from main import app
+from tests.tokens import (
+    APP_SECRET,
+    BASE_TENANT,
+    RAG_SECRET,
+    bearer,
+    legacy_token,
+    strict_token,
+)
+
+client = TestClient(app)
+
+CORPUS = [
+    {"file_id": "file-owned", "user_id": "user-1", "chunk": "owner chunk a"},
+    {"file_id": "file-owned", "user_id": "user-1", "chunk": "owner chunk b"},
+    {"file_id": "file-foreign", "user_id": "user-2", "chunk": "foreign chunk"},
+    {"file_id": "file-shared", "user_id": "user-1", "chunk": "shared owner chunk"},
+    {"file_id": "file-shared", "user_id": "user-2", "chunk": "shared foreign chunk"},
+    {"file_id": "file-agent", "user_id": "agent-7", "chunk": "agent chunk"},
+]
+
+
+def _matches(metadata: Dict[str, Any], predicate: Dict[str, Any]) -> bool:
+    """Minimal evaluator for the LangChain metadata-filter dialect."""
+    for key, clause in predicate.items():
+        if key == "$and":
+            if not all(_matches(metadata, sub) for sub in clause):
+                return False
+            continue
+        if key == "$or":
+            if not any(_matches(metadata, sub) for sub in clause):
+                return False
+            continue
+        value = metadata.get(key)
+        operator, operand = next(iter(clause.items()))
+        if operator == "$eq" and value != operand:
+            return False
+        if operator == "$in" and value not in operand:
+            return False
+        if operator not in ("$eq", "$in"):
+            raise AssertionError(f"unexpected operator in predicate: {operator}")
+    return True
+
+
+@pytest.fixture
+def captured_filters(monkeypatch):
+    """Route the store through a filter-evaluating fake and record predicates."""
+    seen: List[Dict[str, Any]] = []
+
+    def search(embedding, k, filter=None) -> List[Tuple[Document, float]]:
+        seen.append(filter)
+        hits = []
+        for position, row in enumerate(CORPUS):
+            metadata = {"file_id": row["file_id"], "user_id": row["user_id"]}
+            if filter is not None and not _matches(metadata, filter):
+                continue
+            hits.append(
+                (Document(page_content=row["chunk"], metadata=metadata), 0.1 * position)
+            )
+        return hits[:k]
+
+    async def asearch(self, embedding, k, filter=None, executor=None):
+        return search(embedding, k, filter)
+
+    monkeypatch.setattr(
+        AsyncPgVector, "asimilarity_search_with_score_by_vector", asearch
+    )
+    monkeypatch.setattr(
+        "app.services.embedding.get_cached_query_embedding",
+        lambda query: [0.1, 0.2, 0.3],
+    )
+    monkeypatch.setattr(
+        "app.routes.document_routes.get_cached_query_embedding",
+        lambda query: [0.1, 0.2, 0.3],
+    )
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+    return seen
+
+
+@pytest.fixture
+def strict_auth(monkeypatch):
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_AUTH_ACCEPT_LEGACY", "true")
+    auth.reset_settings()
+
+
+def owners_in(predicate: Dict[str, Any]) -> List[str]:
+    for clause in predicate["$and"]:
+        if "user_id" in clause:
+            return clause["user_id"]["$in"]
+    raise AssertionError(f"no owner predicate in {predicate}")
+
+
+def test_owner_predicate_is_part_of_the_store_query(captured_filters, strict_auth):
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-owned", "k": 10},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 200
+    assert owners_in(captured_filters[0]) == ["user-1"]
+
+
+def test_query_hides_foreign_file(captured_filters, strict_auth):
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-foreign", "k": 10},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_query_never_authorizes_the_whole_set_from_the_first_hit(
+    captured_filters, strict_auth
+):
+    """file-shared holds one chunk per user; only the caller's may come back."""
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-shared", "k": 10},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 200
+    owners = {hit[0]["metadata"]["user_id"] for hit in response.json()}
+    assert owners == {"user-1"}
+
+
+def test_query_entity_id_cannot_impersonate_another_owner(
+    captured_filters, strict_auth
+):
+    """Naming a victim as entity_id used to authorize the victim's chunks."""
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-foreign", "k": 10, "entity_id": "user-2"},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 403
+    assert captured_filters == []
+
+
+def test_query_permitted_entity_is_scoped_to_that_entity(captured_filters, strict_auth):
+    token = strict_token(subject="user-1", entities=["agent-7"])
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-agent", "k": 10, "entity_id": "agent-7"},
+        headers=bearer(token),
+    )
+    assert response.status_code == 200
+    assert owners_in(captured_filters[0]) == ["agent-7", "user-1"]
+    assert [hit[0]["metadata"]["user_id"] for hit in response.json()] == ["agent-7"]
+
+
+def test_query_multiple_hides_foreign_files(captured_filters, strict_auth):
+    response = client.post(
+        "/query_multiple",
+        json={"query": "q", "file_ids": ["file-foreign"], "k": 10},
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 404
+    assert owners_in(captured_filters[0]) == ["user-1"]
+
+
+def test_query_multiple_returns_only_the_callers_chunks(captured_filters, strict_auth):
+    response = client.post(
+        "/query_multiple",
+        json={
+            "query": "q",
+            "file_ids": ["file-owned", "file-foreign", "file-shared"],
+            "k": 10,
+        },
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 200
+    owners = {hit[0]["metadata"]["user_id"] for hit in response.json()}
+    assert owners == {"user-1"}
+
+
+def test_query_multiple_entity_id_is_authorized_against_the_token(
+    captured_filters, strict_auth
+):
+    response = client.post(
+        "/query_multiple",
+        json={
+            "query": "q",
+            "file_ids": ["file-agent"],
+            "k": 10,
+            "entity_id": "agent-7",
+        },
+        headers=bearer(strict_token(subject="user-1")),
+    )
+    assert response.status_code == 403
+
+
+def test_legacy_token_is_still_scoped_to_its_subject(captured_filters, strict_auth):
+    """Legacy tokens cannot prove entity access, but they are still scoped."""
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-shared", "k": 10},
+        headers=bearer(legacy_token(user_id="user-1")),
+    )
+    assert response.status_code == 200
+    assert owners_in(captured_filters[0]) == ["user-1"]
+    owners = {hit[0]["metadata"]["user_id"] for hit in response.json()}
+    assert owners == {"user-1"}
+
+
+def test_legacy_token_entity_id_never_widens_beyond_two_owners(
+    captured_filters, strict_auth
+):
+    response = client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-shared", "k": 10, "entity_id": "agent-7"},
+        headers=bearer(legacy_token(user_id="user-1")),
+    )
+    assert response.status_code == 200
+    assert owners_in(captured_filters[0]) == ["agent-7", "user-1"]
+    assert "user-2" not in owners_in(captured_filters[0])
+
+
+def test_tenant_claim_does_not_widen_owner_scope(captured_filters, strict_auth):
+    token = strict_token(subject="user-1", tenant=BASE_TENANT)
+    client.post(
+        "/query",
+        json={"query": "q", "file_id": "file-owned", "k": 10},
+        headers=bearer(token),
+    )
+    assert owners_in(captured_filters[0]) == ["user-1"]

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -40,7 +40,16 @@ def limited(monkeypatch):
     )
     monkeypatch.setattr("app.services.embedding.embed_texts", fake.embed_documents)
     monkeypatch.setattr(
-        vector_store, "get_vectors_by_ids", lambda ids, owners: {}, raising=False
+        vector_store,
+        "get_vectors_by_ids",
+        lambda ids, owners, tenants=(None,), executor=None: {},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        vector_store,
+        "probe_candidate_ids",
+        lambda ids, owners, tenants=(None,), executor=None: (set(), set()),
+        raising=False,
     )
     return fake
 

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -97,8 +97,14 @@ def test_tenant_budget_is_enforced_across_subjects(limited):
 
 
 def test_tenants_have_independent_budgets(limited):
-    for _ in range(3):
-        embed(subject="user-1", tenant="tenant-a")
+    """Three distinct subjects, because only served requests spend the budget.
+
+    The tenant limit is 3 and the subject limit is 2, so one subject cannot
+    exhaust the tenant on its own — its third request is rejected by the subject
+    arm and never reaches the tenant counter.
+    """
+    for subject in ("user-1", "user-2", "user-3"):
+        assert embed(subject=subject, tenant="tenant-a").status_code == 200
     assert embed(subject="user-9", tenant="tenant-a").status_code == 429
     assert embed(subject="user-9", tenant="tenant-b").status_code == 200
 
@@ -151,3 +157,50 @@ class TestLimiterUnit:
         assert limiter.check("embed", budget, "t", "s1", now).allowed
         decision = limiter.check("embed", budget, "t", "s2", now)
         assert decision.scope == "tenant"
+
+    def test_a_subject_rejection_does_not_spend_the_tenant_budget(self):
+        """One subject must not be able to deny service to its whole tenant.
+
+        The tenant counter used to increment before the subject arm ran, so a
+        single token could burn every tenant slot on requests that were rejected
+        anyway and lock out every other subject in that tenant.
+        """
+        limiter = ratelimit.FixedWindowLimiter()
+        budget = self._budget(tenant_limit=4, subject_limit=1)
+        now = 1_000_000.0
+
+        assert limiter.check("embed", budget, "t", "noisy", now).allowed
+        for _ in range(20):
+            decision = limiter.check("embed", budget, "t", "noisy", now)
+            assert not decision.allowed
+            assert decision.scope == "subject"
+
+        # Three tenant slots are left: the noisy subject spent exactly one.
+        for quiet in ("s1", "s2", "s3"):
+            assert limiter.check("embed", budget, "t", quiet, now).allowed
+        assert limiter.check("embed", budget, "t", "s4", now).scope == "tenant"
+
+    def test_a_tenant_rejection_does_not_spend_the_subject_budget(self):
+        limiter = ratelimit.FixedWindowLimiter()
+        budget = self._budget(tenant_limit=1, subject_limit=2)
+        now = 1_000_000.0
+
+        assert limiter.check("embed", budget, "t", "s1", now).allowed
+        for _ in range(5):
+            assert limiter.check("embed", budget, "t", "s2", now).scope == "tenant"
+
+        # s2 was never served, so its own budget is untouched in the next window.
+        assert limiter.check("embed", budget, "t", "s2", now + 60).allowed
+        assert limiter.check("embed", budget, "t", "s2", now + 60).scope == "tenant"
+
+
+def test_a_throttled_subject_does_not_lock_out_its_tenant(limited):
+    """End to end: subject limit 2, tenant limit 3, one noisy caller."""
+    assert embed(subject="noisy").status_code == 200
+    assert embed(subject="noisy").status_code == 200
+    for _ in range(10):
+        response = embed(subject="noisy")
+        assert response.status_code == 429
+        assert "subject" in response.json()["detail"]
+
+    assert embed(subject="quiet").status_code == 200

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,144 @@
+"""Per-tenant and per-subject budgets, separate for embedding and rerank."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import auth
+from app.config import vector_store
+from app.services import ratelimit
+from app.services import space as space_module
+from main import app
+from tests.fakes import FakeEmbeddingClient, install_fake_space
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
+
+client = TestClient(app)
+
+SPACE = space_module.CHAT_SPACE_SPEC.name
+
+
+@pytest.fixture
+def limited(monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("RAG_RATE_LIMIT_EMBED_SUBJECT", "2")
+    monkeypatch.setenv("RAG_RATE_LIMIT_EMBED_TENANT", "3")
+    monkeypatch.setenv("RAG_RATE_LIMIT_RERANK_SUBJECT", "5")
+    monkeypatch.setenv("RAG_RATE_LIMIT_RERANK_TENANT", "50")
+    auth.reset_settings()
+    ratelimit.reset()
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+
+    fake = FakeEmbeddingClient(dimensions=2)
+    install_fake_space(monkeypatch, fake)
+    monkeypatch.setattr(
+        "app.services.embedding.get_cached_query_embedding", fake.embed_query
+    )
+    monkeypatch.setattr("app.services.embedding.embed_texts", fake.embed_documents)
+    monkeypatch.setattr(
+        vector_store, "get_vectors_by_ids", lambda ids, owners: {}, raising=False
+    )
+    return fake
+
+
+def embed(subject="user-1", tenant="tenant-a"):
+    return client.post(
+        "/v1/embeddings",
+        json={
+            "space": SPACE,
+            "input_type": "query",
+            "inputs": [{"id": "a", "text": "x"}],
+        },
+        headers=bearer(strict_token(subject=subject, tenant=tenant)),
+    )
+
+
+def do_rerank(subject="user-1", tenant="tenant-a"):
+    return client.post(
+        "/v1/rerank",
+        json={
+            "profile": "fast-v1",
+            "query": "q",
+            "candidates": [{"id": "c1", "text": "t", "base_score": 1.0}],
+        },
+        headers=bearer(strict_token(subject=subject, tenant=tenant)),
+    )
+
+
+def test_subject_budget_is_enforced(limited):
+    assert embed().status_code == 200
+    assert embed().status_code == 200
+    response = embed()
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert "subject" in response.json()["detail"]
+
+
+def test_tenant_budget_is_enforced_across_subjects(limited):
+    assert embed(subject="user-1").status_code == 200
+    assert embed(subject="user-2").status_code == 200
+    assert embed(subject="user-3").status_code == 200
+    response = embed(subject="user-4")
+    assert response.status_code == 429
+    assert "tenant" in response.json()["detail"]
+
+
+def test_tenants_have_independent_budgets(limited):
+    for _ in range(3):
+        embed(subject="user-1", tenant="tenant-a")
+    assert embed(subject="user-9", tenant="tenant-a").status_code == 429
+    assert embed(subject="user-9", tenant="tenant-b").status_code == 200
+
+
+def test_embedding_and_rerank_budgets_are_separate(limited):
+    assert embed().status_code == 200
+    assert embed().status_code == 200
+    assert embed().status_code == 429
+    # The rerank budget is untouched by the exhausted embedding budget.
+    assert do_rerank().status_code == 200
+
+
+def test_disabled_limiter_lets_everything_through(limited, monkeypatch):
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    ratelimit.reset()
+    for _ in range(10):
+        assert embed().status_code == 200
+
+
+class TestLimiterUnit:
+    def _budget(self, tenant_limit=10, subject_limit=2, window=60):
+        return ratelimit.Budget(
+            tenant_limit=tenant_limit,
+            subject_limit=subject_limit,
+            window_seconds=window,
+        )
+
+    def test_counters_reset_in_the_next_window(self):
+        limiter = ratelimit.FixedWindowLimiter()
+        budget = self._budget()
+        now = 1_000_000.0
+        assert limiter.check("embed", budget, "t", "s", now).allowed
+        assert limiter.check("embed", budget, "t", "s", now).allowed
+        assert not limiter.check("embed", budget, "t", "s", now).allowed
+        assert limiter.check("embed", budget, "t", "s", now + 60).allowed
+
+    def test_retry_after_points_at_the_next_window(self):
+        limiter = ratelimit.FixedWindowLimiter()
+        budget = self._budget(subject_limit=1)
+        now = 1_000_000.0
+        limiter.check("embed", budget, "t", "s", now)
+        decision = limiter.check("embed", budget, "t", "s", now + 10)
+        assert not decision.allowed
+        assert 1 <= decision.retry_after <= 60
+
+    def test_the_tenant_arm_is_checked_before_the_subject_arm(self):
+        limiter = ratelimit.FixedWindowLimiter()
+        budget = self._budget(tenant_limit=1, subject_limit=5)
+        now = 1_000_000.0
+        assert limiter.check("embed", budget, "t", "s1", now).allowed
+        decision = limiter.check("embed", budget, "t", "s2", now)
+        assert decision.scope == "tenant"

--- a/tests/test_rerank_endpoint.py
+++ b/tests/test_rerank_endpoint.py
@@ -17,6 +17,7 @@ from app import auth
 from app.config import vector_store
 from app.constants import MAX_RERANK_CANDIDATES, MAX_RERANK_TOP_N
 from app.services import embedding as embedding_service
+from app.services import ratelimit
 from main import app
 from tests.fakes import FakeEmbeddingClient
 from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
@@ -51,27 +52,74 @@ def backend(monkeypatch):
     )
     monkeypatch.setattr("app.services.embedding.embed_texts", fake.embed_documents)
     monkeypatch.setattr(
-        vector_store, "get_vectors_by_ids", lambda ids, owners: {}, raising=False
+        vector_store,
+        "get_vectors_by_ids",
+        lambda ids, owners, tenants=(None,), executor=None: {},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        vector_store,
+        "probe_candidate_ids",
+        lambda ids, owners, tenants=(None,), executor=None: (set(), set()),
+        raising=False,
     )
     return fake
 
 
+class FakeStore:
+    """Store stub that records how it was scoped and answers both lookups.
+
+    ``rows`` maps a candidate id to ``(owner, tenant, vector)`` so the probe and
+    the vector lookup answer from one source of truth, exactly as the database
+    does.
+    """
+
+    def __init__(self):
+        self.rows: Dict[str, tuple] = {}
+        self.probe_calls: List[Dict[str, object]] = []
+        self.vector_calls: List[Dict[str, object]] = []
+
+    def add(self, candidate_id, vector, owner="user-1", tenant="__BASE__"):
+        self.rows[candidate_id] = (owner, tenant, vector)
+
+    def probe_candidate_ids(self, ids, owners, tenants=(None,), executor=None):
+        self.probe_calls.append(
+            {"ids": list(ids), "owners": list(owners), "tenants": list(tenants)}
+        )
+        existing, authorized = set(), set()
+        for candidate_id in ids:
+            if candidate_id not in self.rows:
+                continue
+            owner, tenant, _ = self.rows[candidate_id]
+            existing.add(candidate_id)
+            if owner in owners and tenant in tenants:
+                authorized.add(candidate_id)
+        return existing, authorized
+
+    def get_vectors_by_ids(self, ids, owners, tenants=(None,), executor=None):
+        self.vector_calls.append(
+            {"ids": list(ids), "owners": list(owners), "tenants": list(tenants)}
+        )
+        found = {}
+        for candidate_id in ids:
+            if candidate_id not in self.rows:
+                continue
+            owner, tenant, vector = self.rows[candidate_id]
+            if owner in owners and tenant in tenants:
+                found[candidate_id] = vector
+        return found
+
+
 @pytest.fixture
 def stored(monkeypatch):
-    """Install a store stub and record the (ids, owners) it is queried with."""
-    calls: List[Dict[str, List[str]]] = []
-    contents: Dict[str, List[float]] = {}
-
-    def lookup(ids, owners):
-        calls.append({"ids": list(ids), "owners": list(owners)})
-        return {
-            candidate_id: contents[candidate_id]
-            for candidate_id in ids
-            if candidate_id in contents
-        }
-
-    monkeypatch.setattr(vector_store, "get_vectors_by_ids", lookup, raising=False)
-    return {"calls": calls, "contents": contents}
+    store = FakeStore()
+    monkeypatch.setattr(
+        vector_store, "probe_candidate_ids", store.probe_candidate_ids, raising=False
+    )
+    monkeypatch.setattr(
+        vector_store, "get_vectors_by_ids", store.get_vectors_by_ids, raising=False
+    )
+    return store
 
 
 def rerank(candidates, profile="fast-v1", top_n=None, token=None, query=QUERY):
@@ -201,14 +249,14 @@ def test_unknown_profile_is_rejected(backend):
 
 
 def test_stored_vectors_are_reused_and_only_gaps_are_embedded(backend, stored):
-    stored["contents"]["c-alpha"] = VECTORS["alpha"]
-    stored["contents"]["c-beta"] = VECTORS["beta"]
+    stored.add("c-alpha", VECTORS["alpha"])
+    stored.add("c-beta", VECTORS["beta"])
 
     response = rerank(blended_candidates())
     assert response.status_code == 200
     # Query embed + the one vectorless candidate, and nothing else.
     assert backend.embedded_texts == [QUERY, "gamma"]
-    assert stored["calls"][0]["ids"] == ["c-alpha", "c-beta", "c-gamma"]
+    assert stored.vector_calls[0]["ids"] == ["c-alpha", "c-beta", "c-gamma"]
 
 
 def test_fully_stored_candidates_cost_no_candidate_inference(backend, stored):
@@ -217,7 +265,7 @@ def test_fully_stored_candidates_cost_no_candidate_inference(backend, stored):
         ("c-beta", "beta"),
         ("c-gamma", "gamma"),
     ):
-        stored["contents"][candidate_id] = VECTORS[text]
+        stored.add(candidate_id, VECTORS[text])
 
     assert rerank(blended_candidates()).status_code == 200
     assert backend.embedded_texts == [QUERY]
@@ -226,22 +274,111 @@ def test_fully_stored_candidates_cost_no_candidate_inference(backend, stored):
 def test_stored_lookup_is_scoped_to_the_tokens_owners(backend, stored):
     token = strict_token(subject="user-1", entities=["agent-7", "agent-9"])
     assert rerank(blended_candidates(), token=token).status_code == 200
-    assert stored["calls"][0]["owners"] == ["agent-7", "agent-9", "user-1"]
+    assert stored.vector_calls[0]["owners"] == ["agent-7", "agent-9", "user-1"]
 
 
 def test_stored_lookup_is_scoped_to_the_subject_alone_without_entities(backend, stored):
     assert rerank(blended_candidates()).status_code == 200
-    assert stored["calls"][0]["owners"] == ["user-1"]
+    assert stored.vector_calls[0]["owners"] == ["user-1"]
 
 
-def test_store_failure_degrades_to_inference_rather_than_failing(backend, monkeypatch):
-    def explode(ids, owners):
+def test_lookup_is_scoped_to_the_tokens_tenant(backend, stored):
+    token = strict_token(subject="user-1", tenant="tenant-a")
+    assert rerank(blended_candidates(), token=token).status_code == 200
+    assert stored.vector_calls[0]["tenants"] == ["tenant-a"]
+    assert stored.probe_calls[0]["tenants"] == ["tenant-a"]
+
+
+def test_base_tenant_also_matches_chunks_written_before_tenants_were_recorded(
+    backend, stored
+):
+    assert rerank(blended_candidates()).status_code == 200
+    assert stored.vector_calls[0]["tenants"] == ["__BASE__", None]
+
+
+def test_vector_lookup_failure_degrades_to_inference(backend, stored, monkeypatch):
+    """Losing stored vectors costs inference; it does not lose authorization."""
+
+    def explode(ids, owners, tenants=(None,), executor=None):
         raise RuntimeError("store is down")
 
     monkeypatch.setattr(vector_store, "get_vectors_by_ids", explode, raising=False)
     response = rerank(blended_candidates())
     assert response.status_code == 200
     assert len(response.json()["results"]) == 3
+
+
+class TestAuthorizeBeforeEgress:
+    """No candidate text may reach the gateway before scope is verified."""
+
+    def test_a_foreign_candidate_is_refused_and_nothing_is_embedded(
+        self, backend, stored
+    ):
+        stored.add("c-alpha", VECTORS["alpha"], owner="user-2")
+        response = rerank(blended_candidates())
+        assert response.status_code == 403
+        assert backend.calls == []
+
+    def test_a_cross_tenant_candidate_is_refused_and_nothing_is_embedded(
+        self, backend, stored
+    ):
+        stored.add("c-alpha", VECTORS["alpha"], owner="user-1", tenant="tenant-b")
+        response = rerank(
+            blended_candidates(),
+            token=strict_token(subject="user-1", tenant="tenant-a"),
+        )
+        assert response.status_code == 403
+        assert backend.calls == []
+
+    def test_authorization_runs_before_the_vector_lookup(self, backend, stored):
+        stored.add("c-alpha", VECTORS["alpha"], owner="user-2")
+        assert rerank(blended_candidates()).status_code == 403
+        assert stored.probe_calls != []
+        assert stored.vector_calls == []
+
+    def test_ids_that_match_nothing_in_the_store_are_unaffected(self, backend, stored):
+        candidates = [{"id": "web-scrape-1", "text": "gamma", "base_score": 1.0}]
+        assert rerank(candidates).status_code == 200
+        assert backend.embedded_texts == [QUERY, "gamma"]
+
+    def test_a_digest_shared_with_another_owner_is_still_authorized(
+        self, backend, stored
+    ):
+        """Identical chunk content collides on digest; owning a copy is enough."""
+        stored.add("c-alpha", VECTORS["alpha"], owner="user-1")
+        assert rerank(blended_candidates()).status_code == 200
+
+    def test_probe_failure_fails_closed_rather_than_embedding(
+        self, backend, stored, monkeypatch
+    ):
+        def explode(ids, owners, tenants=(None,), executor=None):
+            raise RuntimeError("store is down")
+
+        monkeypatch.setattr(vector_store, "probe_candidate_ids", explode, raising=False)
+        response = rerank(blended_candidates())
+        assert response.status_code == 503
+        assert backend.calls == []
+        assert "store is down" not in response.text
+
+    def test_unauthorized_requests_never_reach_the_backend(self, backend, stored):
+        no_scope = strict_token(subject="user-1", scopes=["rag:embed"])
+        assert rerank(blended_candidates(), token=no_scope).status_code == 403
+        system = strict_token(subject="user-1", tenant="__SYSTEM__")
+        assert rerank(blended_candidates(), token=system).status_code == 403
+        assert rerank(blended_candidates(), profile="slow-v9").status_code == 400
+        assert backend.calls == []
+        assert stored.probe_calls == []
+
+    def test_rate_limited_requests_never_reach_the_backend(
+        self, backend, stored, monkeypatch
+    ):
+        monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "true")
+        monkeypatch.setenv("RAG_RATE_LIMIT_RERANK_SUBJECT", "1")
+        ratelimit.reset()
+        assert rerank(blended_candidates()).status_code == 200
+        calls_after_first = len(backend.calls)
+        assert rerank(blended_candidates()).status_code == 429
+        assert len(backend.calls) == calls_after_first
 
 
 def test_embedding_backend_failure_returns_503(backend, monkeypatch):

--- a/tests/test_rerank_endpoint.py
+++ b/tests/test_rerank_endpoint.py
@@ -1,0 +1,275 @@
+"""POST /v1/rerank — the fast-v1 embed-blend contract.
+
+Candidate vectors come from storage where they exist; only vectorless
+candidates are embedded. Scores blend cosine similarity with the caller's
+base_score, so ranking is never pure embedding order. No candidate text
+appears in the response or in the logs.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import auth
+from app.config import vector_store
+from app.constants import MAX_RERANK_CANDIDATES, MAX_RERANK_TOP_N
+from app.services import embedding as embedding_service
+from main import app
+from tests.fakes import FakeEmbeddingClient
+from tests.tokens import APP_SECRET, RAG_SECRET, bearer, strict_token
+
+client = TestClient(app)
+
+QUERY = "how do I rotate the signing key"
+
+# Two-dimensional vectors make the cosine order exact and readable.
+VECTORS = {
+    QUERY: [1.0, 0.0],
+    "alpha": [1.0, 0.0],
+    "beta": [0.9, 0.4358898943540674],
+    "gamma": [0.8, 0.6],
+    "delta": [0.0, 1.0],
+}
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    monkeypatch.setenv("RAG_SEARCH_API_ENABLED", "true")
+    monkeypatch.setenv("RAG_JWT_SECRET", RAG_SECRET)
+    monkeypatch.setenv("JWT_SECRET", APP_SECRET)
+    monkeypatch.setenv("RAG_RATE_LIMIT_ENABLED", "false")
+    auth.reset_settings()
+    if getattr(app.state, "thread_pool", None) is None:
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+
+    fake = FakeEmbeddingClient(dimensions=2, vectors=VECTORS)
+    monkeypatch.setattr(
+        "app.services.embedding.get_cached_query_embedding", fake.embed_query
+    )
+    monkeypatch.setattr("app.services.embedding.embed_texts", fake.embed_documents)
+    monkeypatch.setattr(
+        vector_store, "get_vectors_by_ids", lambda ids, owners: {}, raising=False
+    )
+    return fake
+
+
+@pytest.fixture
+def stored(monkeypatch):
+    """Install a store stub and record the (ids, owners) it is queried with."""
+    calls: List[Dict[str, List[str]]] = []
+    contents: Dict[str, List[float]] = {}
+
+    def lookup(ids, owners):
+        calls.append({"ids": list(ids), "owners": list(owners)})
+        return {
+            candidate_id: contents[candidate_id]
+            for candidate_id in ids
+            if candidate_id in contents
+        }
+
+    monkeypatch.setattr(vector_store, "get_vectors_by_ids", lookup, raising=False)
+    return {"calls": calls, "contents": contents}
+
+
+def rerank(candidates, profile="fast-v1", top_n=None, token=None, query=QUERY):
+    body = {"profile": profile, "query": query, "candidates": candidates}
+    if top_n is not None:
+        body["top_n"] = top_n
+    return client.post("/v1/rerank", json=body, headers=bearer(token or strict_token()))
+
+
+def blended_candidates():
+    return [
+        {"id": "c-alpha", "text": "alpha", "base_score": 1.0},
+        {"id": "c-beta", "text": "beta", "base_score": 5.0},
+        {"id": "c-gamma", "text": "gamma", "base_score": 10.0},
+    ]
+
+
+def test_response_shape_matches_the_contract(backend):
+    response = rerank(blended_candidates())
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {"profile", "model", "results"}
+    assert payload["profile"] == "fast-v1"
+    assert payload["model"] == embedding_service.STORE_EMBEDDING_MODEL
+    assert all(set(result) == {"id", "index", "score"} for result in payload["results"])
+
+
+def test_caller_ids_and_request_indices_are_preserved(backend):
+    payload = rerank(blended_candidates()).json()
+    for result in payload["results"]:
+        assert blended_candidates()[result["index"]]["id"] == result["id"]
+
+
+def test_ranking_is_not_pure_embedding_order(backend):
+    """Cosine order here is alpha > beta > gamma; the base scores reverse beta/gamma."""
+    payload = rerank(blended_candidates()).json()
+    assert [result["id"] for result in payload["results"]] == [
+        "c-alpha",
+        "c-gamma",
+        "c-beta",
+    ]
+
+
+def test_exact_ties_order_by_request_position(backend):
+    payload = rerank(blended_candidates()).json()
+    scores = {result["id"]: result["score"] for result in payload["results"]}
+    assert scores["c-alpha"] == scores["c-gamma"]
+    indices = [result["index"] for result in payload["results"]]
+    assert indices[0] < indices[1]
+
+
+def test_repeated_requests_are_identical(backend):
+    first = rerank(blended_candidates()).json()
+    second = rerank(blended_candidates()).json()
+    assert first == second
+
+
+def test_candidate_text_never_appears_in_the_response(backend):
+    response = rerank(
+        [
+            {"id": "c1", "text": "confidential chunk body", "base_score": 1.0},
+            {"id": "c2", "text": "another private passage", "base_score": 2.0},
+        ]
+    )
+    assert response.status_code == 200
+    assert "confidential" not in response.text
+    assert "private" not in response.text
+    assert all(
+        set(result) == {"id", "index", "score"} for result in response.json()["results"]
+    )
+
+
+def test_query_and_candidate_text_never_reach_the_logs(backend, caplog):
+    secret_query = "supersecretquerystring"
+    secret_text = "supersecretcandidatetext"
+    with caplog.at_level(logging.DEBUG):
+        response = rerank(
+            [{"id": "c1", "text": secret_text, "base_score": 1.0}], query=secret_query
+        )
+    assert response.status_code == 200
+    assert secret_query not in caplog.text
+    assert secret_text not in caplog.text
+
+
+def test_top_n_truncates(backend):
+    payload = rerank(blended_candidates(), top_n=2).json()
+    assert len(payload["results"]) == 2
+
+
+def test_top_n_defaults_to_the_candidate_count(backend):
+    payload = rerank(blended_candidates()).json()
+    assert len(payload["results"]) == 3
+
+
+def test_top_n_above_the_cap_is_rejected(backend):
+    response = rerank(blended_candidates(), top_n=MAX_RERANK_TOP_N + 1)
+    assert response.status_code == 422
+
+
+def test_default_top_n_never_exceeds_the_cap(backend):
+    candidates = [
+        {"id": f"c{n}", "text": f"text {n}", "base_score": float(n)}
+        for n in range(MAX_RERANK_CANDIDATES)
+    ]
+    payload = rerank(candidates).json()
+    assert len(payload["results"]) == MAX_RERANK_TOP_N
+
+
+def test_candidate_limit_is_enforced(backend):
+    candidates = [
+        {"id": f"c{n}", "text": "t", "base_score": 1.0}
+        for n in range(MAX_RERANK_CANDIDATES + 1)
+    ]
+    assert rerank(candidates).status_code == 422
+
+
+def test_duplicate_candidate_ids_are_rejected(backend):
+    candidates = [
+        {"id": "same", "text": "alpha", "base_score": 1.0},
+        {"id": "same", "text": "beta", "base_score": 1.0},
+    ]
+    assert rerank(candidates).status_code == 422
+
+
+def test_unknown_profile_is_rejected(backend):
+    assert rerank(blended_candidates(), profile="slow-v9").status_code == 400
+
+
+def test_stored_vectors_are_reused_and_only_gaps_are_embedded(backend, stored):
+    stored["contents"]["c-alpha"] = VECTORS["alpha"]
+    stored["contents"]["c-beta"] = VECTORS["beta"]
+
+    response = rerank(blended_candidates())
+    assert response.status_code == 200
+    # Query embed + the one vectorless candidate, and nothing else.
+    assert backend.embedded_texts == [QUERY, "gamma"]
+    assert stored["calls"][0]["ids"] == ["c-alpha", "c-beta", "c-gamma"]
+
+
+def test_fully_stored_candidates_cost_no_candidate_inference(backend, stored):
+    for candidate_id, text in (
+        ("c-alpha", "alpha"),
+        ("c-beta", "beta"),
+        ("c-gamma", "gamma"),
+    ):
+        stored["contents"][candidate_id] = VECTORS[text]
+
+    assert rerank(blended_candidates()).status_code == 200
+    assert backend.embedded_texts == [QUERY]
+
+
+def test_stored_lookup_is_scoped_to_the_tokens_owners(backend, stored):
+    token = strict_token(subject="user-1", entities=["agent-7", "agent-9"])
+    assert rerank(blended_candidates(), token=token).status_code == 200
+    assert stored["calls"][0]["owners"] == ["agent-7", "agent-9", "user-1"]
+
+
+def test_stored_lookup_is_scoped_to_the_subject_alone_without_entities(backend, stored):
+    assert rerank(blended_candidates()).status_code == 200
+    assert stored["calls"][0]["owners"] == ["user-1"]
+
+
+def test_store_failure_degrades_to_inference_rather_than_failing(backend, monkeypatch):
+    def explode(ids, owners):
+        raise RuntimeError("store is down")
+
+    monkeypatch.setattr(vector_store, "get_vectors_by_ids", explode, raising=False)
+    response = rerank(blended_candidates())
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 3
+
+
+def test_embedding_backend_failure_returns_503(backend, monkeypatch):
+    def explode(text):
+        raise RuntimeError("gateway down")
+
+    monkeypatch.setattr("app.services.embedding.get_cached_query_embedding", explode)
+    response = rerank(blended_candidates())
+    assert response.status_code == 503
+    assert "gateway down" not in response.text
+
+
+def test_candidates_without_text_or_stored_vector_still_rank(backend, stored):
+    candidates = [
+        {"id": "c-alpha", "text": "alpha", "base_score": 3.0},
+        {"id": "c-vectorless", "base_score": 100.0},
+        {"id": "c-gamma", "text": "gamma", "base_score": 1.0},
+    ]
+    payload = rerank(candidates).json()
+    returned = [result["id"] for result in payload["results"]]
+    assert returned == ["c-alpha", "c-vectorless", "c-gamma"]
+    assert backend.embedded_texts == [QUERY, "alpha", "gamma"]
+
+
+def test_base_scores_are_optional(backend):
+    candidates = [
+        {"id": "c-gamma", "text": "gamma"},
+        {"id": "c-alpha", "text": "alpha"},
+    ]
+    payload = rerank(candidates).json()
+    assert [result["id"] for result in payload["results"]] == ["c-alpha", "c-gamma"]

--- a/tests/test_rerank_endpoint.py
+++ b/tests/test_rerank_endpoint.py
@@ -391,6 +391,97 @@ def test_embedding_backend_failure_returns_503(backend, monkeypatch):
     assert "gateway down" not in response.text
 
 
+class TestFailuresAreLoggedWithoutProviderText:
+    """An exception message is provider-controlled and may quote the input.
+
+    The endpoint promises that no query or candidate text is logged. That has to
+    hold on the error paths too, which means logging the exception's class chain
+    rather than its message or a traceback.
+    """
+
+    SECRET_QUERY = "supersecretquerystring"
+    SECRET_TEXT = "supersecretcandidatetext"
+
+    def _candidates(self):
+        return [{"id": "c1", "text": self.SECRET_TEXT, "base_score": 1.0}]
+
+    def _assert_clean(self, caplog, response):
+        assert self.SECRET_QUERY not in caplog.text
+        assert self.SECRET_TEXT not in caplog.text
+        assert self.SECRET_QUERY not in response.text
+        assert self.SECRET_TEXT not in response.text
+
+    def test_a_query_embedding_failure_that_echoes_the_query(
+        self, backend, caplog, monkeypatch
+    ):
+        def explode(text):
+            raise RuntimeError(f"tokenizer rejected: '{text}'")
+
+        monkeypatch.setattr(
+            "app.services.embedding.get_cached_query_embedding", explode
+        )
+        with caplog.at_level(logging.DEBUG):
+            response = rerank(self._candidates(), query=self.SECRET_QUERY)
+        assert response.status_code == 503
+        self._assert_clean(caplog, response)
+        assert "RuntimeError" in caplog.text
+
+    def test_a_candidate_embedding_failure_that_echoes_the_candidate(
+        self, backend, caplog, monkeypatch
+    ):
+        def explode(texts):
+            raise RuntimeError(f"batch rejected: {texts}")
+
+        monkeypatch.setattr("app.services.embedding.embed_texts", explode)
+        with caplog.at_level(logging.DEBUG):
+            response = rerank(self._candidates(), query=self.SECRET_QUERY)
+        assert response.status_code == 503
+        self._assert_clean(caplog, response)
+
+    def test_no_traceback_is_written(self, backend, caplog, monkeypatch):
+        """A traceback carries the frame locals' repr into the log with it."""
+
+        def explode(text):
+            raise RuntimeError("gateway down")
+
+        monkeypatch.setattr(
+            "app.services.embedding.get_cached_query_embedding", explode
+        )
+        with caplog.at_level(logging.DEBUG):
+            assert rerank(self._candidates()).status_code == 503
+        assert "Traceback (most recent call last)" not in caplog.text
+        assert "gateway down" not in caplog.text
+
+    def test_a_store_failure_does_not_log_the_candidate_ids(
+        self, backend, stored, caplog, monkeypatch
+    ):
+        """Driver errors embed the statement parameters, which are caller strings."""
+
+        def explode(ids, owners, tenants=(None,), executor=None):
+            raise RuntimeError(f"could not execute: {list(ids)}")
+
+        monkeypatch.setattr(vector_store, "probe_candidate_ids", explode, raising=False)
+        with caplog.at_level(logging.DEBUG):
+            response = rerank([{"id": "leaky-id-42", "text": "t", "base_score": 1.0}])
+        assert response.status_code == 503
+        assert "leaky-id-42" not in caplog.text
+        assert "could not execute" not in caplog.text
+
+    def test_the_error_category_chain_survives_wrapping(self):
+        from app.routes.search_routes import error_category
+
+        cause = ValueError("provider echoed the input")
+        try:
+            try:
+                raise cause
+            except ValueError as exc:
+                raise RuntimeError("wrapper") from exc
+        except RuntimeError as exc:
+            category = error_category(exc)
+        assert category == "RuntimeError <- ValueError"
+        assert "provider echoed" not in category
+
+
 def test_candidates_without_text_or_stored_vector_still_rank(backend, stored):
     candidates = [
         {"id": "c-alpha", "text": "alpha", "base_score": 3.0},

--- a/tests/test_rerank_endpoint.py
+++ b/tests/test_rerank_endpoint.py
@@ -410,3 +410,11 @@ def test_base_scores_are_optional(backend):
     ]
     payload = rerank(candidates).json()
     assert [result["id"] for result in payload["results"]] == ["c-alpha", "c-gamma"]
+
+
+def test_a_store_that_cannot_be_probed_refuses_rerank(backend, monkeypatch):
+    """There is no unauthenticated fallback path for candidate authorization."""
+    monkeypatch.delattr(vector_store, "probe_candidate_ids", raising=False)
+    response = rerank(blended_candidates())
+    assert response.status_code == 503
+    assert backend.calls == []

--- a/tests/test_rerank_endpoint.py
+++ b/tests/test_rerank_endpoint.py
@@ -15,7 +15,12 @@ from fastapi.testclient import TestClient
 
 from app import auth
 from app.config import vector_store
-from app.constants import MAX_RERANK_CANDIDATES, MAX_RERANK_TOP_N
+from app.constants import (
+    MAX_EMBEDDING_CHARS,
+    MAX_QUERY_CHARS,
+    MAX_RERANK_CANDIDATES,
+    MAX_RERANK_TOP_N,
+)
 from app.services import embedding as embedding_service
 from app.services import ratelimit
 from main import app
@@ -509,3 +514,38 @@ def test_a_store_that_cannot_be_probed_refuses_rerank(backend, monkeypatch):
     response = rerank(blended_candidates())
     assert response.status_code == 503
     assert backend.calls == []
+
+
+class TestTheQueryIsBounded:
+    """The query is embedded on its own, so the candidate budget never covers it.
+
+    Without a limit of its own an authenticated caller hands the gateway an
+    arbitrarily large query and gets the provider's refusal back as a 503 —
+    inference paid for, memory spent, and a server-fault status for a request
+    the service could have rejected.
+    """
+
+    def test_a_query_at_the_limit_is_accepted(self, backend, stored):
+        response = rerank(blended_candidates(), query="q" * MAX_QUERY_CHARS)
+        assert response.status_code == 200
+
+    def test_an_oversized_query_is_rejected(self, backend, stored):
+        response = rerank(blended_candidates(), query="q" * (MAX_QUERY_CHARS + 1))
+        assert response.status_code == 422
+
+    def test_an_oversized_query_never_reaches_the_backend(self, backend, stored):
+        assert (
+            rerank(blended_candidates(), query="q" * (MAX_QUERY_CHARS + 1)).status_code
+            == 422
+        )
+        assert backend.calls == []
+
+    def test_the_bound_holds_even_when_the_candidates_are_tiny(self, backend, stored):
+        """The candidate aggregate is the check the query used to hide behind."""
+        candidates = [{"id": "c-alpha", "text": "a"}]
+        response = rerank(candidates, query="q" * (MAX_EMBEDDING_CHARS - 1))
+        assert response.status_code == 422
+        assert backend.calls == []
+
+    def test_an_empty_query_is_still_rejected(self, backend, stored):
+        assert rerank(blended_candidates(), query="").status_code == 422

--- a/tests/test_upload_isolation.py
+++ b/tests/test_upload_isolation.py
@@ -6,14 +6,20 @@ Validates:
 - _make_unique_temp_path isolates users into separate subdirectories
 - _make_unique_temp_path rejects path traversal filenames
 - generate_digest is consistent for all string inputs including surrogates
+- loader metadata cannot overwrite the identity the writer resolved from the token
 """
 
 import hashlib
 import os
 from pathlib import Path
 import pytest
+from langchain_core.documents import Document
 
-from app.routes.document_routes import _make_unique_temp_path, generate_digest
+from app.routes.document_routes import (
+    _make_unique_temp_path,
+    _prepare_documents_sync,
+    generate_digest,
+)
 
 
 class TestMakeUniqueTempPath:
@@ -86,3 +92,70 @@ class TestGenerateDigest:
     def test_deterministic(self):
         content = "same input"
         assert generate_digest(content) == generate_digest(content)
+
+
+class TestLoaderMetadataCannotOverrideTheWriter:
+    """Document properties are attacker-controlled; the token's identity is not.
+
+    Loaders for several formats preserve embedded document properties verbatim,
+    so an uploaded file can carry a key named ``tenant_id``. Merging that after
+    the resolved values let it replace them and stamp the chunks into another
+    tenant, defeating the write-side tenant boundary that the read predicate
+    depends on.
+    """
+
+    HOSTILE_METADATA = {
+        "file_id": "victim-file",
+        "user_id": "victim-user",
+        "tenant_id": "victim-tenant",
+        "digest": "0" * 32,
+    }
+
+    def _prepare(self, metadata):
+        return _prepare_documents_sync(
+            [Document(page_content="chunk body", metadata=dict(metadata))],
+            file_id="real-file",
+            user_id="real-user",
+            clean_content=False,
+            tenant_id="real-tenant",
+        )
+
+    @pytest.mark.parametrize("key", sorted(HOSTILE_METADATA))
+    def test_a_single_hostile_key_is_overwritten(self, key):
+        prepared = self._prepare({key: self.HOSTILE_METADATA[key]})
+        assert prepared
+        for document in prepared:
+            assert document.metadata[key] != self.HOSTILE_METADATA[key]
+
+    def test_every_trusted_key_wins_at_once(self):
+        prepared = self._prepare(self.HOSTILE_METADATA)
+        assert prepared
+        for document in prepared:
+            assert document.metadata["file_id"] == "real-file"
+            assert document.metadata["user_id"] == "real-user"
+            assert document.metadata["tenant_id"] == "real-tenant"
+            assert document.metadata["digest"] == generate_digest(document.page_content)
+
+    def test_the_write_lands_in_the_writers_tenant_not_the_crafted_one(self):
+        prepared = self._prepare({"tenant_id": "victim-tenant"})
+        assert {document.metadata["tenant_id"] for document in prepared} == {
+            "real-tenant"
+        }
+
+    def test_harmless_loader_metadata_is_still_preserved(self):
+        prepared = self._prepare({"source": "report.pdf", "page": 3})
+        for document in prepared:
+            assert document.metadata["source"] == "report.pdf"
+            assert document.metadata["page"] == 3
+            assert document.metadata["user_id"] == "real-user"
+
+    def test_documents_without_metadata_are_unaffected(self):
+        prepared = _prepare_documents_sync(
+            [Document(page_content="chunk body")],
+            file_id="real-file",
+            user_id="real-user",
+            clean_content=False,
+            tenant_id="real-tenant",
+        )
+        assert prepared[0].metadata["file_id"] == "real-file"
+        assert prepared[0].metadata["tenant_id"] == "real-tenant"

--- a/tests/tokens.py
+++ b/tests/tokens.py
@@ -1,0 +1,62 @@
+"""Token minting helpers shared by the auth and service-endpoint tests."""
+
+import datetime
+from typing import Iterable, Optional
+
+import jwt
+
+# Both secrets are >= 32 chars so they satisfy the startup length check.
+RAG_SECRET = "rag-signing-secret-0123456789abcdef"
+APP_SECRET = "librechat-app-secret-0123456789abcdef"
+
+ISSUER = "librechat"
+AUDIENCE = "rag_api"
+
+BASE_TENANT = "__BASE__"
+SYSTEM_TENANT = "__SYSTEM__"
+
+
+def _exp(seconds: int) -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=seconds
+    )
+
+
+def strict_token(
+    subject: str = "user-1",
+    tenant: Optional[str] = BASE_TENANT,
+    scopes: Optional[Iterable[str]] = ("rag:embed", "rag:rerank"),
+    entities: Iterable[str] = (),
+    secret: str = RAG_SECRET,
+    issuer: Optional[str] = ISSUER,
+    audience: Optional[str] = AUDIENCE,
+    expires_in: int = 300,
+    algorithm: str = "HS256",
+) -> str:
+    claims = {"sub": subject, "exp": _exp(expires_in)}
+    if issuer is not None:
+        claims["iss"] = issuer
+    if audience is not None:
+        claims["aud"] = audience
+    if tenant is not None:
+        claims["tenant"] = tenant
+    if scopes is not None:
+        claims["scopes"] = list(scopes)
+    if entities:
+        claims["entities"] = list(entities)
+    return jwt.encode(claims, secret, algorithm=algorithm)
+
+
+def legacy_token(
+    user_id: str = "user-1",
+    secret: str = APP_SECRET,
+    expires_in: int = 300,
+) -> str:
+    """The ``{ id }`` shape LibreChat's generateShortLivedToken mints today."""
+    return jwt.encode(
+        {"id": user_id, "exp": _exp(expires_in)}, secret, algorithm="HS256"
+    )
+
+
+def bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## Summary

Closes two authorization holes in the retrieval endpoints, then builds two new
service endpoints (`POST /v1/embeddings`, `POST /v1/rerank`) on top of the
fixed authorization model. Also removes the default database credentials that
ship in this repository.

The security fixes stand on their own and are the reason to review this first.

---

## 1. Security fixes

### 1a. `POST /query` authorized a whole result set from the first returned hit

`query_embeddings_by_file_id` ran the vector search filtered by `file_id`
alone, then inspected **`documents[0]`** — the top-ranked hit — and returned
either the entire result list or nothing:

```python
documents = await vector_store.asimilarity_search_with_score_by_vector(
    embedding, k=body.k, filter={"file_id": {"$eq": body.file_id}}, ...
)
document, score = documents[0]
doc_user_id = document.metadata.get("user_id")
if doc_user_id is None or doc_user_id == user_authorized:
    authorized_documents = documents      # every hit, checked or not
```

Two independent defects:

- **Hits 2..k were never checked.** When one `file_id` holds chunks from more
  than one owner, a caller whose own chunk ranks first receives every other
  owner's chunk in the same response. Chunks are stored with `custom_id =
  file_id`, so co-owned `file_id` values are a normal state, not a corrupted
  one.
- **`doc_user_id is None` returned everything.** Any chunk written without
  `user_id` metadata was readable by every caller.

### 1b. `entity_id` was taken as the identity to compare against

The identity the check compared to was chosen from the request body:

```python
user_authorized = body.entity_id if body.entity_id else request.state.user.get("id")
```

`entity_id` is caller-controlled. Sending `{"file_id": "<victim's file>",
"entity_id": "<victim's user id>"}` made `doc_user_id == user_authorized`
true, and the victim's chunks came back verbatim. This required no token
beyond a valid one of the attacker's own — it is a full read of another user's
file content.

### 1c. `POST /query_multiple` had no authorization at all

`query_embeddings_by_file_ids` filtered on `file_id` only and returned the
result set unconditionally. Any authenticated caller who could name (or
enumerate) a `file_id` read its chunks. `GET /ids` returns every `custom_id`
in the store, so the ids were not a secret.

### The fix

Authorization moved into the query predicate, before ranking:

```python
scope = resolve_scope(request, body.entity_id)
query_filter = scope.predicate(file_clause(body.file_id))
documents = await vector_store.asimilarity_search_with_score_by_vector(
    embedding, k=body.k, filter=query_filter, ...
)
return _apply_distance_threshold(documents)
```

- The predicate is `(tenant, owner/entity, file_id)`. An out-of-scope chunk
  cannot rank, cannot be counted against `k`, and is never read out of the
  database — as opposed to being filtered out of a result set afterwards.
- No result-derived authorization remains anywhere. Nothing downstream reads
  `metadata["user_id"]` to decide anything.
- Owner scope comes from the verified token. `entity_id` widens it only when
  the token's `entities` claim names that entity; otherwise the request is
  `403`.
- One builder (`app/scope.py`) produces the predicate for every path —
  `/query`, `/query_multiple`, and the rerank stored-vector lookup — so the
  three cannot drift apart.

### 1d. Authorize before egress

`/v1/rerank` accepts candidate `text` and sends it to an inference provider.
Text that reaches a provider has left the trust boundary whether or not the
caller ever sees a response, so filtering the *response* is not sufficient.

Every candidate id is probed against the store before anything is embedded.
The probe reads metadata only — no vectors, no document text. An id that
exists in the store but resolves to nothing inside the caller's scope makes
the whole request `403` with zero egress. Ids that match nothing (web-scrape
candidates, synthetic ids) are unaffected. If the probe cannot run, the
request fails closed with `503` rather than embedding text it could not check;
there is no store-without-a-probe fallback.

`/v1/embeddings` reads no store at all — it embeds only text the authenticated
caller supplied — and rejects on scope, quota and limits before calling the
backend.

### 1e. Signing-key separation

`JWT_SECRET` verifies tokens minted by the calling application. Before this
change the same secret was the only key, so a token minted for this service
was simultaneously a full session token for the caller's own API, and vice
versa — the confusion runs in both directions.

`RAG_JWT_SECRET` is now a dedicated key for this service, and startup refuses
to proceed if it equals `JWT_SECRET`. The `/v1` endpoints accept **only**
`RAG_JWT_SECRET`-signed tokens, in every mode: a captured application session
token cannot reach them, whatever claims it carries.

### 1f. Raw exception text in 500 responses

The database-facing routes returned `detail=str(e)`. SQLAlchemy and driver
errors can carry connection details, so they now return a fixed message and
log the exception server-side.

### 1g. The document plane and the inference plane are separate capabilities

`GET /ids`, `GET /documents`, `GET /documents/{id}/context` and
`DELETE /documents` read or delete stored chunks. None of them calls an
inference provider. But the strict-token vocabulary offered only `rag:embed`
and `rag:rerank`, and a strict token carrying no scope at all is refused — so a
caller that needed nothing but a delete had to ask for `rag:embed`, and the
resulting credential also carried the ability to spend embedding budget.
Least-privilege in name only.

Those four routes now require `rag:documents`, and the scopes do not substitute
for each other in either direction:

| Scope | Grants |
| --- | --- |
| `rag:embed` | `POST /v1/embeddings` |
| `rag:rerank` | `POST /v1/rerank` |
| `rag:documents` | `GET /ids`, `GET /documents`, `GET /documents/{id}/context`, `DELETE /documents` |

A `rag:embed` token reaches no document route; a `rag:documents` token is
refused by both `/v1` endpoints. A leaked delete credential therefore cannot be
replayed against an inference provider, and a leaked embedding credential
cannot read or destroy stored content.

The refusal is a `403` raised before the store is touched, so it says nothing
about whether a file exists — the `404`-not-`403` rule for out-of-scope reads
is unchanged, as is the scope inside the `DELETE` predicate. Legacy
`{"id": userId}` tokens predate every scope and are grandfathered into this one
exactly as into the others. Deployments with no signing key configured have no
principal to check and are unchanged.

### Test evidence

`tests/test_query_authorization.py` (19 tests) routes the endpoint through a
store that **evaluates the metadata filter the route actually builds**, so a
route that stops putting scope into the predicate fails rather than passing on
a post-hoc check. Checked out against the pre-fix `document_routes.py`, 10 of
the original 11 fail; against the fix, all pass.

`tests/integration/test_query_authorization_pg.py` (18 tests) writes through
the real pgvector path and lets PostgreSQL execute the predicate: foreign
files return nothing, each user sees only their own side of a co-owned
`file_id`, `entity_id` impersonation is `403`, tenants do not see each other,
and uploaded chunks are stamped with the writer's owner and tenant.

`tests/test_rerank_endpoint.py::TestAuthorizeBeforeEgress` and
`tests/integration/test_rerank_pg.py::TestRerankOverStoredVectors` assert the
egress rule directly — the fake and real embedders record every call, and the
assertions are that the call list is *empty* on every rejection path.

`tests/test_auth.py` covers the key-separation matrix, including a session
token failing against `/v1/embeddings` both with and without full claims.

`tests/test_document_authorization.py::TestThePlanesAreSeparable` drives both
planes against one another: a `rag:documents` token reaches all four document
routes and is `403` on both `/v1` endpoints, a `rag:embed` token embeds
successfully and is `403` on all four document routes, and legacy tokens still
reach both. Checked out against the pre-fix routes, the three tests asserting
that an inference scope reaches no document route fail; the rest pass either
way, which is what makes them the control.

Totals: **481 unit tests, 80 integration tests** (pgvector via testcontainers),
all passing. The integration fixtures skip cleanly when no container runtime is
reachable.

---

## 2. Residual risk during the legacy-token transition

**This is not closed by this PR and needs to be understood before deploying.**

A legacy `{"id": userId}` token carries no `entities` claim. This service
therefore cannot distinguish a legitimate agent id from a victim's user id in
`entity_id`, and while `RAG_AUTH_ACCEPT_LEGACY=true` it takes the caller's
`entity_id` at face value — so **1b is mitigated but not eliminated for legacy
tokens**: the blast radius drops from "any file, any owner" to "the owner named
in `entity_id`, and only for chunks the caller also names by `file_id`", but a
caller can still reach another owner's chunks by naming them.

What the flag being `true` does buy immediately, for every caller including
legacy ones:

- hits 2..k are scoped (1a is fully closed)
- `user_id is None` no longer returns everything (1a is fully closed)
- `/query_multiple` is scoped at all (1c is fully closed)

Flipping `RAG_AUTH_ACCEPT_LEGACY=false` eliminates the remainder, and requires
callers to mint the full claim set first. Startup logs a warning for as long as
the flag is true, and
`test_legacy_entity_id_is_still_trusted_until_the_flag_flips` pins both the
residual behaviour and the fact that flipping the flag ends it.

---

## 3. New endpoints

```text
POST /v1/embeddings
{ "space": "chat-v1", "input_type": "query" | "document",
  "inputs": [{ "id": "...", "text": "..." }] }
-> { "space", "model", "dimensions", "normalized",
     "items": [{ "id", "content_hash", "embedding" }], "usage" }

POST /v1/rerank
{ "profile": "fast-v1", "query": "...",
  "candidates": [{ "id", "text", "base_score" }], "top_n": 25 }
-> { "profile", "model", "results": [{ "id", "index", "score" }] }
```

Enabled by `RAG_SEARCH_API_ENABLED=true` (default `false`). Scopes:
`rag:embed` and `rag:rerank`. Neither accepts `rag:documents` — see §1g.

Limits: 64 inputs and 256,000 aggregate characters per embeddings call; 50
candidates and `top_n <= 25` per rerank call. Caller ids are preserved. Tie
ordering is deterministic — ties break on the candidate's position in the
request, so identical input always produces identical output.

`content_hash` is the SHA-256 of the NFKC-normalized, whitespace-collapsed text
that was actually embedded, which lets a caller detect that stored text has
drifted from its stored vector.

Vectors leave the service L2-normalized. This is load-bearing rather than
cosmetic: the provider used in testing returns unnormalized vectors (measured
norms ≈ 67–71), so a caller assuming unit vectors and using a dot product as
cosine similarity would be silently wrong.

The `chat-v1` space is substitution-locked. If its backend fails, or returns a
different dimensionality than the space declares, the call is `503` — never a
quiet fall back to another model, another width, or the file-search space. A
model swap behind an OpenAI-compatible endpoint is invisible in the response
body, so the width check is the only thing that catches it.

Neither endpoint returns candidate text, and neither logs query or candidate
text — only lengths and non-reversible fingerprints. The
`RequestValidationError` handler no longer logs raw input values, and no longer
500s when a custom field validator puts a `ValueError` in `ctx` (it was not
JSON-serializable).

### `fast-v1` embed-blend

The query is embedded once through the retrieval cache, so a rerank that
follows a `/query` on the same query string pays no query inference at all.
Candidate vectors are read from the pgvector store wherever they already exist
— scoped to the caller — and only vectorless candidates are embedded. On the
file-search path that is zero candidate inference.

The score is reciprocal-rank fusion of cosine similarity with the caller's
`base_score`, never pure embedding order. Bi-encoder similarity alone regresses
identifier and exact-match queries, where the retrieval score is the better
signal; fusing the two arms keeps the semantic gain without discarding it.
`RAG_RERANK_RRF_K` (default 60) and the two arm weights are configurable. An
arm with no usable values is dropped rather than contributing a constant, so a
fully vectorless call degrades to the caller's own order instead of shuffling
it.

Candidate ids resolve against the stored row's `uuid` or the chunk `digest` in
its metadata. `custom_id` is the file id and is shared by every chunk of a
file, so it identifies no single vector; `digest` is the handle a caller
already holds from a `/query` response.

Measured cost of the in-process scoring, 50 candidates × 1024 dimensions:
p50 2.3 ms, p95 2.6 ms.

### Rate limiting

Per tenant and per subject, with separate embedding and rerank budgets so a
rerank burst cannot starve the interactive query-embedding path. Counters are
process-local, which a multi-pod deployment should read as `limit × pods`; they
are sized as a safety valve, not a billing control.

---

## 4. Tenant scope

Retrieval is scoped by `(tenant, owner/entity, file_id)`. Chunks now record the
writing caller's `tenant_id` alongside `user_id`.

Chunks written before `tenant_id` existed carry no value and normalize to the
base tenant `__BASE__`, so a single-tenant deployment reads them exactly as
before while a named tenant never absorbs untagged content. This is implemented
by teaching the pgvector filter builder MongoDB's `$in: [null]` semantic —
match null **or absent** — rather than dropping the null and silently narrowing
the filter, so both backends behave identically.

Writes are scoped too: uploading under an `entity_id` the token does not permit
is `403`, so a caller cannot plant content in a knowledge base it cannot read.

---

## 5. Credentials

`POSTGRES_DB`, `POSTGRES_USER` and `POSTGRES_PASSWORD` no longer have working
defaults. A default that works is the problem, not the convenience: a database
brought up with credentials that are public in this repository is reachable by
anyone who can route to it.

- `app/config.py` requires them when `VECTOR_DB_TYPE=pgvector`, and refuses to
  start otherwise (`POSTGRES_PASSWORD` may be empty only under
  `POSTGRES_USE_UNIX_SOCKET=True`, where peer authentication carries none).
- `docker-compose.yaml` and `db-compose.yaml` use `${VAR:?}`, so
  `docker compose up` fails loudly rather than starting a database with a
  known password.
- `.env.example` ships `REPLACE_ME_*` placeholders and is the documented
  starting point.
- `tests/test_credentials.py` scans every tracked file and fails if a default
  credential reappears anywhere.

There is no fallback path for the signing configuration either: with
`RAG_SEARCH_API_ENABLED=true` and no `RAG_JWT_SECRET`, startup raises. No key
is generated or defaulted, and secrets appear in no log line or error message.

---

## Breaking changes

1. **`POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` are required.**
   Deployments relying on the previous defaults must set them. This is
   deliberate — see §5.
2. **Chunks with no `user_id` in metadata are no longer readable.** They were
   readable by everyone (§1a); re-embed them if they are still needed.
3. **`/query` and `/query_multiple` return only the caller's own chunks.** A
   caller that was relying on reading another owner's chunks through a shared
   `file_id` will see fewer results. That is the fix.
4. **`atlas-mongo` deployments** must declare `user_id` and `tenant_id` as
   filter fields on the Atlas vector index, since the owner and tenant
   predicates are now part of the vector-search filter.
5. **The file-addressed document routes require `rag:documents`.** Strict
   tokens minted for them before the scope existed carried `rag:embed` — the
   smallest set that satisfied the non-empty-scopes rule — and are now `403`.
   Mint `rag:documents` for calls that read or delete stored chunks and keep
   `rag:embed` for the ones that actually embed. Legacy `{"id": userId}` tokens
   are unaffected while `RAG_AUTH_ACCEPT_LEGACY` is true.

## Migration

`RAG_AUTH_ACCEPT_LEGACY` defaults to `true`, so existing `{"id": userId}`
tokens keep working and no caller breaks on deploy. Order of operations:

1. Deploy this change with `RAG_AUTH_ACCEPT_LEGACY=true` and a
   `RAG_JWT_SECRET` distinct from `JWT_SECRET`.
2. Update every caller that mints a token for this service to emit the full
   claim set — `iss`, `aud`, `sub`, `exp`, a tenant claim, `scopes`, and
   `entities` for any agent-scoped file access — signed with
   `RAG_JWT_SECRET`. In the LibreChat integration this is
   `generateShortLivedToken` plus its six call sites (file search, vector
   CRUD, context handlers, RAG delete, text parsing), which must move together
   because they share one helper.
3. Set `RAG_AUTH_ACCEPT_LEGACY=false`. This closes the residual risk in §2 and
   is the point at which `entity_id` becomes verifiable.

### Ordering for the `rag:documents` requirement

Step 2 above and this build are coupled, and the coupling is asymmetric:

- **Callers first, then this build — safe.** A service build that does not yet
  enforce `rag:documents` never inspects the scope on those routes, so a token
  carrying it is simply accepted. The unknown scope is inert.
- **This build first, then callers — breaks.** This build refuses a token that
  still carries only `rag:embed`, so every document read and delete returns
  `403` until the callers catch up.

Roll the minting change out first, or deploy both together. The LibreChat side
is `danny-avila/LibreChat#14692`.

## Verification

```bash
pytest                  # 335 unit tests
pytest -m integration   # 54 integration tests (pgvector via testcontainers)
```

Integration fixtures skip rather than error when no container runtime is
reachable. An optional live check against a real OpenAI-compatible endpoint
runs only when `RAG_GATEWAY_TEST_BASEURL` and `RAG_GATEWAY_TEST_API_KEY` are
set.

