### PR TITLE
🔒 fix: scope every document read and delete by owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,79 @@ The API will evolve over time to employ different querying/re-ranking methods, e
 - **Vector Store**: Utilizes Langchain's vector store for efficient document retrieval.
 - **Asynchronous Support**: Offers async operations for enhanced performance.
 
+## Retrieval scope
+
+Chunks are owned. Every route that reads or removes stored content resolves the
+caller's owner set from the verified token and puts it into the store query
+*before* ranking, so a chunk outside that set is never read into the process.
+The owner set is built in one place — `app/scope.py` — rather than re-derived per
+route.
+
+Before this release these routes addressed the store by caller-supplied
+`file_id` alone, or authorized a whole result set from the first hit returned:
+
+- `GET /ids` listed every file id in the deployment.
+- `POST /query_multiple` performed no authorization at all, so pairing it with
+  `GET /ids` disclosed the content of every file to any authenticated caller.
+- `POST /query` authorized the whole result set from `documents[0]`, so any hit
+  behind the first was never checked. A `file_id` is chosen by whoever uploads,
+  so an attacker's own row ranking first authorized the rows behind it.
+- `GET /documents`, `GET /documents/{id}/context` and `DELETE /documents` read or
+  deleted the chunks of any file id the caller could name.
+- A chunk with no recorded `user_id` read as "belongs to everyone".
+- On the synchronous store path, a failed ingestion rolled back by `file_id`
+  alone, so an upload under someone else's file id destroyed their chunks. The
+  async pgvector pipeline already scopes its rollback to the ingestion attempt.
+
+**What changes for callers.** A caller reads and deletes only what it owns. A
+file id outside the caller's scope answers "not found" rather than "found but
+refused", so none of these routes is an existence oracle. Chunks with no
+`user_id` are owned by nobody and are no longer readable — if a deployment holds
+such rows and still needs them, stamp an owner on them before upgrading:
+
+```sql
+UPDATE langchain_pg_embedding
+SET cmetadata = jsonb_set(cmetadata, '{user_id}', '"<owner>"')
+WHERE cmetadata->>'user_id' IS NULL;
+```
+
+`atlas-mongo` deployments must add `user_id` to the vector search index first;
+see [Use Atlas MongoDB as Vector Database](#use-atlas-mongodb-as-vector-database).
+
+**Deleting entity-owned files requires `entity_id`.** Chunks embedded under an
+`entity_id` — an agent knowledge base, for instance — are owned by that entity
+rather than by the uploading user, so `DELETE /documents` needs the same
+`entity_id` that the upload used, as a query parameter alongside the JSON body of
+file ids. A delete that omits it resolves to the caller's own scope, matches
+nothing, and answers 404 with the chunks left in place. Because a 404 is
+indistinguishable from "already deleted", a caller that treats it as success will
+orphan those chunks silently.
+
+**Upgrade the client first.** Deploy order matters, in one direction only:
+
+- A client that sends `entity_id` against an *older* build is inert — the
+  parameter is simply undeclared there, so the request behaves exactly as before.
+- An *older* client against this build orphans every agent knowledge-base file it
+  tries to delete.
+
+So upgrade the client first, or both together — never this service first.
+LibreChat carries the matching change: it records the owner each embed was made
+under and sends it on delete, with `npm run migrate:embed-owners` to backfill
+files embedded before that.
+
+**`entity_id` is unchanged and still caller-asserted.** Agent knowledge bases are
+owned by an agent id rather than a user id, so a caller reading one names it via
+`entity_id`. That id now *widens* the owner set rather than replacing the
+caller's identity — the caller's own scope always remains — but nothing in a
+token minted today proves the caller may act for the entity it names. A caller
+that knows another owner's id can still name it — on read, to reach that owner's
+chunks, and on the ingestion routes, where `entity_id` is what gets stamped as the
+owner, to write into that owner's namespace. Deployments exposing this API to
+untrusted callers must continue to authorize entity access upstream. Closing this
+requires the token to carry the entity authorization, which is a coordinated
+change with the callers that mint those tokens and is tracked separately from
+this release.
+
 ## Setup
 
 ### Getting Started
@@ -201,12 +274,22 @@ The `ATLAS_MONGO_DB_URI` could be the same or different from what is used by Lib
     {
       "path": "file_id",
       "type": "filter"
+    },
+    {
+      "path": "user_id",
+      "type": "filter"
     }
   ]
 }
 ```
 
 Follow one of the [four documented methods](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#procedure) to create the vector index.
+
+> **Upgrading an existing Atlas deployment:** `user_id` is a required filter field
+> as of the release described under [Retrieval scope](#retrieval-scope). Retrieval
+> now filters on it, and Atlas Vector Search rejects a `$vectorSearch` pre-filter on
+> a path the index does not declare — so add it to the index definition **before**
+> deploying, or `/query` and `/query_multiple` will start returning errors.
 
 #### Create a `file_id` Index (recommended)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ SET cmetadata = jsonb_set(cmetadata, '{user_id}', '"<owner>"')
 WHERE cmetadata->>'user_id' IS NULL;
 ```
 
+**If this deployment ever ran without `JWT_SECRET`, check for `public` too.** With
+no signing key configured there is no caller identity to record, so every chunk
+written in that period is owned by the literal string `public`. Once a signing
+key is set, callers arrive with their own ids and none of them owns `public`, so
+that content stops being readable. Routes other than `/query` returned it to
+everybody before this release, which is exactly the hole being closed — but if
+the content is still wanted, give it a real owner first:
+
+```sql
+-- inspect before rewriting: this is content nobody was ever identified as owning
+SELECT count(*) FROM langchain_pg_embedding WHERE cmetadata->>'user_id' = 'public';
+```
+
+Deployments that never set `JWT_SECRET` are unaffected: with no key configured
+the read scope is `public` as well, so what was written is what is read.
+
 `atlas-mongo` deployments must add `user_id` to the vector search index first;
 see [Use Atlas MongoDB as Vector Database](#use-atlas-mongodb-as-vector-database).
 

--- a/app/models.py
+++ b/app/models.py
@@ -42,3 +42,4 @@ class QueryMultipleBody(BaseModel):
     query: str
     file_ids: List[str]
     k: int = 4
+    entity_id: Optional[str] = None

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -487,14 +487,12 @@ async def delete_documents(
 ):
     scope = resolve_scope(request, entity_id)
     try:
+        # Resolve existence within the caller's scope *before* deleting anything.
+        # A request mixing owned and unknown ids would otherwise destroy the owned
+        # rows and still answer 404, leaving the caller to believe nothing went.
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
                 document_ids,
-                owners=scope.owners,
-                executor=request.app.state.thread_pool,
-            )
-            await vector_store.delete_scoped(
-                ids=document_ids,
                 owners=scope.owners,
                 executor=request.app.state.thread_pool,
             )
@@ -502,10 +500,18 @@ async def delete_documents(
             existing_ids = vector_store.get_filtered_ids(
                 document_ids, owners=scope.owners
             )
-            vector_store.delete_scoped(ids=document_ids, owners=scope.owners)
 
         if not all(id in existing_ids for id in document_ids):
             raise HTTPException(status_code=404, detail="One or more IDs not found")
+
+        if isinstance(vector_store, AsyncPgVector):
+            await vector_store.delete_scoped(
+                ids=document_ids,
+                owners=scope.owners,
+                executor=request.app.state.thread_pool,
+            )
+        else:
+            vector_store.delete_scoped(ids=document_ids, owners=scope.owners)
 
         file_count = len(document_ids)
         return {

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -45,6 +45,7 @@ from app.config import (
     PARALLEL_EXECUTION,
     RAG_DISTANCE_THRESHOLD,
 )
+from app.scope import file_clause, files_clause, resolve_scope
 
 # Warn once at import time if the user set a threshold under Atlas, where
 # the score direction is inverted (Atlas vectorSearchScore: higher = better)
@@ -390,12 +391,15 @@ async def cleanup_temp_file_async(file_path: str) -> None:
 
 
 @router.get("/ids")
-async def get_all_ids(request: Request):
+async def get_all_ids(request: Request, entity_id: str = None):
+    scope = resolve_scope(request, entity_id)
     try:
         if isinstance(vector_store, AsyncPgVector):
-            ids = await vector_store.get_all_ids(executor=request.app.state.thread_pool)
+            ids = await vector_store.get_all_ids(
+                owners=scope.owners, executor=request.app.state.thread_pool
+            )
         else:
-            ids = vector_store.get_all_ids()
+            ids = vector_store.get_all_ids(owners=scope.owners)
 
         return list(set(ids))
     except HTTPException as http_exc:
@@ -432,20 +436,24 @@ async def health_check():
 
 
 @router.get("/documents", response_model=list[DocumentResponse])
-async def get_documents_by_ids(request: Request, ids: list[str] = Query(...)):
+async def get_documents_by_ids(
+    request: Request, ids: list[str] = Query(...), entity_id: str = None
+):
+    scope = resolve_scope(request, entity_id)
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners=scope.owners, executor=request.app.state.thread_pool
             )
             documents = await vector_store.get_documents_by_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners=scope.owners, executor=request.app.state.thread_pool
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(ids)
-            documents = vector_store.get_documents_by_ids(ids)
+            existing_ids = vector_store.get_filtered_ids(ids, owners=scope.owners)
+            documents = vector_store.get_documents_by_ids(ids, owners=scope.owners)
 
-        # Ensure all requested ids exist
+        # A file outside the caller's scope reads as absent rather than refused,
+        # so this route is not an existence oracle over the deployment.
         if not all(id in existing_ids for id in ids):
             raise HTTPException(status_code=404, detail="One or more IDs not found")
 
@@ -474,18 +482,27 @@ async def get_documents_by_ids(request: Request, ids: list[str] = Query(...)):
 
 
 @router.delete("/documents")
-async def delete_documents(request: Request, document_ids: List[str] = Body(...)):
+async def delete_documents(
+    request: Request, document_ids: List[str] = Body(...), entity_id: str = None
+):
+    scope = resolve_scope(request, entity_id)
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                document_ids, executor=request.app.state.thread_pool
+                document_ids,
+                owners=scope.owners,
+                executor=request.app.state.thread_pool,
             )
-            await vector_store.delete(
-                ids=document_ids, executor=request.app.state.thread_pool
+            await vector_store.delete_scoped(
+                ids=document_ids,
+                owners=scope.owners,
+                executor=request.app.state.thread_pool,
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(document_ids)
-            vector_store.delete(ids=document_ids)
+            existing_ids = vector_store.get_filtered_ids(
+                document_ids, owners=scope.owners
+            )
+            vector_store.delete_scoped(ids=document_ids, owners=scope.owners)
 
         if not all(id in existing_ids for id in document_ids):
             raise HTTPException(status_code=404, detail="One or more IDs not found")
@@ -522,62 +539,25 @@ async def query_embeddings_by_file_id(
     body: QueryRequestBody,
     request: Request,
 ):
-    if not hasattr(request.state, "user"):
-        user_authorized = body.entity_id if body.entity_id else "public"
-    else:
-        user_authorized = (
-            body.entity_id if body.entity_id else request.state.user.get("id")
-        )
-
-    authorized_documents = []
+    scope = resolve_scope(request, body.entity_id)
 
     try:
         embedding = get_cached_query_embedding(body.query)
+        query_filter = scope.predicate(file_clause(body.file_id))
 
         if isinstance(vector_store, AsyncPgVector):
             documents = await vector_store.asimilarity_search_with_score_by_vector(
                 embedding,
                 k=body.k,
-                filter={"file_id": {"$eq": body.file_id}},
+                filter=query_filter,
                 executor=request.app.state.thread_pool,
             )
         else:
             documents = vector_store.similarity_search_with_score_by_vector(
-                embedding, k=body.k, filter={"file_id": {"$eq": body.file_id}}
+                embedding, k=body.k, filter=query_filter
             )
 
-        documents = _apply_distance_threshold(documents)
-
-        if not documents:
-            return authorized_documents
-
-        document, score = documents[0]
-        doc_metadata = document.metadata
-        doc_user_id = doc_metadata.get("user_id")
-
-        if doc_user_id is None or doc_user_id == user_authorized:
-            authorized_documents = documents
-        else:
-            # If using entity_id and access denied, try again with user's actual ID
-            if body.entity_id and hasattr(request.state, "user"):
-                user_authorized = request.state.user.get("id")
-                if doc_user_id == user_authorized:
-                    authorized_documents = documents
-                else:
-                    if body.entity_id == doc_user_id:
-                        logger.warning(
-                            f"Entity ID {body.entity_id} matches document user_id but user {user_authorized} is not authorized"
-                        )
-                    else:
-                        logger.warning(
-                            f"Access denied for both entity ID {body.entity_id} and user {user_authorized} to document with user_id {doc_user_id}"
-                        )
-            else:
-                logger.warning(
-                    f"Unauthorized access attempt by user {user_authorized} to a document with user_id {doc_user_id}"
-                )
-
-        return authorized_documents
+        return _apply_distance_threshold(documents)
 
     except HTTPException as http_exc:
         logger.error(
@@ -872,6 +852,7 @@ async def _process_documents_async_pipeline(
 async def _process_documents_batched_sync(
     documents: List[Document],
     file_id: str,
+    user_id: str,
     vector_store: Union["PgVector", "AtlasMongoVector"],
     executor: "ThreadPoolExecutor",
 ) -> List[str]:
@@ -881,6 +862,7 @@ async def _process_documents_batched_sync(
     Args:
         documents: List of Document objects to process
         file_id: Unique identifier for the file being processed
+        user_id: Owner of the chunks being written; scopes the rollback
         vector_store: Synchronous vector store instance (ExtendedPgVector or AtlasMongoVector)
         executor: ThreadPoolExecutor for running sync operations
 
@@ -938,7 +920,10 @@ async def _process_documents_batched_sync(
                 logger.warning("Rolling back file %s due to batch failure", file_id)
                 try:
                     await loop.run_in_executor(
-                        executor, lambda: vector_store.delete(ids=[file_id])
+                        executor,
+                        lambda: vector_store.delete_scoped(
+                            ids=[file_id], owners=[user_id]
+                        ),
                     )
                     logger.info("Rollback completed for file %s", file_id)
                 except Exception as rollback_error:
@@ -1054,7 +1039,7 @@ async def store_data_in_vector_db(
             else:
                 # Fallback to batched processing for sync vector stores
                 ids = await _process_documents_batched_sync(
-                    docs, file_id, vector_store, executor
+                    docs, file_id, user_id, vector_store, executor
                 )
 
         logger.info(
@@ -1319,21 +1304,23 @@ async def embed_file(
 
 
 @router.get("/documents/{id}/context")
-async def load_document_context(request: Request, id: str):
+async def load_document_context(request: Request, id: str, entity_id: str = None):
     ids = [id]
+    scope = resolve_scope(request, entity_id)
     try:
         if isinstance(vector_store, AsyncPgVector):
             existing_ids = await vector_store.get_filtered_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners=scope.owners, executor=request.app.state.thread_pool
             )
             documents = await vector_store.get_documents_by_ids(
-                ids, executor=request.app.state.thread_pool
+                ids, owners=scope.owners, executor=request.app.state.thread_pool
             )
         else:
-            existing_ids = vector_store.get_filtered_ids(ids)
-            documents = vector_store.get_documents_by_ids(ids)
+            existing_ids = vector_store.get_filtered_ids(ids, owners=scope.owners)
+            documents = vector_store.get_documents_by_ids(ids, owners=scope.owners)
 
-        # Ensure the requested id exists
+        # A file outside the caller's scope reads as absent rather than refused,
+        # so this route is not an existence oracle over the deployment.
         if not all(id in existing_ids for id in ids):
             raise HTTPException(
                 status_code=404, detail="The specified file_id was not found"
@@ -1464,21 +1451,23 @@ async def embed_file_upload(
 
 @router.post("/query_multiple")
 async def query_embeddings_by_file_ids(request: Request, body: QueryMultipleBody):
+    scope = resolve_scope(request, body.entity_id)
     try:
         # Get the embedding of the query text
         embedding = get_cached_query_embedding(body.query)
+        query_filter = scope.predicate(files_clause(body.file_ids))
 
         # Perform similarity search with the query embedding and filter by the file_ids in metadata
         if isinstance(vector_store, AsyncPgVector):
             documents = await vector_store.asimilarity_search_with_score_by_vector(
                 embedding,
                 k=body.k,
-                filter={"file_id": {"$in": body.file_ids}},
+                filter=query_filter,
                 executor=request.app.state.thread_pool,
             )
         else:
             documents = vector_store.similarity_search_with_score_by_vector(
-                embedding, k=body.k, filter={"file_id": {"$in": body.file_ids}}
+                embedding, k=body.k, filter=query_filter
             )
 
         documents = _apply_distance_threshold(documents)

--- a/app/scope.py
+++ b/app/scope.py
@@ -1,0 +1,83 @@
+"""The one place a request's scope becomes a store predicate.
+
+Files and their chunks are owner-scoped and carry raw content, so scope is
+enforced structurally rather than remembered by each caller. Every route that
+reads or removes stored content builds its predicate from :class:`ScopeFilter`.
+Drift between hand-written scope clauses is the realistic failure mode; one
+builder makes it impossible rather than merely reviewable.
+
+The predicate is always ``(owner, file)`` and always goes into the store query
+*before* ranking. Nothing downstream re-derives authorization from what the
+store returned.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from fastapi import Request
+
+PUBLIC_OWNER = "public"
+
+OWNER_METADATA_KEY = "user_id"
+
+
+@dataclass(frozen=True)
+class ScopeFilter:
+    """The owners a request may read, as a store-query clause."""
+
+    owners: Tuple[str, ...]
+
+    def owner_clause(self) -> Dict[str, Any]:
+        return {OWNER_METADATA_KEY: {"$in": list(self.owners)}}
+
+    def predicate(self, *clauses: Dict[str, Any]) -> Dict[str, Any]:
+        """Combine caller clauses (e.g. file id) with the owner clause."""
+        return {"$and": [*clauses, self.owner_clause()]}
+
+    def owns(self, owner: Optional[str]) -> bool:
+        """Whether a stored row's recorded owner falls inside this scope.
+
+        A row with no recorded owner is *not* in scope. Before this release an
+        absent ``user_id`` read as "belongs to everyone", which made any such
+        chunk readable by every caller.
+        """
+        return owner in self.owners
+
+
+def file_clause(file_id: str) -> Dict[str, Any]:
+    return {"file_id": {"$eq": file_id}}
+
+
+def files_clause(file_ids: Sequence[str]) -> Dict[str, Any]:
+    return {"file_id": {"$in": list(file_ids)}}
+
+
+def resolve_scope(request: Request, entity_id: Optional[str] = None) -> ScopeFilter:
+    """Resolve the owners this request may read.
+
+    The caller's own identity always comes from the verified token — never from
+    the query string, the body, or the rows the store returned.
+
+    A caller-supplied ``entity_id`` *widens* the owner set rather than replacing
+    it, which is the change that closes the read paths below. It remains
+    caller-asserted: this release does not yet carry a claim that proves the
+    caller may act for that entity, so a deployment that exposes this API to
+    untrusted callers must still authorize entity access upstream. See
+    ``README.md``.
+    """
+    user = getattr(request.state, "user", None)
+
+    if user is None:
+        # No signing key configured anywhere: preserve the unauthenticated
+        # deployment's single-owner behaviour rather than opening the store.
+        return ScopeFilter(owners=(entity_id or PUBLIC_OWNER,))
+
+    owners = {user.get("id") or PUBLIC_OWNER}
+    if entity_id:
+        owners.add(entity_id)
+
+    return ScopeFilter(owners=tuple(sorted(owners)))
+
+
+def scope_owners(scope: ScopeFilter) -> List[str]:
+    return list(scope.owners)

--- a/app/services/vector_store/async_pg_vector.py
+++ b/app/services/vector_store/async_pg_vector.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, List, Tuple, Dict, Any, TypeVar
+from typing import Callable, Optional, List, Sequence, Tuple, Dict, Any, TypeVar
 import asyncio
 from concurrent.futures import Executor
 from langchain_core.documents import Document
@@ -44,19 +44,31 @@ class AsyncPgVector(ExtendedPgVector):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, wrapper)
 
-    async def get_all_ids(self, executor=None) -> list[str]:
+    async def get_all_ids(self, owners: Sequence[str], executor=None) -> list[str]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_all_ids)
+        return await self._run_in_executor(executor, super().get_all_ids, owners)
 
-    async def get_filtered_ids(self, ids: list[str], executor=None) -> list[str]:
+    async def get_filtered_ids(
+        self, ids: Sequence[str], owners: Sequence[str], executor=None
+    ) -> list[str]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_filtered_ids, ids)
+        return await self._run_in_executor(
+            executor, super().get_filtered_ids, ids, owners
+        )
 
     async def get_documents_by_ids(
-        self, ids: list[str], executor=None
+        self, ids: Sequence[str], owners: Sequence[str], executor=None
     ) -> list[Document]:
         executor = executor or self._get_thread_pool()
-        return await self._run_in_executor(executor, super().get_documents_by_ids, ids)
+        return await self._run_in_executor(
+            executor, super().get_documents_by_ids, ids, owners
+        )
+
+    async def delete_scoped(
+        self, ids: Sequence[str], owners: Sequence[str], executor=None
+    ) -> None:
+        executor = executor or self._get_thread_pool()
+        await self._run_in_executor(executor, super().delete_scoped, ids, owners)
 
     async def delete(
         self,

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -1,6 +1,6 @@
 import copy
 import hashlib
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_mongodb import MongoDBAtlasVectorSearch
@@ -54,16 +54,44 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
             processed_documents.append((new_document, score))
         return processed_documents
 
-    def get_all_ids(self) -> list[str]:
-        # Return unique file_id fields in self._collection
-        return self._collection.distinct("file_id")
+    @staticmethod
+    def _owner_clause(owners: Sequence[str]) -> dict:
+        return {"user_id": {"$in": list(dict.fromkeys(owners))}}
 
-    def get_filtered_ids(self, ids: list[str]) -> list[str]:
-        # Return unique file_id fields filtered by the provided ids
-        return self._collection.distinct("file_id", {"file_id": {"$in": ids}})
+    def _file_scope_clause(self, ids: Sequence[str], owners: Sequence[str]) -> dict:
+        """``(file id, owner)`` for the file-addressed routes.
 
-    def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
-        # Return documents filtered by file_id
+        Scope is a required argument rather than an optional one: a
+        caller-supplied file id is not an authorization.
+        """
+        return {
+            "file_id": {"$in": list(dict.fromkeys(ids))},
+            **self._owner_clause(owners),
+        }
+
+    def get_all_ids(self, owners: Sequence[str]) -> list[str]:
+        """File ids this caller owns — never the deployment's whole set."""
+        allowed = list(dict.fromkeys(owners))
+        if not allowed:
+            return []
+        return self._collection.distinct("file_id", self._owner_clause(allowed))
+
+    def get_filtered_ids(self, ids: Sequence[str], owners: Sequence[str]) -> list[str]:
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return []
+        return self._collection.distinct(
+            "file_id", self._file_scope_clause(wanted, allowed)
+        )
+
+    def get_documents_by_ids(
+        self, ids: Sequence[str], owners: Sequence[str]
+    ) -> list[Document]:
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return []
         return [
             Document(
                 page_content=doc["text"],
@@ -75,8 +103,21 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
                     "page": int(doc.get("page", 0)),
                 },
             )
-            for doc in self._collection.find({"file_id": {"$in": ids}})
+            for doc in self._collection.find(self._file_scope_clause(wanted, allowed))
         ]
+
+    def delete_scoped(self, ids: Sequence[str], owners: Sequence[str]) -> None:
+        """Delete the chunks of ``ids`` that ``owners`` actually own.
+
+        A file id is caller-supplied and not unique across owners, so the delete
+        carries the scope in its own predicate rather than trusting a separate
+        existence check.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return
+        self._collection.delete_many(self._file_scope_clause(wanted, allowed))
 
     def delete(self, ids: Optional[list[str]] = None) -> None:
         # Delete documents by file_id

--- a/app/services/vector_store/extended_pg_vector.py
+++ b/app/services/vector_store/extended_pg_vector.py
@@ -1,7 +1,8 @@
 import os
 import time
 import logging
-from typing import Optional, Any, Dict, List, Union
+from typing import Optional, Any, Dict, List, Sequence, Union
+import sqlalchemy
 from sqlalchemy import event
 from sqlalchemy import delete
 from sqlalchemy.orm import Session
@@ -172,30 +173,101 @@ class ExtendedPgVector(PGVector):
 
         return super()._handle_field_filter(field, value)
 
-    def get_all_ids(self) -> list[str]:
-        with Session(self._bind) as session:
-            results = session.query(self.EmbeddingStore.custom_id).all()
-            return [result[0] for result in results if result[0] is not None]
+    def _collection_clause(self, session: Session):
+        """Restrict a query to the collection this store serves, or ``None``.
 
-    def get_filtered_ids(self, ids: list[str]) -> list[str]:
-        with Session(self._bind) as session:
-            query = session.query(self.EmbeddingStore.custom_id).filter(
-                self.EmbeddingStore.custom_id.in_(ids)
-            )
-            results = query.all()
-            return [result[0] for result in results if result[0] is not None]
+        ``langchain_pg_embedding`` is shared by every collection in the
+        database, so a lookup that omits ``collection_id`` can read a row this
+        store does not serve. ``None`` means the collection has not been created
+        yet, which is indistinguishable from it holding no rows.
+        """
+        collection = self.get_collection(session)
+        if collection is None:
+            return None
+        return self.EmbeddingStore.collection_id == collection.uuid
 
-    def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
+    def _owner_clause(self, owners: Sequence[str]):
+        return self.EmbeddingStore.cmetadata["user_id"].astext.in_(list(owners))
+
+    def _file_scope_clause(
+        self, session: Session, ids: Sequence[str], owners: Sequence[str]
+    ):
+        """``(collection, file id, owner)`` for the file-addressed routes.
+
+        ``None`` means this store's collection does not exist yet, which is
+        indistinguishable from it holding no rows.
+        """
+        collection_clause = self._collection_clause(session)
+        if collection_clause is None:
+            return None
+        return sqlalchemy.and_(
+            collection_clause,
+            self.EmbeddingStore.custom_id.in_(list(ids)),
+            self._owner_clause(owners),
+        )
+
+    def get_all_ids(self, owners: Sequence[str]) -> list[str]:
+        """File ids this caller owns — never the deployment's whole set."""
+        allowed = list(dict.fromkeys(owners))
+        if not allowed:
+            return []
         with Session(self._bind) as session:
+            collection_clause = self._collection_clause(session)
+            if collection_clause is None:
+                return []
             results = (
-                session.query(self.EmbeddingStore)
-                .filter(self.EmbeddingStore.custom_id.in_(ids))
+                session.query(self.EmbeddingStore.custom_id)
+                .filter(collection_clause)
+                .filter(self._owner_clause(allowed))
+                .distinct()
                 .all()
             )
+            return [result[0] for result in results if result[0] is not None]
+
+    def get_filtered_ids(self, ids: Sequence[str], owners: Sequence[str]) -> list[str]:
+        """Which of ``ids`` exist inside ``owners``.
+
+        Scope is a required argument rather than an optional one: a
+        caller-supplied file id is not an authorization, and an existence answer
+        computed without the owner predicate is an oracle over every file in the
+        deployment.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return []
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed)
+            if file_clause is None:
+                return []
+            results = (
+                session.query(self.EmbeddingStore.custom_id)
+                .filter(file_clause)
+                .distinct()
+                .all()
+            )
+            return [result[0] for result in results if result[0] is not None]
+
+    def get_documents_by_ids(
+        self, ids: Sequence[str], owners: Sequence[str]
+    ) -> list[Document]:
+        """Chunks of ``ids`` owned by ``owners``.
+
+        The scope goes into the SQL predicate, so a foreign chunk is never read
+        into this process rather than being filtered out after the fact.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return []
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed)
+            if file_clause is None:
+                return []
+            results = session.query(self.EmbeddingStore).filter(file_clause).all()
             return [
                 Document(page_content=result.document, metadata=result.cmetadata or {})
                 for result in results
-                if result.custom_id in ids
             ]
 
     def _delete_by_metadata(self, metadata_filter: Dict[str, Any]) -> None:
@@ -216,6 +288,24 @@ class ExtendedPgVector(PGVector):
                 stmt = stmt.where(self._handle_field_filter(field, value))
 
             session.execute(stmt)
+            session.commit()
+
+    def delete_scoped(self, ids: Sequence[str], owners: Sequence[str]) -> None:
+        """Delete the chunks of ``ids`` that ``owners`` actually own.
+
+        A file id is caller-supplied and not unique across owners — anyone may
+        upload under a chosen ``file_id`` — so the DELETE carries the scope in
+        its own predicate rather than trusting a separate existence check.
+        """
+        wanted = list(dict.fromkeys(ids))
+        allowed = list(dict.fromkeys(owners))
+        if not wanted or not allowed:
+            return
+        with Session(self._bind) as session:
+            file_clause = self._file_scope_clause(session, wanted, allowed)
+            if file_clause is None:
+                return
+            session.execute(delete(self.EmbeddingStore).where(file_clause))
             session.commit()
 
     def _delete_multiple(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,14 +27,14 @@ from langchain_core.documents import Document
 
 
 class DummyVectorStore:
-    def get_all_ids(self) -> list[str]:
+    def get_all_ids(self, owners=None) -> list[str]:
         return ["testid1", "testid2"]
 
-    def get_filtered_ids(self, ids) -> list[str]:
+    def get_filtered_ids(self, ids, owners=None) -> list[str]:
         dummy_ids = ["testid1", "testid2"]
         return [id for id in dummy_ids if id in ids]
 
-    async def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
+    async def get_documents_by_ids(self, ids: list[str], owners=None) -> list[Document]:
         return [
             Document(page_content="Test content", metadata={"file_id": id})
             for id in ids
@@ -57,6 +57,9 @@ class DummyVectorStore:
         return ids
 
     async def delete(self, ids=None, collection_only: bool = False):
+        return None
+
+    async def delete_scoped(self, ids=None, owners=None):
         return None
 
     # Implement the missing as_retriever() method

--- a/tests/integration/test_authorization_pg.py
+++ b/tests/integration/test_authorization_pg.py
@@ -1,0 +1,330 @@
+"""Integration tests: the owner predicate holds against a real pgvector database.
+
+Every test here corresponds to a hole that was open before this change. They run
+against a real PostgreSQL+pgvector container and a real ``ExtendedPgVector``, so
+what is proven is the SQL that ships — not a double's idea of it.
+
+Run with:  pytest tests/integration/ -m integration -v
+"""
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.scope import ScopeFilter, file_clause, files_clause
+from app.services.vector_store.extended_pg_vector import ExtendedPgVector
+
+pytestmark = pytest.mark.integration
+
+VICTIM = "victim-user"
+ATTACKER = "attacker-user"
+AGENT = "agent-abc"
+
+
+def _seed(conn, collection_id, *, file_id, owner, count=3, prefix="chunk"):
+    """Insert ``count`` chunks of ``file_id`` owned by ``owner``.
+
+    ``owner=None`` writes a row with no ``user_id`` at all — the shape that read
+    as "belongs to everyone" before this change.
+    """
+    metadata = {"file_id": file_id}
+    if owner is not None:
+        metadata["user_id"] = owner
+    for i in range(count):
+        conn.execute(
+            text(
+                "INSERT INTO langchain_pg_embedding "
+                "(collection_id, embedding, document, cmetadata, custom_id) "
+                "VALUES (:cid, :emb, :doc, :meta, :cust)"
+            ),
+            {
+                "cid": collection_id,
+                "emb": f"[{0.1 * (i + 1)},{0.2 * (i + 1)},{0.3 * (i + 1)}]",
+                "doc": f"{prefix}-{owner}-{i}",
+                "meta": json.dumps({**metadata, "index": i}),
+                "cust": file_id,
+            },
+        )
+
+
+@pytest.fixture()
+def store(engine):
+    from langchain_community.vectorstores.pgvector import (
+        _get_embedding_collection_store,
+    )
+
+    class TestableStore(ExtendedPgVector):
+        def __init__(self):
+            self._bind = engine
+            EmbeddingStore, CollectionStore = _get_embedding_collection_store(
+                vector_dimension=3, use_jsonb=True
+            )
+            self.EmbeddingStore = EmbeddingStore
+            self.CollectionStore = CollectionStore
+            self.collection_name = "test_collection"
+            self.collection_metadata = None
+
+    return TestableStore()
+
+
+@pytest.fixture()
+def two_owners(engine, collection_id):
+    """Victim and attacker each hold a distinct file; ids are returned."""
+    victim_file = f"file-victim-{uuid.uuid4().hex[:8]}"
+    attacker_file = f"file-attacker-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        _seed(conn, collection_id, file_id=victim_file, owner=VICTIM, prefix="secret")
+        _seed(conn, collection_id, file_id=attacker_file, owner=ATTACKER)
+    yield victim_file, attacker_file
+    with engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM langchain_pg_embedding WHERE custom_id = ANY(:ids)"),
+            {"ids": [victim_file, attacker_file]},
+        )
+
+
+def test_get_all_ids_returns_only_the_callers_files(store, two_owners):
+    """``GET /ids`` listed every file in the deployment, which is how an
+    attacker discovered the file ids to then read."""
+    victim_file, attacker_file = two_owners
+
+    ids = store.get_all_ids(owners=[ATTACKER])
+
+    assert attacker_file in ids
+    assert victim_file not in ids
+
+
+def test_get_filtered_ids_is_not_an_existence_oracle(store, two_owners):
+    """Naming a foreign file id answered "it exists"."""
+    victim_file, _ = two_owners
+
+    assert store.get_filtered_ids([victim_file], owners=[ATTACKER]) == []
+    assert store.get_filtered_ids([victim_file], owners=[VICTIM]) == [victim_file]
+
+
+def test_get_documents_by_ids_refuses_foreign_content(store, two_owners):
+    """``GET /documents`` and ``/documents/{id}/context`` returned the chunks of
+    any file id the caller could name."""
+    victim_file, _ = two_owners
+
+    assert store.get_documents_by_ids([victim_file], owners=[ATTACKER]) == []
+
+    owned = store.get_documents_by_ids([victim_file], owners=[VICTIM])
+    assert len(owned) == 3
+    assert all("secret" in doc.page_content for doc in owned)
+
+
+def test_delete_scoped_cannot_remove_foreign_chunks(store, two_owners, engine):
+    """``DELETE /documents`` deleted by file id alone, so naming a victim's file
+    id destroyed their chunks."""
+    victim_file, _ = two_owners
+
+    store.delete_scoped([victim_file], owners=[ATTACKER])
+
+    with engine.begin() as conn:
+        surviving = conn.execute(
+            text("SELECT count(*) FROM langchain_pg_embedding WHERE custom_id = :fid"),
+            {"fid": victim_file},
+        ).scalar()
+    assert surviving == 3
+
+    store.delete_scoped([victim_file], owners=[VICTIM])
+    with engine.begin() as conn:
+        remaining = conn.execute(
+            text("SELECT count(*) FROM langchain_pg_embedding WHERE custom_id = :fid"),
+            {"fid": victim_file},
+        ).scalar()
+    assert remaining == 0
+
+
+def test_one_file_id_held_by_two_owners_stays_separated(store, engine, collection_id):
+    """A file id is chosen by whoever uploads, so two owners can hold rows under
+    the same id. Each may read only their own."""
+    shared_id = f"file-collision-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        _seed(conn, collection_id, file_id=shared_id, owner=VICTIM, prefix="victim")
+        _seed(conn, collection_id, file_id=shared_id, owner=ATTACKER, prefix="attacker")
+
+    try:
+        victim_docs = store.get_documents_by_ids([shared_id], owners=[VICTIM])
+        attacker_docs = store.get_documents_by_ids([shared_id], owners=[ATTACKER])
+
+        assert len(victim_docs) == 3
+        assert len(attacker_docs) == 3
+        assert all("victim" in doc.page_content for doc in victim_docs)
+        assert all("attacker" in doc.page_content for doc in attacker_docs)
+
+        store.delete_scoped([shared_id], owners=[ATTACKER])
+        assert len(store.get_documents_by_ids([shared_id], owners=[VICTIM])) == 3
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = :fid"),
+                {"fid": shared_id},
+            )
+
+
+def test_chunks_with_no_owner_are_not_readable_by_anyone(store, engine, collection_id):
+    """An absent ``user_id`` read as "belongs to everyone", so any such chunk was
+    readable by every caller. It is now owned by nobody instead."""
+    orphan_file = f"file-orphan-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        _seed(conn, collection_id, file_id=orphan_file, owner=None)
+
+    try:
+        assert store.get_documents_by_ids([orphan_file], owners=[ATTACKER]) == []
+        assert store.get_documents_by_ids([orphan_file], owners=[VICTIM]) == []
+        assert store.get_all_ids(owners=[ATTACKER]) == [] or (
+            orphan_file not in store.get_all_ids(owners=[ATTACKER])
+        )
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = :fid"),
+                {"fid": orphan_file},
+            )
+
+
+def test_empty_owner_set_reads_nothing(store, two_owners):
+    """A scope with no owners must not degrade into "no filter"."""
+    victim_file, attacker_file = two_owners
+
+    assert store.get_all_ids(owners=[]) == []
+    assert store.get_filtered_ids([victim_file, attacker_file], owners=[]) == []
+    assert store.get_documents_by_ids([victim_file, attacker_file], owners=[]) == []
+
+
+def test_scope_predicate_filters_ranked_search(store, engine, collection_id):
+    """``/query`` authorized a whole result set from ``documents[0]``, so any hit
+    past the first was never checked. The predicate now runs before ranking.
+    """
+    shared_id = f"file-ranked-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        # Attacker's row sorts nearest the probe vector, so under the old
+        # first-hit check it would authorize the victim's rows behind it.
+        _seed(
+            conn,
+            collection_id,
+            file_id=shared_id,
+            owner=ATTACKER,
+            count=1,
+            prefix="attacker",
+        )
+        _seed(conn, collection_id, file_id=shared_id, owner=VICTIM, prefix="victim")
+
+    try:
+        scope = ScopeFilter(owners=(ATTACKER,))
+        clause = store._create_filter_clause(scope.predicate(file_clause(shared_id)))
+
+        with Session(engine) as session:
+            rows = (
+                session.query(store.EmbeddingStore.document)
+                .filter(store.EmbeddingStore.collection_id == collection_id)
+                .filter(clause)
+                .all()
+            )
+
+        documents = [row[0] for row in rows]
+        assert documents
+        assert all("attacker" in doc for doc in documents)
+        assert not any("victim" in doc for doc in documents)
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = :fid"),
+                {"fid": shared_id},
+            )
+
+
+def test_entity_id_widens_rather_than_replaces_the_owner(store, engine, collection_id):
+    """An agent knowledge base is owned by the agent id, so a caller reading it
+    must reach both owners — and only those two."""
+    own_file = f"file-own-{uuid.uuid4().hex[:8]}"
+    agent_file = f"file-agent-{uuid.uuid4().hex[:8]}"
+    victim_file = f"file-victim-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        _seed(conn, collection_id, file_id=own_file, owner=ATTACKER)
+        _seed(conn, collection_id, file_id=agent_file, owner=AGENT)
+        _seed(conn, collection_id, file_id=victim_file, owner=VICTIM)
+
+    try:
+        scope = ScopeFilter(owners=tuple(sorted({ATTACKER, AGENT})))
+        ids = store.get_filtered_ids(
+            [own_file, agent_file, victim_file], owners=scope.owners
+        )
+
+        assert set(ids) == {own_file, agent_file}
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = ANY(:ids)"),
+                {"ids": [own_file, agent_file, victim_file]},
+            )
+
+
+def test_multi_file_query_predicate_drops_foreign_files(store, engine, collection_id):
+    """``/query_multiple`` performed no authorization at all: every file id the
+    caller listed was searched and returned."""
+    mine = f"file-mine-{uuid.uuid4().hex[:8]}"
+    theirs = f"file-theirs-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        _seed(conn, collection_id, file_id=mine, owner=ATTACKER, prefix="mine")
+        _seed(conn, collection_id, file_id=theirs, owner=VICTIM, prefix="theirs")
+
+    try:
+        scope = ScopeFilter(owners=(ATTACKER,))
+        clause = store._create_filter_clause(
+            scope.predicate(files_clause([mine, theirs]))
+        )
+
+        with Session(engine) as session:
+            rows = (
+                session.query(store.EmbeddingStore.document)
+                .filter(store.EmbeddingStore.collection_id == collection_id)
+                .filter(clause)
+                .all()
+            )
+
+        documents = [row[0] for row in rows]
+        assert documents
+        assert all("mine" in doc for doc in documents)
+        assert not any("theirs" in doc for doc in documents)
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = ANY(:ids)"),
+                {"ids": [mine, theirs]},
+            )
+
+
+def test_sibling_collection_rows_are_not_visible(store, engine, collection_id):
+    """``langchain_pg_embedding`` is shared by every collection, so a lookup that
+    omitted ``collection_id`` could read rows this store does not serve."""
+    other_file = f"file-other-collection-{uuid.uuid4().hex[:8]}"
+    with engine.begin() as conn:
+        other_collection = conn.execute(
+            text(
+                "INSERT INTO langchain_pg_collection (name, cmetadata) "
+                "VALUES (:name, :meta) RETURNING uuid"
+            ),
+            {"name": f"other-{uuid.uuid4().hex[:8]}", "meta": "{}"},
+        ).fetchone()[0]
+        _seed(conn, collection_id=other_collection, file_id=other_file, owner=ATTACKER)
+
+    try:
+        assert store.get_filtered_ids([other_file], owners=[ATTACKER]) == []
+        assert store.get_documents_by_ids([other_file], owners=[ATTACKER]) == []
+        assert other_file not in store.get_all_ids(owners=[ATTACKER])
+    finally:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM langchain_pg_embedding WHERE custom_id = :fid"),
+                {"fid": other_file},
+            )
+            conn.execute(
+                text("DELETE FROM langchain_pg_collection WHERE uuid = :cid"),
+                {"cid": other_collection},
+            )

--- a/tests/services/test_async_pg_vector.py
+++ b/tests/services/test_async_pg_vector.py
@@ -25,8 +25,8 @@ async def test_get_all_ids_dispatches_to_super(store):
     with patch.object(
         ExtendedPgVector, "get_all_ids", return_value=["id1", "id2"]
     ) as mock:
-        result = await store.get_all_ids()
-    mock.assert_called_once_with()
+        result = await store.get_all_ids(owners=["u1"])
+    mock.assert_called_once_with(["u1"])
     assert result == ["id1", "id2"]
 
 
@@ -35,8 +35,8 @@ async def test_get_filtered_ids_passes_ids(store):
     with patch.object(
         ExtendedPgVector, "get_filtered_ids", return_value=["id1"]
     ) as mock:
-        result = await store.get_filtered_ids(["id1", "id2"])
-    mock.assert_called_once_with(["id1", "id2"])
+        result = await store.get_filtered_ids(["id1", "id2"], owners=["u1"])
+    mock.assert_called_once_with(["id1", "id2"], ["u1"])
     assert result == ["id1"]
 
 
@@ -46,8 +46,8 @@ async def test_get_documents_by_ids_passes_ids(store):
     with patch.object(
         ExtendedPgVector, "get_documents_by_ids", return_value=docs
     ) as mock:
-        result = await store.get_documents_by_ids(["id1"])
-    mock.assert_called_once_with(["id1"])
+        result = await store.get_documents_by_ids(["id1"], owners=["u1"])
+    mock.assert_called_once_with(["id1"], ["u1"])
     assert result == docs
 
 
@@ -95,9 +95,9 @@ async def test_aadd_documents_passes_args(store):
 async def test_run_in_executor_converts_stop_iteration(store):
     """StopIteration can't be set on an asyncio.Future — verify it becomes RuntimeError."""
 
-    def raises_stop():
+    def raises_stop(*args):
         raise StopIteration("exhausted")
 
     with patch.object(ExtendedPgVector, "get_all_ids", side_effect=raises_stop):
         with pytest.raises(RuntimeError):
-            await store.get_all_ids()
+            await store.get_all_ids(owners=["u1"])

--- a/tests/services/test_atlas_mongo_vector.py
+++ b/tests/services/test_atlas_mongo_vector.py
@@ -1,0 +1,174 @@
+"""The owner predicate holds on the atlas-mongo store too.
+
+There is no Atlas instance in CI, so the collection here is a small in-memory
+double that *evaluates* the filter documents rather than recording them: the
+thing under test is the predicate each method builds, and a double that only
+asserted on call arguments would pass just as happily against a filter that
+selects the wrong rows.
+
+The vector search path is covered by asserting the `pre_filter` handed to Atlas,
+since scoring is Atlas's own and cannot be reproduced here.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from app.scope import ScopeFilter, file_clause
+from app.services.vector_store.atlas_mongo_vector import AtlasMongoVector
+
+VICTIM = "victim-user"
+ATTACKER = "attacker-user"
+AGENT = "agent-abc"
+
+
+def _matches(document: Dict[str, Any], query: Dict[str, Any]) -> bool:
+    """Evaluate the subset of the query language these methods use."""
+    for field, condition in query.items():
+        if field == "$and":
+            if not all(_matches(document, clause) for clause in condition):
+                return False
+            continue
+        value = document.get(field)
+        if isinstance(condition, dict):
+            if "$in" in condition and value not in condition["$in"]:
+                return False
+            if "$eq" in condition and value != condition["$eq"]:
+                return False
+        elif value != condition:
+            return False
+    return True
+
+
+class FakeCollection:
+    """Enough of a pymongo collection for the store's four scoped methods."""
+
+    def __init__(self, documents: List[Dict[str, Any]]):
+        self.documents = list(documents)
+
+    def distinct(self, field: str, query: Optional[Dict[str, Any]] = None) -> List[str]:
+        query = query or {}
+        seen = []
+        for document in self.documents:
+            if not _matches(document, query):
+                continue
+            value = document.get(field)
+            if value is not None and value not in seen:
+                seen.append(value)
+        return seen
+
+    def find(self, query: Optional[Dict[str, Any]] = None):
+        query = query or {}
+        return [d for d in self.documents if _matches(d, query)]
+
+    def delete_many(self, query: Dict[str, Any]) -> None:
+        self.documents = [d for d in self.documents if not _matches(d, query)]
+
+
+def _chunk(file_id: str, owner: Optional[str], text: str) -> Dict[str, Any]:
+    document = {
+        "file_id": file_id,
+        "text": text,
+        "digest": f"digest-{text}",
+        "source": "test",
+        "page": 0,
+    }
+    if owner is not None:
+        document["user_id"] = owner
+    return document
+
+
+@pytest.fixture()
+def store():
+    instance = AtlasMongoVector.__new__(AtlasMongoVector)
+    instance._collection = FakeCollection(
+        [
+            _chunk("file-victim", VICTIM, "victim secret"),
+            _chunk("file-attacker", ATTACKER, "attacker note"),
+            _chunk("file-agent", AGENT, "agent knowledge"),
+            # One caller-chosen file id held by two owners.
+            _chunk("file-shared", ATTACKER, "attacker own row"),
+            _chunk("file-shared", VICTIM, "victim hidden row"),
+            # Written before owners were recorded.
+            _chunk("file-orphan", None, "unowned row"),
+        ]
+    )
+    return instance
+
+
+def test_get_all_ids_returns_only_the_callers_files(store):
+    assert sorted(store.get_all_ids(owners=[ATTACKER])) == [
+        "file-attacker",
+        "file-shared",
+    ]
+
+
+def test_get_filtered_ids_is_not_an_existence_oracle(store):
+    assert store.get_filtered_ids(["file-victim"], owners=[ATTACKER]) == []
+    assert store.get_filtered_ids(["file-victim"], owners=[VICTIM]) == ["file-victim"]
+
+
+def test_get_documents_by_ids_refuses_foreign_content(store):
+    assert store.get_documents_by_ids(["file-victim"], owners=[ATTACKER]) == []
+
+    owned = store.get_documents_by_ids(["file-victim"], owners=[VICTIM])
+    assert [document.page_content for document in owned] == ["victim secret"]
+
+
+def test_one_file_id_held_by_two_owners_stays_separated(store):
+    attacker_docs = store.get_documents_by_ids(["file-shared"], owners=[ATTACKER])
+    victim_docs = store.get_documents_by_ids(["file-shared"], owners=[VICTIM])
+
+    assert [d.page_content for d in attacker_docs] == ["attacker own row"]
+    assert [d.page_content for d in victim_docs] == ["victim hidden row"]
+
+
+def test_delete_scoped_cannot_remove_foreign_chunks(store):
+    store.delete_scoped(["file-victim"], owners=[ATTACKER])
+    assert store.get_documents_by_ids(["file-victim"], owners=[VICTIM]) != []
+
+    store.delete_scoped(["file-shared"], owners=[ATTACKER])
+    assert store.get_documents_by_ids(["file-shared"], owners=[ATTACKER]) == []
+    # The other owner's rows under the same file id survive.
+    assert store.get_documents_by_ids(["file-shared"], owners=[VICTIM]) != []
+
+
+def test_chunks_with_no_owner_are_not_readable_by_anyone(store):
+    assert store.get_documents_by_ids(["file-orphan"], owners=[ATTACKER]) == []
+    assert store.get_documents_by_ids(["file-orphan"], owners=[VICTIM]) == []
+    assert "file-orphan" not in store.get_all_ids(owners=[ATTACKER])
+
+
+def test_empty_owner_set_reads_nothing(store):
+    """A scope with no owners must not degrade into "no filter"."""
+    assert store.get_all_ids(owners=[]) == []
+    assert store.get_filtered_ids(["file-victim"], owners=[]) == []
+    assert store.get_documents_by_ids(["file-victim"], owners=[]) == []
+
+    store.delete_scoped(["file-victim"], owners=[])
+    assert store.get_documents_by_ids(["file-victim"], owners=[VICTIM]) != []
+
+
+def test_vector_search_sends_the_owner_clause_as_a_pre_filter(store, monkeypatch):
+    """Atlas applies `pre_filter` inside `$vectorSearch`, so the owner clause has
+    to reach it — scoring the whole file and trimming afterwards would both leak
+    and consume `k`."""
+    captured = {}
+
+    def fake_search(embedding, k, pre_filter, post_filter_pipeline, **kwargs):
+        captured["pre_filter"] = pre_filter
+        return []
+
+    monkeypatch.setattr(store, "_similarity_search_with_score", fake_search)
+
+    scope = ScopeFilter(owners=(ATTACKER,))
+    store.similarity_search_with_score_by_vector(
+        [0.1, 0.2, 0.3], k=4, filter=scope.predicate(file_clause("file-shared"))
+    )
+
+    assert captured["pre_filter"] == {
+        "$and": [
+            {"file_id": {"$eq": "file-shared"}},
+            {"user_id": {"$in": [ATTACKER]}},
+        ]
+    }

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -343,6 +343,28 @@ def test_delete_without_entity_id_leaves_entity_owned_chunks(
     assert store_double == []
 
 
+def test_partial_delete_destroys_nothing_before_reporting_not_found(
+    attacker_headers, store_double
+):
+    """A delete mixing an owned id with an unknown one must remove neither.
+
+    The existence check has to run *before* the delete. With the order reversed
+    the owned rows are destroyed and the caller is still told "not found", so a
+    client that treats 404 as "nothing happened" — which is exactly how the 404
+    reads — silently loses data it never asked to delete. Reported against the
+    first version of this route and re-pinned here.
+    """
+    response = client.request(
+        "DELETE",
+        "/documents",
+        json=[ATTACKER_FILE, "file-does-not-exist"],
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 404
+    assert store_double == []
+
+
 def test_owner_still_reads_and_deletes_their_own(victim_headers, store_double):
     """The scope must not lock owners out of their own content."""
     read = client.get(

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,386 @@
+"""Route-level proof that the read and delete paths carry the caller's scope.
+
+The store double here is not a stub: it evaluates the predicate the route builds
+against real rows, so what these tests exercise is the route wiring — that every
+path passes a scope at all, and that the scope it passes is the token's rather
+than the caller's. The SQL that implements the predicate is covered against a
+real database in ``tests/integration/test_authorization_pg.py``.
+"""
+
+import datetime
+import os
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.documents import Document
+
+from app.routes import document_routes
+from app.services.vector_store.async_pg_vector import AsyncPgVector
+from main import app
+
+JWT_SECRET = "testsecret"
+VICTIM = "victim-user"
+ATTACKER = "attacker-user"
+AGENT = "agent-abc"
+
+VICTIM_FILE = "file-victim"
+ATTACKER_FILE = "file-attacker"
+AGENT_FILE = "file-agent"
+
+client = TestClient(app)
+
+
+def _token(user_id: str) -> dict:
+    os.environ["JWT_SECRET"] = JWT_SECRET
+    payload = {
+        "id": user_id,
+        "exp": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+    }
+    return {
+        "Authorization": f"Bearer {jwt.encode(payload, JWT_SECRET, algorithm='HS256')}"
+    }
+
+
+@pytest.fixture
+def attacker_headers():
+    return _token(ATTACKER)
+
+
+@pytest.fixture
+def victim_headers():
+    return _token(VICTIM)
+
+
+SHARED_FILE = "file-shared-id"
+
+ROWS = [
+    {"file_id": VICTIM_FILE, "user_id": VICTIM, "text": "victim secret"},
+    {"file_id": ATTACKER_FILE, "user_id": ATTACKER, "text": "attacker note"},
+    {"file_id": AGENT_FILE, "user_id": AGENT, "text": "agent knowledge"},
+    # Two owners under one caller-chosen file id. The attacker's row is listed
+    # first so it lands at documents[0] in an unfiltered search.
+    {"file_id": SHARED_FILE, "user_id": ATTACKER, "text": "attacker own row"},
+    {"file_id": SHARED_FILE, "user_id": VICTIM, "text": "victim hidden row"},
+]
+
+
+def _owners_from_filter(query_filter: dict) -> list:
+    """Read the owner set out of the predicate the route built.
+
+    Raises when the predicate carries no owner clause: a route that forgot to
+    scope its query must fail these tests rather than quietly return everything.
+    """
+    clauses = query_filter.get("$and")
+    assert clauses, f"route built an unscoped filter: {query_filter!r}"
+    for clause in clauses:
+        if "user_id" in clause:
+            return clause["user_id"]["$in"]
+    raise AssertionError(f"predicate carries no owner clause: {query_filter!r}")
+
+
+def _files_from_filter(query_filter: dict) -> list:
+    for clause in query_filter["$and"]:
+        if "file_id" in clause:
+            spec = clause["file_id"]
+            return [spec["$eq"]] if "$eq" in spec else spec["$in"]
+    raise AssertionError(f"predicate carries no file clause: {query_filter!r}")
+
+
+def _matching(query_filter: dict) -> list:
+    owners = _owners_from_filter(query_filter)
+    files = _files_from_filter(query_filter)
+    return [row for row in ROWS if row["user_id"] in owners and row["file_id"] in files]
+
+
+@pytest.fixture(autouse=True)
+def store_double(monkeypatch):
+    """Patch AsyncPgVector so every read honours the predicate it is given."""
+    document_routes.get_cached_query_embedding.cache_clear()
+    monkeypatch.setattr(
+        document_routes, "get_cached_query_embedding", lambda query: [0.1, 0.2, 0.3]
+    )
+
+    if getattr(app.state, "thread_pool", None) is None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        app.state.thread_pool = ThreadPoolExecutor(max_workers=2)
+
+    deleted = []
+
+    async def get_all_ids(self, owners, executor=None):
+        return [row["file_id"] for row in ROWS if row["user_id"] in owners]
+
+    async def get_filtered_ids(self, ids, owners, executor=None):
+        return [
+            row["file_id"]
+            for row in ROWS
+            if row["user_id"] in owners and row["file_id"] in ids
+        ]
+
+    async def get_documents_by_ids(self, ids, owners, executor=None):
+        return [
+            Document(
+                page_content=row["text"],
+                metadata={"file_id": row["file_id"], "user_id": row["user_id"]},
+            )
+            for row in ROWS
+            if row["user_id"] in owners and row["file_id"] in ids
+        ]
+
+    async def delete_scoped(self, ids, owners, executor=None):
+        deleted.extend(
+            row["file_id"]
+            for row in ROWS
+            if row["user_id"] in owners and row["file_id"] in ids
+        )
+
+    async def asimilarity_search(self, embedding, k=4, filter=None, executor=None):
+        return [
+            (
+                Document(
+                    page_content=row["text"],
+                    metadata={"file_id": row["file_id"], "user_id": row["user_id"]},
+                ),
+                0.1,
+            )
+            for row in _matching(filter)
+        ]
+
+    monkeypatch.setattr(AsyncPgVector, "get_all_ids", get_all_ids)
+    monkeypatch.setattr(AsyncPgVector, "get_filtered_ids", get_filtered_ids)
+    monkeypatch.setattr(AsyncPgVector, "get_documents_by_ids", get_documents_by_ids)
+    monkeypatch.setattr(AsyncPgVector, "delete_scoped", delete_scoped)
+    monkeypatch.setattr(
+        AsyncPgVector,
+        "asimilarity_search_with_score_by_vector",
+        asimilarity_search,
+    )
+    monkeypatch.setattr(document_routes, "_apply_distance_threshold", lambda docs: docs)
+    return deleted
+
+
+def test_ids_lists_only_the_callers_files(attacker_headers):
+    """``GET /ids`` returned every file id in the deployment, which is the
+    discovery half of the read chain."""
+    response = client.get("/ids", headers=attacker_headers)
+
+    assert response.status_code == 200
+    assert set(response.json()) == {ATTACKER_FILE, SHARED_FILE}
+    assert VICTIM_FILE not in response.json()
+    assert AGENT_FILE not in response.json()
+
+
+def test_query_multiple_no_longer_returns_foreign_files(attacker_headers):
+    """``/query_multiple`` performed no authorization at all: every file id the
+    caller listed was searched and returned. Paired with ``GET /ids`` above,
+    that disclosed the content of the whole deployment to any authenticated
+    caller."""
+    response = client.post(
+        "/query_multiple",
+        json={
+            "query": "anything",
+            "file_ids": [VICTIM_FILE, ATTACKER_FILE, AGENT_FILE],
+            "k": 10,
+        },
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    contents = [entry[0]["page_content"] for entry in response.json()]
+    assert contents == ["attacker note"]
+
+
+def test_query_authorizes_every_hit_not_just_the_first(attacker_headers):
+    """``/query`` authorized the whole result set from ``documents[0]`` — the
+    first *returned* hit — so any hit behind it was never checked.
+
+    A file id is caller-chosen, so an attacker could upload one row under a
+    victim's file id, have their own row rank first, and read the victim's rows
+    that followed. The predicate now runs before ranking, so the foreign rows are
+    never in the result set to begin with.
+    """
+    response = client.post(
+        "/query",
+        json={"query": "anything", "file_id": SHARED_FILE, "k": 10},
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    contents = [entry[0]["page_content"] for entry in response.json()]
+    assert contents == ["attacker own row"]
+
+
+def test_query_without_entity_id_cannot_reach_another_owner(attacker_headers):
+    """The caller's own identity is the whole scope when no entity is named, so
+    a victim's file id returns nothing rather than the victim's chunks."""
+    response = client.post(
+        "/query",
+        json={"query": "anything", "file_id": VICTIM_FILE, "k": 10},
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_entity_id_is_still_caller_asserted(attacker_headers):
+    """Known residual, carried deliberately by this release.
+
+    ``entity_id`` no longer *replaces* the caller's identity — it widens the
+    owner set, and the caller's own identity always stays in it. But nothing in
+    a token minted today proves the caller may act for the entity it names, so a
+    caller who knows a victim's user id can still name it and reach that owner.
+
+    Closing this requires the token to carry the entity authorization, which is a
+    coordinated change with the callers that mint those tokens. It is tracked
+    separately from this release; see ``README.md``. This test asserts the gap so
+    that closing it is a deliberate edit rather than a silent behaviour change.
+    """
+    response = client.post(
+        "/query",
+        json={
+            "query": "anything",
+            "file_id": VICTIM_FILE,
+            "k": 10,
+            "entity_id": VICTIM,
+        },
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    contents = [entry[0]["page_content"] for entry in response.json()]
+    assert contents == ["victim secret"], (
+        "entity_id reach changed — if a token now proves entity authorization, "
+        "this test should assert refusal instead"
+    )
+
+
+def test_query_reaches_an_agent_knowledge_base(attacker_headers):
+    """Agent knowledge-base chunks are owned by the agent id, so a caller
+    reading one must reach both owners. This is the behaviour ``entity_id``
+    exists for and it must keep working."""
+    response = client.post(
+        "/query",
+        json={
+            "query": "anything",
+            "file_id": AGENT_FILE,
+            "k": 10,
+            "entity_id": AGENT,
+        },
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    contents = [entry[0]["page_content"] for entry in response.json()]
+    assert contents == ["agent knowledge"]
+
+
+def test_documents_route_refuses_a_foreign_file(attacker_headers):
+    """``GET /documents`` returned the chunks of any file id the caller named."""
+    response = client.get(
+        "/documents", params={"ids": [VICTIM_FILE]}, headers=attacker_headers
+    )
+
+    assert response.status_code == 404
+
+
+def test_document_context_refuses_a_foreign_file(attacker_headers):
+    """``/documents/{id}/context`` had the same reach as ``GET /documents``."""
+    response = client.get(f"/documents/{VICTIM_FILE}/context", headers=attacker_headers)
+
+    assert response.status_code == 404
+
+
+def test_delete_cannot_remove_a_foreign_file(attacker_headers, store_double):
+    """``DELETE /documents`` deleted by file id alone, so any authenticated
+    caller could destroy another owner's chunks by naming one."""
+    response = client.request(
+        "DELETE", "/documents", json=[VICTIM_FILE], headers=attacker_headers
+    )
+
+    assert response.status_code == 404
+    assert store_double == []
+
+
+def test_delete_accepts_entity_id_as_a_query_parameter(attacker_headers, store_double):
+    """Entity-owned chunks must be deletable by naming the entity.
+
+    Chunks embedded under an ``entity_id`` — an agent knowledge base — are owned
+    by that entity rather than by any user, so a delete scoped to the caller
+    alone matches nothing and orphans them. This route takes ``entity_id`` on the
+    query string alongside the JSON body of file ids, which is the shape callers
+    send; a delete that only accepted it in the body would silently drop it and
+    orphan every agent knowledge-base file.
+    """
+    response = client.request(
+        "DELETE",
+        "/documents",
+        params={"entity_id": AGENT},
+        json=[AGENT_FILE],
+        headers=attacker_headers,
+    )
+
+    assert response.status_code == 200
+    assert store_double == [AGENT_FILE]
+
+
+def test_delete_without_entity_id_leaves_entity_owned_chunks(
+    attacker_headers, store_double
+):
+    """The failure mode the query parameter above exists to prevent.
+
+    Pinned deliberately: this is what a caller that has not been updated will
+    do, and the 404 it gets is indistinguishable from "already deleted" — so the
+    orphan is silent unless the caller names the entity.
+    """
+    response = client.request(
+        "DELETE", "/documents", json=[AGENT_FILE], headers=attacker_headers
+    )
+
+    assert response.status_code == 404
+    assert store_double == []
+
+
+def test_owner_still_reads_and_deletes_their_own(victim_headers, store_double):
+    """The scope must not lock owners out of their own content."""
+    read = client.get(
+        "/documents", params={"ids": [VICTIM_FILE]}, headers=victim_headers
+    )
+    assert read.status_code == 200
+    assert read.json()[0]["page_content"] == "victim secret"
+
+    removed = client.request(
+        "DELETE", "/documents", json=[VICTIM_FILE], headers=victim_headers
+    )
+    assert removed.status_code == 200
+    assert store_double == [VICTIM_FILE]
+
+
+def test_unauthenticated_deployment_keeps_reading_its_own_chunks(monkeypatch):
+    """A deployment with no ``JWT_SECRET`` has no token to resolve scope from.
+
+    Writes stamp ``public`` as the owner in that mode, so reads must resolve to
+    the same single owner rather than to an empty scope — otherwise upgrading
+    would lock these deployments out of everything they hold.
+    """
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    public_file = "file-public"
+    ROWS.append({"file_id": public_file, "user_id": "public", "text": "public row"})
+
+    try:
+        response = client.post(
+            "/query",
+            json={"query": "anything", "file_id": public_file, "k": 10},
+        )
+
+        assert response.status_code == 200
+        contents = [entry[0]["page_content"] for entry in response.json()]
+        assert contents == ["public row"]
+
+        listed = client.get("/ids")
+        assert listed.status_code == 200
+        assert listed.json() == [public_file]
+    finally:
+        ROWS.pop()

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -188,6 +188,7 @@ class TestBatchProcessing:
             result = await _process_documents_async_pipeline(
                 documents=mock_documents,
                 file_id="test_file",
+                user_id="testuser",
                 vector_store=mock_async_vector_store,
                 executor=None,
             )
@@ -205,6 +206,7 @@ class TestBatchProcessing:
             result = await _process_documents_async_pipeline(
                 documents=docs,
                 file_id="test_file",
+                user_id="testuser",
                 vector_store=mock_async_vector_store,
                 executor=None,
             )
@@ -221,6 +223,7 @@ class TestBatchProcessing:
             result = await _process_documents_async_pipeline(
                 documents=docs,
                 file_id="test_file",
+                user_id="testuser",
                 vector_store=mock_async_vector_store,
                 executor=None,
             )
@@ -236,6 +239,7 @@ class TestBatchProcessing:
             result = await _process_documents_async_pipeline(
                 documents=[],
                 file_id="test_file",
+                user_id="testuser",
                 vector_store=mock_async_vector_store,
                 executor=None,
             )
@@ -260,6 +264,7 @@ class TestBatchProcessing:
                 await _process_documents_async_pipeline(
                     documents=mock_documents,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=mock_async_vector_store,
                     executor=None,
                 )
@@ -324,6 +329,7 @@ class TestBatchProcessing:
                 await _process_documents_async_pipeline(
                     documents=mock_documents,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=mock_async_vector_store,
                     executor=None,
                 )
@@ -347,6 +353,7 @@ class TestBatchProcessing:
                 result = await _process_documents_batched_sync(
                     documents=mock_documents,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=mock_sync_vector_store,
                     executor=executor,
                 )
@@ -363,6 +370,7 @@ class TestBatchProcessing:
             result = await _process_documents_batched_sync(
                 documents=[],
                 file_id="test_file",
+                user_id="testuser",
                 vector_store=mock_sync_vector_store,
                 executor=None,
             )
@@ -389,11 +397,12 @@ class TestBatchProcessing:
                     await _process_documents_batched_sync(
                         documents=mock_documents,
                         file_id="test_file",
+                        user_id="testuser",
                         vector_store=mock_sync_vector_store,
                         executor=executor,
                     )
 
-        mock_sync_vector_store.delete.assert_called_once()
+        mock_sync_vector_store.delete_scoped.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sync_batched_no_rollback_on_first_error(
@@ -411,6 +420,7 @@ class TestBatchProcessing:
                     await _process_documents_batched_sync(
                         documents=mock_documents,
                         file_id="test_file",
+                        user_id="testuser",
                         vector_store=mock_sync_vector_store,
                         executor=executor,
                     )
@@ -520,7 +530,11 @@ class TestBatchSizeEdgeCases:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", batch_size):
             await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         assert mock_store.aadd_documents.call_count == expected_batches
@@ -537,7 +551,11 @@ class TestBatchSizeEdgeCases:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1000):
             await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         assert mock_store.aadd_documents.call_count == 1
@@ -554,7 +572,11 @@ class TestBatchSizeEdgeCases:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
             await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         assert mock_store.aadd_documents.call_count == 5
@@ -575,7 +597,11 @@ class TestProducerConsumerPattern:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 1):
             result = await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         # If we get here without hanging, the producer signaled completion
@@ -597,6 +623,7 @@ class TestProducerConsumerPattern:
                 await _process_documents_async_pipeline(
                     documents=docs,
                     file_id="test",
+                    user_id="testuser",
                     vector_store=mock_store,
                     executor=None,
                 )
@@ -960,7 +987,11 @@ class TestProducerConsumerPattern:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 2):
             result = await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         assert len(result) == 5
@@ -1103,6 +1134,7 @@ class TestSyncBatchedMongoCompat:
                 result = await _process_documents_batched_sync(
                     documents=docs,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=LegacyMongoStore(),
                     executor=executor,
                 )
@@ -1132,6 +1164,7 @@ class TestSyncBatchedMongoCompat:
                 result = await _process_documents_batched_sync(
                     documents=docs,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=BaseClassStore(),
                     executor=executor,
                 )

--- a/tests/test_batch_processing_integration.py
+++ b/tests/test_batch_processing_integration.py
@@ -49,7 +49,11 @@ class TestMemoryOptimization:
         # Process with batch size of 10
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 10):
             result = await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         # Verify we got all 100 IDs back
@@ -88,7 +92,11 @@ class TestMemoryOptimization:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 5):
             await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         current, peak = tracemalloc.get_traced_memory()
@@ -123,7 +131,11 @@ class TestMemoryOptimization:
 
         with patch("app.routes.document_routes.EMBEDDING_BATCH_SIZE", 5):
             result = await _process_documents_async_pipeline(
-                documents=docs, file_id="test", vector_store=mock_store, executor=None
+                documents=docs,
+                file_id="test",
+                user_id="testuser",
+                vector_store=mock_store,
+                executor=None,
             )
 
         # Verify batches were processed in order
@@ -163,6 +175,7 @@ class TestSyncBatchedMemory:
                 result = await _process_documents_batched_sync(
                     documents=docs,
                     file_id="test",
+                    user_id="testuser",
                     vector_store=mock_store,
                     executor=executor,
                 )
@@ -205,6 +218,7 @@ class TestBatchProcessingResilience:
                 await _process_documents_async_pipeline(
                     documents=docs,
                     file_id="test_file",
+                    user_id="testuser",
                     vector_store=mock_store,
                     executor=None,
                 )
@@ -240,6 +254,7 @@ class TestBatchProcessingResilience:
                 await _process_documents_async_pipeline(
                     documents=docs,
                     file_id="my_unique_file_id",
+                    user_id="testuser",
                     vector_store=mock_store,
                     executor=None,
                 )
@@ -331,6 +346,7 @@ class TestConfigurationBehavior:
                 await _process_documents_async_pipeline(
                     documents=docs,
                     file_id="test",
+                    user_id="testuser",
                     vector_store=mock_store,
                     executor=None,
                 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,20 +48,20 @@ def override_vector_store(monkeypatch):
         )
 
     # Override get_all_ids as an async function - patch at CLASS level to bypass run_in_executor
-    async def dummy_get_all_ids(self, executor=None):
+    async def dummy_get_all_ids(self, owners=None, executor=None):
         return ["testid1", "testid2"]
 
     monkeypatch.setattr(AsyncPgVector, "get_all_ids", dummy_get_all_ids)
 
     # Override get_filtered_ids as an async function.
-    async def dummy_get_filtered_ids(self, ids, executor=None):
+    async def dummy_get_filtered_ids(self, ids, owners=None, executor=None):
         dummy_ids = ["testid1", "testid2"]
         return [id for id in dummy_ids if id in ids]
 
     monkeypatch.setattr(AsyncPgVector, "get_filtered_ids", dummy_get_filtered_ids)
 
     # Override get_documents_by_ids as an async function.
-    async def dummy_get_documents_by_ids(self, ids, executor=None):
+    async def dummy_get_documents_by_ids(self, ids, owners=None, executor=None):
         return [
             Document(page_content="Test content", metadata={"file_id": id})
             for id in ids
@@ -126,7 +126,11 @@ def override_vector_store(monkeypatch):
     async def dummy_delete(self, ids=None, collection_only=False, executor=None):
         return None
 
+    async def dummy_delete_scoped(self, ids=None, owners=None, executor=None):
+        return None
+
     monkeypatch.setattr(AsyncPgVector, "delete", dummy_delete)
+    monkeypatch.setattr(AsyncPgVector, "delete_scoped", dummy_delete_scoped)
 
 
 def test_get_all_ids(auth_headers):
@@ -221,7 +225,7 @@ def test_load_document_context(auth_headers):
 def test_load_document_context_restores_parallel_chunk_order(auth_headers, monkeypatch):
     from app.services.vector_store.async_pg_vector import AsyncPgVector
 
-    async def out_of_order_documents(self, ids, executor=None):
+    async def out_of_order_documents(self, ids, owners=None, executor=None):
         return [
             Document(
                 page_content="third",
@@ -272,7 +276,7 @@ def test_load_document_context_groups_repeated_ingestion_attempts(
             },
         )
 
-    async def interleaved_attempts(self, ids, executor=None):
+    async def interleaved_attempts(self, ids, owners=None, executor=None):
         return [
             marked("old-second", 1, "old", 100),
             marked("new-second", 1, "new", 200),


### PR DESCRIPTION
Split out of #318, which was doing two unrelated jobs — these authorization fixes and the search-stack feature — and whose surfaces kept multiplying each review round. This is the authorization half alone: no new endpoints, no strict JWT, no scopes, no tenancy, no new environment variables. #318 keeps the feature and will be restacked on top of this.

Supersedes #302 and #304, which fix two of these holes post-hoc in Python. See the note at the bottom.

## What was open

Six routes addressed the vector store by caller-supplied `file_id` alone, or authorized a whole result set from the first hit the search returned.

- **`GET /ids` listed every file id in the deployment**, and **`POST /query_multiple` performed no authorization at all.** Chained, those two disclosed the content of every file in the deployment to any authenticated caller. This is the one that matters most.
- **`POST /query` authorized its whole result set from `documents[0]`** — the first *returned* hit — so any hit behind it was never checked. A `file_id` is chosen by whoever uploads, so an attacker's own row ranking first authorized the rows behind it.
- **`GET /documents`, `GET /documents/{id}/context` and `DELETE /documents`** read or deleted the chunks of any file id the caller could name.
- **A chunk with no recorded `user_id` read as "belongs to everyone."**
- **On the synchronous store path, a failed ingestion rolled back by `file_id` alone**, so an upload under someone else's file id destroyed their chunks. (The async pgvector pipeline already scopes its rollback to the ingestion attempt after #317, and is left alone.)
- **pgvector lookups omitted `collection_id`.** `langchain_pg_embedding` is shared by every collection in the database, so a lookup could read rows this store does not serve.

## The change

Owner scope is resolved from the verified token in one place — `app/scope.py` — and pushed into the store query *before* ranking. A foreign chunk is never read into the process rather than being filtered out after the fact, so `k` is also no longer consumed by hits the caller may not see.

The scope arguments are **required, not optional**, on both stores, so a new call site cannot skip them by omission. A file outside the caller's scope answers **404, not 403**, so none of these routes is an existence oracle.

## `entity_id` is unchanged, and still caller-asserted

This is deliberate and it is the one thing this PR does *not* close.

Agent knowledge bases are owned by an agent id rather than by any user, so a caller reading one names it via `entity_id`. That id now **widens** the owner set instead of replacing the caller's identity — which is what keeps those knowledge bases readable; strict `owners = {token.id}` would break every one of them. But nothing in a token minted today proves the caller may act for the entity it names, so a caller that knows another owner's id can still name it, on read and on the ingestion routes.

Closing that requires the token to carry the entity authorization, which is a coordinated change with the callers that mint those tokens. It belongs with #318, not with a security release. `tests/test_authorization.py::test_entity_id_is_still_caller_asserted` asserts the residual so that closing it later is a deliberate edit rather than a silent behaviour change.

## Breaking changes

Two, both documented in the README.

1. **Chunks with no `user_id` are owned by nobody and are no longer readable.** The README carries the backfill `UPDATE` for deployments holding such rows.
2. **`atlas-mongo` deployments must add `user_id` as a filter field to the vector search index before deploying**, or `$vectorSearch` will reject the pre-filter.

And one ordering requirement: **upgrade clients first, or both together — never this service first.** A client that sends `entity_id` against an older build is inert, because the parameter is simply undeclared there. An older client against this build orphans every agent knowledge-base file it deletes, silently, because a 404 is indistinguishable from "already deleted". LibreChat's matching change is danny-avila/LibreChat#14692.

## Tests

231 unit + 35 integration, the integration ones against a real pgvector container via testcontainers.

The suite was mutation-tested rather than just run: zeroing the owner clause in the store fails 7 tests, and dropping it from the scope predicate fails 2 more, so the tests are load-bearing rather than incidentally green. Each test names the hole it covers.

`tests/test_authorization.py::test_delete_accepts_entity_id_as_a_query_parameter` pins the cross-repo contract — `entity_id` arrives as a query parameter alongside the JSON body of file ids — since that is exactly the shape a client sends and where FastAPI could otherwise silently drop it.

## On #302 and #304

Both are real fixes for real holes and both predate this. I think this supersedes them:

- They filter **after** the search in Python rather than in the store predicate, so foreign chunks are still read into the process and still consume `k`.
- Both keep `user_id in (None, user_authorized)`, so null-owner chunks stay readable by everyone.
- #304 returns **403** for unauthorized, which is an existence oracle, and uses `get_user_id(request, entity_id)` — the entity-replaces-identity pattern that is itself the original `/query` defect.

#304 independently landed on the same `entity_id` query parameter for `DELETE /documents`, which is good corroboration that the contract shape is right.
